### PR TITLE
Update showcase titling

### DIFF
--- a/app/decorators/v1/showcase_json_decorator.rb
+++ b/app/decorators/v1/showcase_json_decorator.rb
@@ -1,7 +1,7 @@
 
 module V1
   class ShowcaseJSONDecorator < Draper::Decorator
-    delegate :id, :title, :description, :collection, :unique_id, :updated_at
+    delegate :id, :description, :collection, :unique_id, :updated_at
 
     def self.display(showcase, json)
       new(showcase).display(json)
@@ -22,6 +22,23 @@ module V1
     def slug
       CreateURLSlug.call(object.title)
     end
+
+    def title
+      if title_line_2.present?
+        "#{title_line_1} #{title_line_2}"
+      else
+        title_line_1
+      end
+    end
+
+    def title_line_1
+      object.title.to_s
+    end
+
+    def title_line_2
+      object.subtitle.to_s
+    end
+
 
     def sections
       SectionQuery.new(object.sections).ordered

--- a/app/decorators/v1/showcase_json_decorator.rb
+++ b/app/decorators/v1/showcase_json_decorator.rb
@@ -39,7 +39,6 @@ module V1
       object.subtitle.to_s
     end
 
-
     def sections
       SectionQuery.new(object.sections).ordered
     end

--- a/app/views/showcases/_form.html.erb
+++ b/app/views/showcases/_form.html.erb
@@ -1,6 +1,7 @@
 <%= display_errors(@showcase) %>
 
 <%= f.input :title, as: :string %>
+<%= f.input :subtitle, as: :string %>
 
 <%= f.input :description, hint: 'Please keep the description as short as possible', as: :string %>
 

--- a/app/views/v1/showcases/_showcase.json.jbuilder
+++ b/app/views/v1/showcases/_showcase.json.jbuilder
@@ -5,6 +5,8 @@ json.set! 'isPartOf/collection', showcase_object.collection_url
 json.id showcase_object.unique_id
 json.slug showcase_object.slug
 json.title showcase_object.title
+json.title showcase_object.title_line_1
+json.title showcase_object.title_line_2
 json.description showcase_object.description
 json.image showcase_object.image
 json.last_updated showcase_object.updated_at

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,7 +43,9 @@ en:
           description: "Collection/Exhibit Introduction"
           short_description: "Site Introduction"
       showcase:
-        description: "Subtitle"
+        title: 'Title Line 1'
+        subtitle: 'Title Line 2'
+        description: "Short Description "
         image: "Background Image"
     hints:
       showcase:

--- a/db/migrate/20150504153937_add_subtitle_to_showcases.rb
+++ b/db/migrate/20150504153937_add_subtitle_to_showcases.rb
@@ -1,0 +1,5 @@
+class AddSubtitleToShowcases < ActiveRecord::Migration
+  def change
+    add_column :showcases, :subtitle, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150501195915) do
+ActiveRecord::Schema.define(version: 20150504153937) do
 
   create_table "collection_users", force: :cascade do |t|
     t.integer  "user_id",       limit: 4, null: false
@@ -111,6 +111,7 @@ ActiveRecord::Schema.define(version: 20150501195915) do
     t.boolean  "published",          limit: 1
     t.string   "unique_id",          limit: 255
     t.integer  "order",              limit: 4
+    t.string   "subtitle",           limit: 255
   end
 
   add_index "showcases", ["order"], name: "index_showcases_on_order", using: :btree

--- a/spec/decorators/v1/showcase_json_decorator_spec.rb
+++ b/spec/decorators/v1/showcase_json_decorator_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe V1::ShowcaseJSONDecorator do
   end
 
   describe "#sections" do
-    let(:showcase) { double(Showcase, sections: [] ) }
+    let(:showcase) { double(Showcase, sections: []) }
 
     it "uses the section query object ordered" do
       expect_any_instance_of(SectionQuery).to receive(:ordered).and_return(["results"])

--- a/spec/decorators/v1/showcase_json_decorator_spec.rb
+++ b/spec/decorators/v1/showcase_json_decorator_spec.rb
@@ -3,13 +3,10 @@ require 'rails_helper'
 RSpec.describe V1::ShowcaseJSONDecorator do
   subject { described_class.new(showcase) }
 
-  let(:collection) { double(Collection, id: 1, unique_id: 'colasdf', title: 'title title') }
-  let(:showcase) { double(Showcase, id: 1, sections: [], description: nil, unique_id: 'adsf', title: 'title title', collection: collection, honeypot_image: honeypot_image) }
-  let(:honeypot_image) { double(HoneypotImage, json_response: 'json_response') }
-  let(:json) { double }
+  let(:showcase) { double(Showcase) }
 
   describe 'generic fields' do
