### PR TITLE
Add site introduction 

### DIFF
--- a/app/controllers/exhibits_controller.rb
+++ b/app/controllers/exhibits_controller.rb
@@ -24,6 +24,6 @@ class ExhibitsController < ApplicationController
   private
 
   def save_params
-    params.require(:exhibit).permit([:description, :image])
+    params.require(:exhibit).permit([:description, :image, :short_description])
   end
 end

--- a/app/decorators/v1/collection_json_decorator.rb
+++ b/app/decorators/v1/collection_json_decorator.rb
@@ -27,6 +27,10 @@ module V1
       object.exhibit.description.to_s
     end
 
+    def short_intro
+      object.exhibit.short_description.to_s
+    end
+
     def slug
       CreateURLSlug.call(object.title)
     end

--- a/app/views/exhibits/_form.html.erb
+++ b/app/views/exhibits/_form.html.erb
@@ -1,12 +1,8 @@
 <%= display_errors(f.object) %>
 
-<div class="row">
-  <h1><%= f.object.collection.title %></h1>
-  <div class="col-md-9">
-    <%= f.input :description, input_html: { class: 'honeycomb_redactor' } %>
-  </div>
-  <div class="col-md-3">
-    <%= HoneypotThumbnail.display(f.object.honeypot_image) %>
-    <%= f.input :image, as: :file %>
-  </div>
-</div>
+<%= f.input :short_description, input_html: { class: 'honeycomb_redactor'  } %>
+
+<%= f.input :description, input_html: { class: 'honeycomb_redactor'  } %>
+
+<%= HoneypotThumbnail.display(f.object.honeypot_image) %>
+<%= f.input :image, as: :file %>

--- a/app/views/exhibits/edit.html.erb
+++ b/app/views/exhibits/edit.html.erb
@@ -7,7 +7,7 @@
 <%= simple_form_for @exhibit do |f| %>
   <div class="panel panel-default">
     <div class="panel-heading">
-      <h3 class="panel-title">Website</h3>
+      <h3 class="panel-title"><%= f.object.collection.title %></h3>
     </div>
     <div class="panel-body">
       <%= render partial: 'form', locals: { f: f } %>

--- a/app/views/v1/collections/_collection.json.jbuilder
+++ b/app/views/v1/collections/_collection.json.jbuilder
@@ -7,5 +7,6 @@ json.id collection_object.unique_id
 json.slug collection_object.slug
 json.title collection_object.title
 json.description collection_object.site_intro
+json.short_description collection_object.short_intro
 json.image collection_object.image
 json.last_updated collection_object.updated_at

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,7 +40,8 @@ en:
           title: "Rename Collection"
       exhibit:
         edit:
-          description: "Introduction"
+          description: "Collection/Exhibit Introduction"
+          short_description: "Site Introduction"
       showcase:
         description: "Subtitle"
         image: "Background Image"

--- a/db/migrate/20150430164752_add_short_intro_to_collection.rb
+++ b/db/migrate/20150430164752_add_short_intro_to_collection.rb
@@ -1,0 +1,5 @@
+class AddShortIntroToCollection < ActiveRecord::Migration
+  def change
+    add_column :exhibits, :short_description, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150416184347) do
+ActiveRecord::Schema.define(version: 20150430164752) do
 
   create_table "collection_users", force: :cascade do |t|
     t.integer  "user_id",       limit: 4, null: false
@@ -44,6 +44,7 @@ ActiveRecord::Schema.define(version: 20150416184347) do
     t.string   "image_content_type", limit: 255
     t.integer  "image_file_size",    limit: 4
     t.datetime "image_updated_at"
+    t.text     "short_description",  limit: 65535
   end
 
   create_table "honeypot_images", force: :cascade do |t|

--- a/spec/decorators/v1/collection_json_decorator_spec.rb
+++ b/spec/decorators/v1/collection_json_decorator_spec.rb
@@ -1,11 +1,11 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe V1::CollectionJSONDecorator do
   subject { V1::CollectionJSONDecorator.new(collection) }
 
   let(:collection) { double(Collection) }
 
