### PR TITLE
Add redector to item description and transcript fields

### DIFF
--- a/app/views/items/_form.html.erb
+++ b/app/views/items/_form.html.erb
@@ -3,11 +3,9 @@
 
 <%= f.input :title, as: :string %>
 
-<%= f.input :description, as: :text do %>
-  <%= f.text_area :description, class: 'text optional form-control', rows: '3' %>
-<% end %>
+<%= f.input :description, input_html: { class: 'honeycomb_redactor' } %>
 
-<%= f.input :transcription, as: :text %>
+<%= f.input :transcription, input_html: { class: 'honeycomb_redactor' } %>
 
 <%= f.input :manuscript_url, as: :string, placeholder: 'http://', hint: 'Link to externally hosted manuscript viewer.' %>
 

--- a/app/views/items/_list.html.erb
+++ b/app/views/items/_list.html.erb
@@ -22,7 +22,7 @@
         </td>
         <td>
           <h4 class="media-heading"><%= h link_to item.title, item.edit_path %></h4>
-          <%= h item.description %>
+          <%= raw item.description %>
         </td>
         <td>
           <%= PublishedText.display(item) %>


### PR DESCRIPTION
**What** I added the redactor editor to the item description and transcript fields in the UI

**How** I modified a couple of view partials, one for the item edit page, and one associated with the item list for a collection

**Why** The form output for the item edit page needed to be changed to remove the old type, and add a class that renders the redactor editing tools; the description needed to be changed on the item list so that it output raw HTML instead of using the standard Draper helper method to accomodate HTML in the descriptive field

**Note** Beehive will need to be updated to accommodate for HTML being in the item description and transcript fields (see image):

![screen shot 2015-04-29 at 2 43 13 pm](https://cloud.githubusercontent.com/assets/9285578/7398725/cd7492dc-ee7e-11e4-92b9-6bfd7a4505b1.png)