-    [:id, :title, :description, :unique_id, :image, :collection, :updated_at].each do |field|
+    [:id, :description, :unique_id, :image, :collection, :updated_at].each do |field|
       it "responds to #{field}" do
         expect(subject).to respond_to(field)
       end
@@ -17,27 +14,43 @@ RSpec.describe V1::ShowcaseJSONDecorator do
   end
 
   describe '#at_id' do
+    let(:showcase) { double(Showcase, unique_id: "showcae_id") }
+
     it 'returns the path to the id' do
-      expect(subject.at_id).to eq('http://test.host/v1/showcases/adsf')
+      expect(subject.at_id).to eq('http://test.host/v1/showcases/showcae_id')
     end
   end
 
   describe '#collection_url' do
+    let(:collection) { double(Collection, unique_id: "collection_id") }
+    let(:showcase) { double(Showcase, collection: collection) }
+
     it 'returns the path to the items' do
-      expect(subject.collection_url).to eq('http://test.host/v1/collections/colasdf')
+      expect(subject.collection_url).to eq('http://test.host/v1/collections/collection_id')
     end
   end
 
   describe '#description' do
+    let(:showcase) { double(Showcase, description: "description")}
+
+    it "passes description to showcase#description" do
+      expect(showcase).to receive(:description).and_return("description")
+      expect(subject.description).to eq("description")
+    end
+
     it 'converts null to empty string' do
-      expect(subject.description).to eq('')
+      expect(subject.description).to receive(:to_s)
+      subject.description
     end
   end
 
   describe '#slug' do
-    it 'Calls the slug generator' do
-      expect(CreateURLSlug).to receive(:call).with(collection.title).and_return('slug')
-      expect(subject.slug).to eq('slug')
+    let(:showcase) { double(Showcase, title: "title") }
+
+    it "calls the slug generator" do
+      expect(CreateURLSlug).to receive(:call).with(showcase.title).and_return("slug")
+
+      expect(subject.slug).to eq("slug")
     end
   end
 
@@ -82,15 +95,24 @@ RSpec.describe V1::ShowcaseJSONDecorator do
     end
   end
 
+  describe "#image" do
+    let(:showcase) { double(Showcase, honeypot_image: honeypot_image) }
+    let(:honeypot_image) { double(HoneypotImage, json_response: "json_response") }
 
-  describe '#image' do
-    it 'gets the honeypot_image json_response' do
-      expect(honeypot_image).to receive(:json_response).and_return('json_response')
-      expect(subject.image).to eq('json_response')
+    it "gets the honeypot_image json_response" do
+      expect(honeypot_image).to receive(:json_response).and_return("json_response")
+      expect(subject.image).to eq("json_response")
+    end
+
+    it "gets the honeypot_image from the exhibit" do
+      expect(showcase).to receive(:honeypot_image).and_return(honeypot_image)
+      subject.image
     end
   end
 
   describe '#sections' do
+    let(:showcase) { double(Showcase, sections: [] )}
+
     it 'uses the section query object ordered' do
       expect_any_instance_of(SectionQuery).to receive(:ordered).and_return(['results'])
       expect(subject.sections).to eq(['results'])
@@ -103,6 +125,8 @@ RSpec.describe V1::ShowcaseJSONDecorator do
   end
 
   describe '#display' do
+    let(:json) { double }
+
     it 'calls the partial for the display' do
       expect(json).to receive(:partial!).with('/v1/showcases/showcase', showcase_object: showcase)
       subject.display(json)

--- a/spec/decorators/v1/showcase_json_decorator_spec.rb
+++ b/spec/decorators/v1/showcase_json_decorator_spec.rb
@@ -1,11 +1,11 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe V1::ShowcaseJSONDecorator do
   subject { described_class.new(showcase) }
 
   let(:showcase) { double(Showcase) }
 
-  describe 'generic fields' do
+  describe "generic fields" do
     [:id, :description, :unique_id, :image, :collection, :updated_at].each do |field|
       it "responds to #{field}" do
         expect(subject).to respond_to(field)
@@ -13,38 +13,38 @@ RSpec.describe V1::ShowcaseJSONDecorator do
     end
   end
 
-  describe '#at_id' do
+  describe "#at_id" do
     let(:showcase) { double(Showcase, unique_id: "showcae_id") }
 
-    it 'returns the path to the id' do
-      expect(subject.at_id).to eq('http://test.host/v1/showcases/showcae_id')
+    it "returns the path to the id" do
+      expect(subject.at_id).to eq("http://test.host/v1/showcases/showcae_id")
     end
   end
 
