### PR TITLE
DEC-242: Removed etag based caching from all api controllers and updated...

### DIFF
--- a/app/controllers/api/collections_controller.rb
+++ b/app/controllers/api/collections_controller.rb
@@ -2,20 +2,15 @@ module API
   class CollectionsController < APIController
     def index
       @collections = Collection.all
-      if stale?(@collections)
-        respond_to do |format|
-          format.json { render json: GenerateCollectionJSON.call(@collections) }
-        end
+      respond_to do |format|
+        format.json { render json: GenerateCollectionJSON.call(@collections) }
       end
     end
 
     def show
       @collection = Collection.find(params[:id])
-
-      if stale?(@collection)
-        respond_to do |format|
-          format.json { render json: GenerateCollectionJSON.call(@collection) }
-        end
+      respond_to do |format|
+        format.json { render json: GenerateCollectionJSON.call(@collection) }
       end
     end
   end

--- a/app/controllers/api/items_controller.rb
+++ b/app/controllers/api/items_controller.rb
@@ -4,20 +4,15 @@ module API
 
     def index
       @items = ItemQuery.new(collection.items).published
-      if stale?(@items)
-        respond_to do |format|
-          format.json { render json: GenerateItemJSON.new(@items, params) }
-        end
+      respond_to do |format|
+        format.json { render json: GenerateItemJSON.new(@items, params) }
       end
     end
 
     def show
       @item = collection.items.find(params[:id])
-
-      if stale?(@item)
-        respond_to do |format|
-          format.json { render json: GenerateItemJSON.new(@item, params) }
-        end
+      respond_to do |format|
+        format.json { render json: GenerateItemJSON.new(@item, params) }
       end
     end
 

--- a/spec/controllers/api/collections_controller_spec.rb
+++ b/spec/controllers/api/collections_controller_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe API::CollectionsController, type: :controller do
       expect(response.body).to eq("{\"collections\":[{\"test\":\"collection\"}]}")
     end
 
-    it_behaves_like "a private basic custom etag cacher" do
+    it_behaves_like "a private content-based etag cacher" do
       subject { get :index, format: :json }
     end
   end
@@ -44,7 +44,7 @@ RSpec.describe API::CollectionsController, type: :controller do
       expect(response.body).to eq("{\"collections\":{\"test\":\"collection\"}}")
     end
 
-    it_behaves_like "a private basic custom etag cacher" do
+    it_behaves_like "a private content-based etag cacher" do
       subject { get :show, id: collection.id, format: :json }
     end
   end

--- a/spec/controllers/api/items_controller_spec.rb
+++ b/spec/controllers/api/items_controller_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe API::ItemsController, type: :controller do
       expect(assigns(:collection)).to be_present
     end
 
-    it_behaves_like "a private basic custom etag cacher" do
+    it_behaves_like "a private content-based etag cacher" do
       before do
         allow(collection).to receive(:items).and_return(Item.all)
       end
@@ -53,7 +53,7 @@ RSpec.describe API::ItemsController, type: :controller do
       expect(assigns(:item)).to be_present
     end
 
-    it_behaves_like "a private basic custom etag cacher" do
+    it_behaves_like "a private content-based etag cacher" do
       before do
         allow_any_instance_of(ItemJSON).to receive(:to_hash).and_return(item: "item")
       end


### PR DESCRIPTION
... the specs to test for content based etag generation instead.