### PR TITLE
DEC-243: V1/Controller caching

### DIFF
--- a/app/controllers/v1/items_controller.rb
+++ b/app/controllers/v1/items_controller.rb
@@ -10,7 +10,7 @@ module V1
 
     def show
       @item = ItemQuery.new.public_find(params[:id])
-      fresh_when(@item)
+      fresh_when([@item, @item.collection, @item.children])
     end
   end
 end

--- a/app/controllers/v1/sections_controller.rb
+++ b/app/controllers/v1/sections_controller.rb
@@ -2,7 +2,7 @@ module V1
   class SectionsController < APIController
     def show
       @section = SectionJSONDecorator.new(SectionQuery.new.public_find(params[:id]))
-      fresh_when(@section)
+      fresh_when([@section, @section.item, @section.collection, @section.showcase])
     end
   end
 end

--- a/app/controllers/v1/showcases_controller.rb
+++ b/app/controllers/v1/showcases_controller.rb
@@ -9,7 +9,7 @@ module V1
     def show
       showcase = ShowcaseQuery.new.public_find(params[:id])
       @showcase = ShowcaseJSONDecorator.new(showcase)
-      fresh_when([showcase, showcase.sections, showcase.items])
+      fresh_when([showcase, showcase.collection, showcase.sections, showcase.items])
     end
   end
 end

--- a/spec/controllers/v1/items_controller_spec.rb
+++ b/spec/controllers/v1/items_controller_spec.rb
@@ -3,7 +3,7 @@ require "cache_spec_helper"
 
 RSpec.describe V1::ItemsController, type: :controller do
   let(:collection) { instance_double(Collection, id: "1", updated_at: nil, items: nil) }
-  let(:item) { instance_double(Showcase, id: '1') }
+  let(:item) { instance_double(Item, id: "1", collection: nil, children: nil) }
 
   before(:each) do
     allow_any_instance_of(ItemQuery).to receive(:public_find).and_return(item)

--- a/spec/controllers/v1/sections_controller_spec.rb
+++ b/spec/controllers/v1/sections_controller_spec.rb
@@ -3,7 +3,7 @@ require "cache_spec_helper"
 
 RSpec.describe V1::SectionsController, type: :controller do
   let(:collection) { instance_double(Collection, id: '1') }
-  let(:section) { instance_double(Section, id: "1", updated_at: nil) }
+  let(:section) { instance_double(Section, id: "1", updated_at: nil, item: nil, collection: nil, showcase: nil) }
 
   before(:each) do
     allow_any_instance_of(SectionQuery).to receive(:public_find).and_return(section)

--- a/spec/controllers/v1/showcases_controller_spec.rb
+++ b/spec/controllers/v1/showcases_controller_spec.rb
@@ -3,7 +3,7 @@ require "cache_spec_helper"
 
 RSpec.describe V1::ShowcasesController, type: :controller do
   let(:collection) { instance_double(Collection, id: "1", updated_at: nil, showcases: nil) }
-  let(:showcase) { instance_double(Showcase, id: "1", updated_at: nil, sections: nil, items: nil) }
+  let(:showcase) { instance_double(Showcase, id: "1", updated_at: nil, sections: nil, items: nil, collection: nil) }
 
   before(:each) do
     allow_any_instance_of(ShowcaseQuery).to receive(:public_find).and_return(showcase)


### PR DESCRIPTION
These changes should capture all needed data for all v1 controllers when generating etags.