-  describe '#collection_url' do
+  describe "#collection_url" do
     let(:collection) { double(Collection, unique_id: "collection_id") }
     let(:showcase) { double(Showcase, collection: collection) }
 
-    it 'returns the path to the items' do
-      expect(subject.collection_url).to eq('http://test.host/v1/collections/collection_id')
+    it "returns the path to the items" do
+      expect(subject.collection_url).to eq("http://test.host/v1/collections/collection_id")
     end
   end
 
-  describe '#description' do
-    let(:showcase) { double(Showcase, description: "description")}
+  describe "#description" do
+    let(:showcase) { double(Showcase, description: "description") }
 
     it "passes description to showcase#description" do
       expect(showcase).to receive(:description).and_return("description")
       expect(subject.description).to eq("description")
     end
 
-    it 'converts null to empty string' do
+    it "converts null to empty string" do
       expect(subject.description).to receive(:to_s)
       subject.description
     end
   end
 
-  describe '#slug' do
+  describe "#slug" do
     let(:showcase) { double(Showcase, title: "title") }
 
     it "calls the slug generator" do
@@ -53,7 +53,6 @@ RSpec.describe V1::ShowcaseJSONDecorator do
       expect(subject.slug).to eq("slug")
     end
   end
-
 
   describe "#title" do
     it "concatinates title_line_1 and title_line_2 if there is a title_line_2" do
@@ -110,25 +109,25 @@ RSpec.describe V1::ShowcaseJSONDecorator do
     end
   end
 
-  describe '#sections' do
-    let(:showcase) { double(Showcase, sections: [] )}
+  describe "#sections" do
+    let(:showcase) { double(Showcase, sections: [] ) }
 
-    it 'uses the section query object ordered' do
-      expect_any_instance_of(SectionQuery).to receive(:ordered).and_return(['results'])
-      expect(subject.sections).to eq(['results'])
+    it "uses the section query object ordered" do
+      expect_any_instance_of(SectionQuery).to receive(:ordered).and_return(["results"])
+      expect(subject.sections).to eq(["results"])
     end
 
-    it 'filters on just the sections in the showcase' do
+    it "filters on just the sections in the showcase" do
       expect(subject).to receive(:sections).and_return([])
       subject.sections
     end
   end
 
-  describe '#display' do
+  describe "#display" do
     let(:json) { double }
 
-    it 'calls the partial for the display' do
-      expect(json).to receive(:partial!).with('/v1/showcases/showcase', showcase_object: showcase)
+    it "calls the partial for the display" do
+      expect(json).to receive(:partial!).with("/v1/showcases/showcase", showcase_object: showcase)
       subject.display(json)
     end
   end

--- a/spec/decorators/v1/showcase_json_decorator_spec.rb
+++ b/spec/decorators/v1/showcase_json_decorator_spec.rb
@@ -41,6 +41,48 @@ RSpec.describe V1::ShowcaseJSONDecorator do
     end
   end
 
+
+  describe "#title" do
+    it "concatinates title_line_1 and title_line_2 if there is a title_line_2" do
+      expect(subject).to receive(:title_line_1).and_return("title line 1")
+      expect(subject).to receive(:title_line_2).twice.and_return("title line 2")
+
+      expect(subject.title).to eq("title line 1 title line 2")
+    end
+
+    it "does not concatintate title_line_2 if there is no title_line_2" do
+      expect(subject).to receive(:title_line_1).and_return("title line 1")
+      expect(subject).to receive(:title_line_2).and_return(nil)
+
+      expect(subject.title).to eq("title line 1")
+    end
+  end
+
+  describe "#title_line_1" do
+    it "maps to title" do
+      expect(showcase).to receive(:title).and_return("super-title")
+      expect(subject.title_line_1).to eq("super-title")
+    end
+
+    it "returns empty string if title is nil " do
+      allow(showcase).to receive(:title).and_return(nil)
+      expect(subject.title_line_1).to eq("")
+    end
+  end
+
+  describe "#title_line_2" do
+    it "maps to subtitle" do
+      expect(showcase).to receive(:subtitle).and_return("super-title")
+      expect(subject.title_line_2).to eq("super-title")
+    end
+
+    it "returns empty string if subtitle is nil " do
+      expect(showcase).to receive(:subtitle).and_return(nil)
+      expect(subject.title_line_2).to eq("")
+    end
+  end
+
+
   describe '#image' do
     it 'gets the honeypot_image json_response' do
       expect(honeypot_image).to receive(:json_response).and_return('json_response')


### PR DESCRIPTION
I updated showcases to do the same thing with titling i did with collections so we have control over 2 line titles. 

In the api there is a title, title_line_1 and title_line_2, and a description.  Title is title_line_1 + title_line 2.   In addition the showcase table stores the data as title, subtitle and description.  