-  describe 'generic fields' do
+  describe "generic fields" do
     [:id,
      :title,
      :unique_id,
@@ -16,120 +16,119 @@ RSpec.describe V1::CollectionJSONDecorator do
     end
   end
 
-  describe '#description' do
+  describe "#description" do
     let(:collection) { double(Collection, description: nil) }
 
-    it 'converts null to empty string' do
-      expect(subject.description).to eq('')
+    it "converts null to empty string" do
+      expect(subject.description).to eq("")
     end
 
-    it 'delegates to collection' do
-      expect(collection).to receive(:description).and_return('desc')
-      expect(subject.description).to eq('desc')
+    it "delegates to collection" do
+      expect(collection).to receive(:description).and_return("desc")
+      expect(subject.description).to eq("desc")
     end
   end
 
-  describe '#site_intro' do
+  describe "#site_intro" do
     let(:exhibit) { double(Exhibit, description: nil) }
     let(:collection) { double(Collection, exhibit: exhibit) }
 
-    it 'converts null to empty string' do
-      expect(subject.site_intro).to eq('')
+    it "converts null to empty string" do
+      expect(subject.site_intro).to eq("")
     end
 
-    it 'gets the value from the exhibit' do
-      expect(exhibit).to receive(:description).and_return('intro')
-      expect(subject.site_intro).to eq('intro')
+    it "gets the value from the exhibit" do
+      expect(exhibit).to receive(:description).and_return("intro")
+      expect(subject.site_intro).to eq("intro")
     end
   end
 
-
-  describe '#short_intro' do
+  describe "#short_intro" do
     let(:exhibit) { double(Exhibit, short_description: nil) }
     let(:collection) { double(Collection, exhibit: exhibit) }
 
-    it 'converts null to empty string' do
-      expect(subject.short_intro).to eq('')
+    it "converts null to empty string" do
+      expect(subject.short_intro).to eq("")
     end
 
-    it 'gets the value from the exhibit' do
-      expect(exhibit).to receive(:short_description).and_return('intro')
-      expect(subject.short_intro).to eq('intro')
-    end
-  end
-
-  describe '#at_id' do
-    let(:collection) { double(Collection, unique_id: 'adsf') }
-
-    it 'returns the path to the id' do
-      expect(subject.at_id).to eq('http://test.host/v1/collections/adsf')
+    it "gets the value from the exhibit" do
+      expect(exhibit).to receive(:short_description).and_return("intro")
+      expect(subject.short_intro).to eq("intro")
     end
   end
 
-  describe '#items_url' do
-    let(:collection) { double(Collection, unique_id: 'adsf') }
+  describe "#at_id" do
+    let(:collection) { double(Collection, unique_id: "adsf") }
 
-    it 'returns the path to the items' do
-      expect(subject.items_url).to eq('http://test.host/v1/collections/adsf/items')
+    it "returns the path to the id" do
+      expect(subject.at_id).to eq("http://test.host/v1/collections/adsf")
     end
   end
 
-  describe '#slug' do
-    let(:collection) { double(Collection, title: 'title') }
+  describe "#items_url" do
+    let(:collection) { double(Collection, unique_id: "adsf") }
 
-    it 'calls the slug generator' do
+    it "returns the path to the items" do
+      expect(subject.items_url).to eq("http://test.host/v1/collections/adsf/items")
+    end
+  end
+
+  describe "#slug" do
+    let(:collection) { double(Collection, title: "title") }
+
+    it "calls the slug generator" do
       expect(CreateURLSlug).to receive(:call)
-        .with(collection.title).and_return('slug')
+        .with(collection.title).and_return("slug")
 
-      expect(subject.slug).to eq('slug')
+      expect(subject.slug).to eq("slug")
     end
   end
 
-  describe '#items' do
+  describe "#items" do
     let(:collection) { double(Collection, items: []) }
 
-    it 'queries for all the published items' do
+    it "queries for all the published items" do
       expect_any_instance_of(ItemQuery).to receive(:only_top_level)
-        .and_return(['items'])
+        .and_return(["items"])
 
-      expect(subject.items).to eq(['items'])
+      expect(subject.items).to eq(["items"])
     end
   end
 
-  describe '#showcases' do
+  describe "#showcases" do
     let(:collection) { double(Collection, showcases: []) }
 
-    it 'queries for all the published showcases' do
+    it "queries for all the published showcases" do
       expect_any_instance_of(ShowcaseQuery).to receive(:public_api_list)
-        .and_return(['showcases'])
+        .and_return(["showcases"])
 
-      expect(subject.showcases).to eq(['showcases'])
+      expect(subject.showcases).to eq(["showcases"])
     end
   end
 
-  describe '#image' do
+  describe "#image" do
     let(:exhibit) { double(Exhibit, honeypot_image: honeypot_image) }
     let(:collection) { double(Collection, exhibit: exhibit) }
-    let(:honeypot_image) { double(HoneypotImage, json_response: 'json_response') }
+    let(:honeypot_image) { double(HoneypotImage, json_response: "json_response") }
 
-    it 'gets the honeypot_image json_response' do
+    it "gets the honeypot_image json_response" do
       expect(honeypot_image).to receive(:json_response)
-        .and_return('json_response')
-      expect(subject.image).to eq('json_response')
+        .and_return("json_response")
+      expect(subject.image).to eq("json_response")
     end
 
-    it 'gets the honeypot_image from the exhibit' do
+    it "gets the honeypot_image from the exhibit" do
       expect(exhibit).to receive(:honeypot_image).and_return(honeypot_image)
       subject.image
     end
   end
 
-  describe '#display' do
+  describe "#display" do
     let(:json) { double }
 
-    it 'calls the partial for the display' do
+    it "calls the partial for the display" do
       expect(json).to receive(:partial!)
-        .with('/v1/collections/collection', collection_object: collection)
+        .with("/v1/collections/collection", collection_object: collection)
       subject.display(json)
     end
   end

--- a/spec/decorators/v1/collection_json_decorator_spec.rb
+++ b/spec/decorators/v1/collection_json_decorator_spec.rb
@@ -43,6 +43,21 @@ RSpec.describe V1::CollectionJSONDecorator do
     end
   end
 
+
+  describe '#short_intro' do
+    let(:exhibit) { double(Exhibit, short_description: nil) }
+    let(:collection) { double(Collection, exhibit: exhibit) }
+
+    it 'converts null to empty string' do
+      expect(subject.short_intro).to eq('')
+    end
+
+    it 'gets the value from the exhibit' do
+      expect(exhibit).to receive(:short_description).and_return('intro')
+      expect(subject.short_intro).to eq('intro')
+    end
+  end
+
   describe '#at_id' do
     let(:collection) { double(Collection, unique_id: 'adsf') }
 

--- a/spec/decorators/v1/collection_json_decorator_spec.rb
+++ b/spec/decorators/v1/collection_json_decorator_spec.rb
@@ -77,8 +77,7 @@ RSpec.describe V1::CollectionJSONDecorator do
     let(:collection) { double(Collection, title: "title") }
 
     it "calls the slug generator" do
-      expect(CreateURLSlug).to receive(:call)
-        .with(collection.title).and_return("slug")
+      expect(CreateURLSlug).to receive(:call).with(collection.title).and_return("slug")
 
       expect(subject.slug).to eq("slug")
     end
@@ -88,8 +87,7 @@ RSpec.describe V1::CollectionJSONDecorator do
     let(:collection) { double(Collection, items: []) }
 
     it "queries for all the published items" do
-      expect_any_instance_of(ItemQuery).to receive(:only_top_level)
-        .and_return(["items"])
+      expect_any_instance_of(ItemQuery).to receive(:only_top_level).and_return(["items"])
 
       expect(subject.items).to eq(["items"])
     end
@@ -99,8 +97,7 @@ RSpec.describe V1::CollectionJSONDecorator do
     let(:collection) { double(Collection, showcases: []) }
 
     it "queries for all the published showcases" do
-      expect_any_instance_of(ShowcaseQuery).to receive(:public_api_list)
-        .and_return(["showcases"])
+      expect_any_instance_of(ShowcaseQuery).to receive(:public_api_list).and_return(["showcases"])
 
       expect(subject.showcases).to eq(["showcases"])
     end
@@ -112,8 +109,7 @@ RSpec.describe V1::CollectionJSONDecorator do
     let(:honeypot_image) { double(HoneypotImage, json_response: "json_response") }
 
     it "gets the honeypot_image json_response" do
-      expect(honeypot_image).to receive(:json_response)
-        .and_return("json_response")
+      expect(honeypot_image).to receive(:json_response).and_return("json_response")
       expect(subject.image).to eq("json_response")
     end
 
@@ -127,8 +123,8 @@ RSpec.describe V1::CollectionJSONDecorator do
     let(:json) { double }
 
     it "calls the partial for the display" do
-      expect(json).to receive(:partial!)
-        .with("/v1/collections/collection", collection_object: collection)
+      expect(json).to receive(:partial!).with("/v1/collections/collection", collection_object: collection)
+
       subject.display(json)
     end
   end


### PR DESCRIPTION
Beehive needs to have a separation between the site introduction and the introduction for the exhibit.  

To do this I added a field to the exhibit table, added the field to the exhibit form, and added the field to the api.  