### PR TITLE
Cache key generators for v1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,6 +71,7 @@ group :development, :test do
 
   gem 'i18n-debug'
   gem 'pry'
+  gem 'pry-nav'
   gem 'rspec-rails'
   gem 'rspec-collection_matchers'
   gem 'capybara'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -236,6 +236,8 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    pry-nav (0.2.4)
+      pry (>= 0.9.10, < 0.11.0)
     rack (1.6.0)
     rack-cache (1.2)
       rack (>= 0.4)
@@ -416,6 +418,7 @@ DEPENDENCIES
   paper_trail (~> 4.0.0.beta2)
   paperclip
   pry
+  pry-nav
   rack-cache
   rails (~> 4.2.0)
   rake

--- a/app/controllers/admin/administrators_controller.rb
+++ b/app/controllers/admin/administrators_controller.rb
@@ -5,9 +5,10 @@ module Admin
       administrators = AdministratorQuery.new.list
       @administrators = AdministratorListDecorator.new(administrators)
 
-      keyGen = CacheKeys::Generator::Administrators.new
-      cacheKey = CacheKeys::Generator.new(keyGenerator: keyGen, action: "index")
-      fresh_when(etag: cacheKey.generate(decoratedAdministrators: @administrators))
+      cache_key = CacheKeys::Generator.new(keyGenerator: CacheKeys::Generator::Administrators,
+                                          action: "index",
+                                          decoratedAdministrators: @administrators)
+      fresh_when(etag: cache_key.generate)
     end
 
     def create

--- a/app/controllers/admin/administrators_controller.rb
+++ b/app/controllers/admin/administrators_controller.rb
@@ -5,7 +5,7 @@ module Admin
       administrators = AdministratorQuery.new.list
       @administrators = AdministratorListDecorator.new(administrators)
 
-      cache_key = CacheKeys::Generator.new(key_generator: CacheKeys::Generator::Administrators,
+      cache_key = CacheKeys::Generator.new(key_generator: CacheKeys::Custom::Administrators,
                                            action: "index",
                                            decorated_administrators: @administrators)
       fresh_when(etag: cache_key.generate)

--- a/app/controllers/admin/administrators_controller.rb
+++ b/app/controllers/admin/administrators_controller.rb
@@ -6,8 +6,8 @@ module Admin
       @administrators = AdministratorListDecorator.new(administrators)
 
       cache_key = CacheKeys::Generator.new(keyGenerator: CacheKeys::Generator::Administrators,
-                                          action: "index",
-                                          decoratedAdministrators: @administrators)
+                                           action: "index",
+                                           decoratedAdministrators: @administrators)
       fresh_when(etag: cache_key.generate)
     end
 

--- a/app/controllers/admin/administrators_controller.rb
+++ b/app/controllers/admin/administrators_controller.rb
@@ -5,9 +5,9 @@ module Admin
       administrators = AdministratorQuery.new.list
       @administrators = AdministratorListDecorator.new(administrators)
 
-      cache_key = CacheKeys::Generator.new(keyGenerator: CacheKeys::Generator::Administrators,
+      cache_key = CacheKeys::Generator.new(key_generator: CacheKeys::Generator::Administrators,
                                            action: "index",
-                                           decoratedAdministrators: @administrators)
+                                           decorated_administrators: @administrators)
       fresh_when(etag: cache_key.generate)
     end
 

--- a/app/controllers/admin/administrators_controller.rb
+++ b/app/controllers/admin/administrators_controller.rb
@@ -7,8 +7,7 @@ module Admin
 
       keyGen = CacheKeys::Generator::Administrators.new
       cacheKey = CacheKeys::Generator.new(keyGenerator: keyGen, action: "index")
-      print cacheKey.generate(@administrators)
-      fresh_when(etag: cacheKey.generate(@administrators))
+      fresh_when(etag: cacheKey.generate(decoratedAdministrators: @administrators))
     end
 
     def create

--- a/app/controllers/admin/administrators_controller.rb
+++ b/app/controllers/admin/administrators_controller.rb
@@ -4,7 +4,11 @@ module Admin
       check_admin_permission!
       administrators = AdministratorQuery.new.list
       @administrators = AdministratorListDecorator.new(administrators)
-      fresh_when(@administrators)
+
+      keyGen = CacheKeys::Generator::Administrators.new
+      cacheKey = CacheKeys::Generator.new(keyGenerator: keyGen, action: "index")
+      print cacheKey.generate(@administrators)
+      fresh_when(etag: cacheKey.generate(@administrators))
     end
 
     def create

--- a/app/controllers/v1/collections_controller.rb
+++ b/app/controllers/v1/collections_controller.rb
@@ -4,8 +4,8 @@ module V1
       @collections = CollectionQuery.new.public_collections
 
       cache_key = CacheKeys::Generator.new(keyGenerator: CacheKeys::Generator::V1Collections,
-                                          action: "index",
-                                          collections: @collections)
+                                           action: "index",
+                                           collections: @collections)
       fresh_when(etag: cache_key.generate)
     end
 
@@ -13,8 +13,8 @@ module V1
       @collection = CollectionQuery.new.public_find(params[:id])
 
       cache_key = CacheKeys::Generator.new(keyGenerator: CacheKeys::Generator::V1Collections,
-                                          action: "show",
-                                          collection: @collection)
+                                           action: "show",
+                                           collection: @collection)
       fresh_when(etag: cache_key.generate)
     end
   end

--- a/app/controllers/v1/collections_controller.rb
+++ b/app/controllers/v1/collections_controller.rb
@@ -5,8 +5,7 @@ module V1
 
       keyGen = CacheKeys::Generator::V1Collections.new
       cacheKey = CacheKeys::Generator.new(keyGenerator: keyGen, action: "index")
-      print cacheKey.generate(record: @collections)
-      fresh_when(etag: cacheKey.generate(record: @collections))
+      fresh_when(etag: cacheKey.generate(collections: @collections))
     end
 
     def show
@@ -15,8 +14,7 @@ module V1
 
       keyGen = CacheKeys::Generator::V1Collections.new
       cacheKey = CacheKeys::Generator.new(keyGenerator: keyGen, action: "show")
-      print cacheKey.generate(record: @collection)
-      fresh_when(etag: cacheKey.generate(record: @collection))
+      fresh_when(etag: cacheKey.generate(collection: @collection))
     end
   end
 end

--- a/app/controllers/v1/collections_controller.rb
+++ b/app/controllers/v1/collections_controller.rb
@@ -2,12 +2,21 @@ module V1
   class CollectionsController < APIController
     def index
       @collections = CollectionQuery.new.public_collections
-      fresh_when(@collections)
+
+      keyGen = CacheKeys::Generator::V1Collections.new
+      cacheKey = CacheKeys::Generator.new(keyGenerator: keyGen, action: "index")
+      print cacheKey.generate(record: @collections)
+      fresh_when(etag: cacheKey.generate(record: @collections))
     end
 
     def show
       @collection = CollectionQuery.new.public_find(params[:id])
       fresh_when(@collection)
+
+      keyGen = CacheKeys::Generator::V1Collections.new
+      cacheKey = CacheKeys::Generator.new(keyGenerator: keyGen, action: "show")
+      print cacheKey.generate(record: @collection)
+      fresh_when(etag: cacheKey.generate(record: @collection))
     end
   end
 end

--- a/app/controllers/v1/collections_controller.rb
+++ b/app/controllers/v1/collections_controller.rb
@@ -3,7 +3,7 @@ module V1
     def index
       @collections = CollectionQuery.new.public_collections
 
-      cache_key = CacheKeys::Generator.new(key_generator: CacheKeys::Generator::V1Collections,
+      cache_key = CacheKeys::Generator.new(key_generator: CacheKeys::Custom::V1Collections,
                                            action: "index",
                                            collections: @collections)
       fresh_when(etag: cache_key.generate)
@@ -12,7 +12,7 @@ module V1
     def show
       @collection = CollectionQuery.new.public_find(params[:id])
 
-      cache_key = CacheKeys::Generator.new(key_generator: CacheKeys::Generator::V1Collections,
+      cache_key = CacheKeys::Generator.new(key_generator: CacheKeys::Custom::V1Collections,
                                            action: "show",
                                            collection: @collection)
       fresh_when(etag: cache_key.generate)

--- a/app/controllers/v1/collections_controller.rb
+++ b/app/controllers/v1/collections_controller.rb
@@ -3,18 +3,19 @@ module V1
     def index
       @collections = CollectionQuery.new.public_collections
 
-      keyGen = CacheKeys::Generator::V1Collections.new
-      cacheKey = CacheKeys::Generator.new(keyGenerator: keyGen, action: "index")
-      fresh_when(etag: cacheKey.generate(collections: @collections))
+      cache_key = CacheKeys::Generator.new(keyGenerator: CacheKeys::Generator::V1Collections,
+                                          action: "index",
+                                          collections: @collections)
+      fresh_when(etag: cache_key.generate)
     end
 
     def show
       @collection = CollectionQuery.new.public_find(params[:id])
-      fresh_when(@collection)
 
-      keyGen = CacheKeys::Generator::V1Collections.new
-      cacheKey = CacheKeys::Generator.new(keyGenerator: keyGen, action: "show")
-      fresh_when(etag: cacheKey.generate(collection: @collection))
+      cache_key = CacheKeys::Generator.new(keyGenerator: CacheKeys::Generator::V1Collections,
+                                          action: "show",
+                                          collection: @collection)
+      fresh_when(etag: cache_key.generate)
     end
   end
 end

--- a/app/controllers/v1/collections_controller.rb
+++ b/app/controllers/v1/collections_controller.rb
@@ -3,7 +3,7 @@ module V1
     def index
       @collections = CollectionQuery.new.public_collections
 
-      cache_key = CacheKeys::Generator.new(keyGenerator: CacheKeys::Generator::V1Collections,
+      cache_key = CacheKeys::Generator.new(key_generator: CacheKeys::Generator::V1Collections,
                                            action: "index",
                                            collections: @collections)
       fresh_when(etag: cache_key.generate)
@@ -12,7 +12,7 @@ module V1
     def show
       @collection = CollectionQuery.new.public_find(params[:id])
 
-      cache_key = CacheKeys::Generator.new(keyGenerator: CacheKeys::Generator::V1Collections,
+      cache_key = CacheKeys::Generator.new(key_generator: CacheKeys::Generator::V1Collections,
                                            action: "show",
                                            collection: @collection)
       fresh_when(etag: cache_key.generate)

--- a/app/controllers/v1/items_controller.rb
+++ b/app/controllers/v1/items_controller.rb
@@ -5,12 +5,18 @@ module V1
     def index
       collection = CollectionQuery.new.public_find(params[:collection_id])
       @collection = CollectionJSONDecorator.new(collection)
-      fresh_when([collection, collection.items])
+
+      keyGen = CacheKeys::Generator::V1Items.new
+      cacheKey = CacheKeys::Generator.new(keyGenerator: keyGen, action: "index")
+      fresh_when(etag: cacheKey.generate(collection: collection, items: collection.items))
     end
 
     def show
       @item = ItemQuery.new.public_find(params[:id])
-      fresh_when([@item, @item.collection, @item.children])
+
+      keyGen = CacheKeys::Generator::V1Items.new
+      cacheKey = CacheKeys::Generator.new(keyGenerator: keyGen, action: "show")
+      fresh_when(etag: cacheKey.generate(item: @item, collection: @item.collection, children: @item.children))
     end
   end
 end

--- a/app/controllers/v1/items_controller.rb
+++ b/app/controllers/v1/items_controller.rb
@@ -6,7 +6,7 @@ module V1
       collection = CollectionQuery.new.public_find(params[:collection_id])
       @collection = CollectionJSONDecorator.new(collection)
 
-      cache_key = CacheKeys::Generator.new(key_generator: CacheKeys::Generator::V1Items,
+      cache_key = CacheKeys::Generator.new(key_generator: CacheKeys::Custom::V1Items,
                                            action: "index",
                                            collection: collection)
       fresh_when(etag: cache_key.generate)
@@ -15,7 +15,7 @@ module V1
     def show
       @item = ItemQuery.new.public_find(params[:id])
 
-      cache_key = CacheKeys::Generator.new(key_generator: CacheKeys::Generator::V1Items,
+      cache_key = CacheKeys::Generator.new(key_generator: CacheKeys::Custom::V1Items,
                                            action: "show",
                                            item: @item)
       fresh_when(etag: cache_key.generate)

--- a/app/controllers/v1/items_controller.rb
+++ b/app/controllers/v1/items_controller.rb
@@ -6,17 +6,19 @@ module V1
       collection = CollectionQuery.new.public_find(params[:collection_id])
       @collection = CollectionJSONDecorator.new(collection)
 
-      keyGen = CacheKeys::Generator::V1Items.new
-      cacheKey = CacheKeys::Generator.new(keyGenerator: keyGen, action: "index")
-      fresh_when(etag: cacheKey.generate(collection: collection, items: collection.items))
+      cache_key = CacheKeys::Generator.new(keyGenerator: CacheKeys::Generator::V1Items,
+                                           action: "index",
+                                           collection: collection)
+      fresh_when(etag: cache_key.generate)
     end
 
     def show
       @item = ItemQuery.new.public_find(params[:id])
 
-      keyGen = CacheKeys::Generator::V1Items.new
-      cacheKey = CacheKeys::Generator.new(keyGenerator: keyGen, action: "show")
-      fresh_when(etag: cacheKey.generate(item: @item, collection: @item.collection, children: @item.children))
+      cache_key = CacheKeys::Generator.new(keyGenerator: CacheKeys::Generator::V1Items,
+                                           action: "show",
+                                           item: @item)
+      fresh_when(etag: cache_key.generate)
     end
   end
 end

--- a/app/controllers/v1/items_controller.rb
+++ b/app/controllers/v1/items_controller.rb
@@ -6,7 +6,7 @@ module V1
       collection = CollectionQuery.new.public_find(params[:collection_id])
       @collection = CollectionJSONDecorator.new(collection)
 
-      cache_key = CacheKeys::Generator.new(keyGenerator: CacheKeys::Generator::V1Items,
+      cache_key = CacheKeys::Generator.new(key_generator: CacheKeys::Generator::V1Items,
                                            action: "index",
                                            collection: collection)
       fresh_when(etag: cache_key.generate)
@@ -15,7 +15,7 @@ module V1
     def show
       @item = ItemQuery.new.public_find(params[:id])
 
-      cache_key = CacheKeys::Generator.new(keyGenerator: CacheKeys::Generator::V1Items,
+      cache_key = CacheKeys::Generator.new(key_generator: CacheKeys::Generator::V1Items,
                                            action: "show",
                                            item: @item)
       fresh_when(etag: cache_key.generate)

--- a/app/controllers/v1/sections_controller.rb
+++ b/app/controllers/v1/sections_controller.rb
@@ -4,7 +4,7 @@ module V1
       section = SectionQuery.new.public_find(params[:id])
       @section = SectionJSONDecorator.new(section)
 
-      cache_key = CacheKeys::Generator.new(key_generator: CacheKeys::Generator::V1Sections,
+      cache_key = CacheKeys::Generator.new(key_generator: CacheKeys::Custom::V1Sections,
                                            action: "show",
                                            decorated_section: @section)
       fresh_when(etag: cache_key.generate)

--- a/app/controllers/v1/sections_controller.rb
+++ b/app/controllers/v1/sections_controller.rb
@@ -1,8 +1,18 @@
 module V1
   class SectionsController < APIController
     def show
-      @section = SectionJSONDecorator.new(SectionQuery.new.public_find(params[:id]))
-      fresh_when([@section, @section.item, @section.collection, @section.showcase])
+      section = SectionQuery.new.public_find(params[:id])
+      @section = SectionJSONDecorator.new(section)
+
+      keyGen = CacheKeys::Generator::V1Sections.new
+      cacheKey = CacheKeys::Generator.new(keyGenerator: keyGen, action: "show")
+      fresh_when(etag: cacheKey.generate(section: section,
+                                         item: section.item,
+                                         itemChildren: section.item.children,
+                                         nextSection: @section.next,
+                                         previousSection: @section.previous,
+                                         collection: section.collection,
+                                         showcase: section.showcase))
     end
   end
 end

--- a/app/controllers/v1/sections_controller.rb
+++ b/app/controllers/v1/sections_controller.rb
@@ -4,9 +4,9 @@ module V1
       section = SectionQuery.new.public_find(params[:id])
       @section = SectionJSONDecorator.new(section)
 
-      cache_key = CacheKeys::Generator.new(keyGenerator: CacheKeys::Generator::V1Sections,
+      cache_key = CacheKeys::Generator.new(key_generator: CacheKeys::Generator::V1Sections,
                                            action: "show",
-                                           decoratedSection: @section)
+                                           decorated_section: @section)
       fresh_when(etag: cache_key.generate)
     end
   end

--- a/app/controllers/v1/sections_controller.rb
+++ b/app/controllers/v1/sections_controller.rb
@@ -4,15 +4,10 @@ module V1
       section = SectionQuery.new.public_find(params[:id])
       @section = SectionJSONDecorator.new(section)
 
-      keyGen = CacheKeys::Generator::V1Sections.new
-      cacheKey = CacheKeys::Generator.new(keyGenerator: keyGen, action: "show")
-      fresh_when(etag: cacheKey.generate(section: section,
-                                         item: section.item,
-                                         itemChildren: section.item.children,
-                                         nextSection: @section.next,
-                                         previousSection: @section.previous,
-                                         collection: section.collection,
-                                         showcase: section.showcase))
+      cache_key = CacheKeys::Generator.new(keyGenerator: CacheKeys::Generator::V1Sections,
+                                           action: "show",
+                                           decoratedSection: @section)
+      fresh_when(etag: cache_key.generate)
     end
   end
 end

--- a/app/controllers/v1/showcases_controller.rb
+++ b/app/controllers/v1/showcases_controller.rb
@@ -3,13 +3,22 @@ module V1
     def index
       collection = CollectionQuery.new.public_find(params[:collection_id])
       @collection = CollectionJSONDecorator.new(collection)
-      fresh_when([collection, collection.showcases])
+
+      keyGen = CacheKeys::Generator::V1Showcases.new
+      cacheKey = CacheKeys::Generator.new(keyGenerator: keyGen, action: "index")
+      fresh_when(etag: cacheKey.generate(collection: collection, showcases: collection.showcases))
     end
 
     def show
       showcase = ShowcaseQuery.new.public_find(params[:id])
       @showcase = ShowcaseJSONDecorator.new(showcase)
-      fresh_when([showcase, showcase.collection, showcase.sections, showcase.items])
+
+      keyGen = CacheKeys::Generator::V1Showcases.new
+      cacheKey = CacheKeys::Generator.new(keyGenerator: keyGen, action: "show")
+      fresh_when(etag: cacheKey.generate(showcase: showcase,
+                                         collection: showcase.collection,
+                                         sections: showcase.sections,
+                                         items: showcase.items))
     end
   end
 end

--- a/app/controllers/v1/showcases_controller.rb
+++ b/app/controllers/v1/showcases_controller.rb
@@ -4,7 +4,7 @@ module V1
       collection = CollectionQuery.new.public_find(params[:collection_id])
       @collection = CollectionJSONDecorator.new(collection)
 
-      cache_key = CacheKeys::Generator.new(key_generator: CacheKeys::Generator::V1Showcases,
+      cache_key = CacheKeys::Generator.new(key_generator: CacheKeys::Custom::V1Showcases,
                                            action: "index",
                                            collection: collection)
       fresh_when(etag: cache_key.generate)
@@ -14,7 +14,7 @@ module V1
       showcase = ShowcaseQuery.new.public_find(params[:id])
       @showcase = ShowcaseJSONDecorator.new(showcase)
 
-      cache_key = CacheKeys::Generator.new(key_generator: CacheKeys::Generator::V1Showcases,
+      cache_key = CacheKeys::Generator.new(key_generator: CacheKeys::Custom::V1Showcases,
                                            action: "show",
                                            showcase: showcase)
       fresh_when(etag: cache_key.generate)

--- a/app/controllers/v1/showcases_controller.rb
+++ b/app/controllers/v1/showcases_controller.rb
@@ -4,21 +4,20 @@ module V1
       collection = CollectionQuery.new.public_find(params[:collection_id])
       @collection = CollectionJSONDecorator.new(collection)
 
-      keyGen = CacheKeys::Generator::V1Showcases.new
-      cacheKey = CacheKeys::Generator.new(keyGenerator: keyGen, action: "index")
-      fresh_when(etag: cacheKey.generate(collection: collection, showcases: collection.showcases))
+      cache_key = CacheKeys::Generator.new(keyGenerator: CacheKeys::Generator::V1Showcases,
+                                           action: "index",
+                                           collection: collection)
+      fresh_when(etag: cache_key.generate)
     end
 
     def show
       showcase = ShowcaseQuery.new.public_find(params[:id])
       @showcase = ShowcaseJSONDecorator.new(showcase)
 
-      keyGen = CacheKeys::Generator::V1Showcases.new
-      cacheKey = CacheKeys::Generator.new(keyGenerator: keyGen, action: "show")
-      fresh_when(etag: cacheKey.generate(showcase: showcase,
-                                         collection: showcase.collection,
-                                         sections: showcase.sections,
-                                         items: showcase.items))
+      cache_key = CacheKeys::Generator.new(keyGenerator: CacheKeys::Generator::V1Showcases,
+                                           action: "show",
+                                           showcase: showcase)
+      fresh_when(etag: cache_key.generate)
     end
   end
 end

--- a/app/controllers/v1/showcases_controller.rb
+++ b/app/controllers/v1/showcases_controller.rb
@@ -4,7 +4,7 @@ module V1
       collection = CollectionQuery.new.public_find(params[:collection_id])
       @collection = CollectionJSONDecorator.new(collection)
 
-      cache_key = CacheKeys::Generator.new(keyGenerator: CacheKeys::Generator::V1Showcases,
+      cache_key = CacheKeys::Generator.new(key_generator: CacheKeys::Generator::V1Showcases,
                                            action: "index",
                                            collection: collection)
       fresh_when(etag: cache_key.generate)
@@ -14,7 +14,7 @@ module V1
       showcase = ShowcaseQuery.new.public_find(params[:id])
       @showcase = ShowcaseJSONDecorator.new(showcase)
 
-      cache_key = CacheKeys::Generator.new(keyGenerator: CacheKeys::Generator::V1Showcases,
+      cache_key = CacheKeys::Generator.new(key_generator: CacheKeys::Generator::V1Showcases,
                                            action: "show",
                                            showcase: showcase)
       fresh_when(etag: cache_key.generate)

--- a/app/decorators/v1/section_json_decorator.rb
+++ b/app/decorators/v1/section_json_decorator.rb
@@ -39,6 +39,10 @@ module V1
       SectionQuery.new.previous(object)
     end
 
+    def item_children
+      object.item && object.item.children
+    end
+
     def display(json)
       if object.present?
         json.partial! '/v1/sections/section', section_object: self

--- a/app/values/cache_keys/active_record.rb
+++ b/app/values/cache_keys/active_record.rb
@@ -1,4 +1,6 @@
 module CacheKeys
+  # Replicates what Rails does for an ActiveRecord when generating a
+  # cache key
   class ActiveRecord
     def generate(record:)
       ActiveSupport::Cache.expand_cache_key(record)

--- a/app/values/cache_keys/active_record.rb
+++ b/app/values/cache_keys/active_record.rb
@@ -1,11 +1,7 @@
 module CacheKeys
   class ActiveRecord
-    def initialize(list: list)
-      @list = list.flatten
-    end
-
-    def generate()
-      ActiveSupport::Cache.expand_cache_key(@list)
+    def generate(record:)
+      ActiveSupport::Cache.expand_cache_key(record)
     end
   end
 end

--- a/app/values/cache_keys/active_record.rb
+++ b/app/values/cache_keys/active_record.rb
@@ -1,0 +1,11 @@
+module CacheKeys
+  class ActiveRecord
+    def initialize(list: list)
+      @list = list.flatten
+    end
+
+    def generate()
+      ActiveSupport::Cache.expand_cache_key(@list)
+    end
+  end
+end

--- a/app/values/cache_keys/custom/administrators.rb
+++ b/app/values/cache_keys/custom/administrators.rb
@@ -1,0 +1,10 @@
+module CacheKeys
+  module Custom
+    # Generator for admin/administrators_controller
+    class Administrators
+      def index(decorated_administrators:)
+        CacheKeys::DecoratedActiveRecord.new.generate(record: decorated_administrators)
+      end
+    end
+  end
+end

--- a/app/values/cache_keys/custom/v1_collections.rb
+++ b/app/values/cache_keys/custom/v1_collections.rb
@@ -1,0 +1,14 @@
+module CacheKeys
+  module Custom
+    # Generator for v1/collections_controller
+    class V1Collections
+      def index(collections:)
+        CacheKeys::ActiveRecord.new.generate(record: collections)
+      end
+
+      def show(collection:)
+        CacheKeys::ActiveRecord.new.generate(record: collection)
+      end
+    end
+  end
+end

--- a/app/values/cache_keys/custom/v1_items.rb
+++ b/app/values/cache_keys/custom/v1_items.rb
@@ -1,0 +1,14 @@
+module CacheKeys
+  module Custom
+    # Generator for v1/items_controller
+    class V1Items
+      def index(collection:)
+        CacheKeys::ActiveRecord.new.generate(record: [collection, collection.items])
+      end
+
+      def show(item:)
+        CacheKeys::ActiveRecord.new.generate(record: [item, item.collection, item.children])
+      end
+    end
+  end
+end

--- a/app/values/cache_keys/custom/v1_sections.rb
+++ b/app/values/cache_keys/custom/v1_sections.rb
@@ -1,0 +1,16 @@
+module CacheKeys
+  module Custom
+    # Generator for v1/sections_controller
+    class V1Sections
+      def show(decorated_section:)
+        CacheKeys::ActiveRecord.new.generate(record: [decorated_section.object,
+                                                      decorated_section.item,
+                                                      decorated_section.item_children,
+                                                      decorated_section.next,
+                                                      decorated_section.previous,
+                                                      decorated_section.collection,
+                                                      decorated_section.showcase])
+      end
+    end
+  end
+end

--- a/app/values/cache_keys/custom/v1_showcases.rb
+++ b/app/values/cache_keys/custom/v1_showcases.rb
@@ -1,0 +1,14 @@
+module CacheKeys
+  module Custom
+    # Generator for v1/showcases_controller
+    class V1Showcases
+      def index(collection:)
+        CacheKeys::ActiveRecord.new.generate(record: [collection, collection.showcases])
+      end
+
+      def show(showcase:)
+        CacheKeys::ActiveRecord.new.generate(record: [showcase, showcase.collection, showcase.sections, showcase.items])
+      end
+    end
+  end
+end

--- a/app/values/cache_keys/decorated_active_record.rb
+++ b/app/values/cache_keys/decorated_active_record.rb
@@ -1,0 +1,15 @@
+module CacheKeys
+  class DecoratedActiveRecord
+    def initialize(list: list)
+      @list = list.flatten
+    end
+
+    def generate()
+      keys = []
+      @list.each do |decoratedObject|
+        keys.push ActiveSupport::Cache.expand_cache_key(decoratedObject.object)
+      end
+      keys.join('/')
+    end
+  end
+end

--- a/app/values/cache_keys/decorated_active_record.rb
+++ b/app/values/cache_keys/decorated_active_record.rb
@@ -1,4 +1,6 @@
 module CacheKeys
+  # Replicates what Rails does for an ActiveRecord when generating a
+  # cache key, for decorated objects
   class DecoratedActiveRecord
     def generate(record:)
       record.instance_exec() { ActiveSupport::Cache.expand_cache_key(object) }

--- a/app/values/cache_keys/decorated_active_record.rb
+++ b/app/values/cache_keys/decorated_active_record.rb
@@ -3,7 +3,7 @@ module CacheKeys
   # cache key, for decorated objects
   class DecoratedActiveRecord
     def generate(record:)
-      record.instance_exec() { ActiveSupport::Cache.expand_cache_key(object) }
+      record.instance_exec { ActiveSupport::Cache.expand_cache_key(object) }
     end
   end
 end

--- a/app/values/cache_keys/decorated_active_record.rb
+++ b/app/values/cache_keys/decorated_active_record.rb
@@ -1,15 +1,7 @@
 module CacheKeys
   class DecoratedActiveRecord
-    def initialize(list: list)
-      @list = list.flatten
-    end
-
-    def generate()
-      keys = []
-      @list.each do |decoratedObject|
-        keys.push ActiveSupport::Cache.expand_cache_key(decoratedObject.object)
-      end
-      keys.join('/')
+    def generate(record:)
+      record.instance_exec() { ActiveSupport::Cache.expand_cache_key(object) }
     end
   end
 end

--- a/app/values/cache_keys/generator.rb
+++ b/app/values/cache_keys/generator.rb
@@ -12,7 +12,7 @@ module CacheKeys
 
     def generate
       # print generator.class.name + "." + action + "='" + generator.send(action, **@args) + "'\n"
-      generator.send(@action, **@args)
+      generator.send(action, **args)
     end
   end
 end

--- a/app/values/cache_keys/generator.rb
+++ b/app/values/cache_keys/generator.rb
@@ -1,4 +1,6 @@
 module CacheKeys
+  # Generator handles routing the cache key generation to a given
+  # key generator and action for that generator
   class Generator
     def initialize(keyGenerator:, action: :generate)
       @generator = keyGenerator
@@ -6,31 +8,54 @@ module CacheKeys
     end
 
     def generate(*args)
-      @generator.send(@action, args)
+      key = @generator.send(@action, *args)
+      print @generator.class.name + "." + @action + "='" + key + "'\n"
     end
 
+    # Generator for admin/administrators_controller
     class Administrators
-      def none(args)
-      end
-
-      def index(args)
-        decoratedAdministrators = args[0]
+      def index(decoratedAdministrators:)
         CacheKeys::DecoratedActiveRecord.new.generate(record: decoratedAdministrators)
       end
     end
 
+    # Generator for v1/collections_controller
     class V1Collections
-      def none(args)
-      end
-
-      def index(args)
-        collections = args[0]
+      def index(collections:)
         CacheKeys::ActiveRecord.new.generate(record: collections)
       end
 
-      def show(args)
-        collection = args[0]
+      def show(collection:)
         CacheKeys::ActiveRecord.new.generate(record: collection)
+      end
+    end
+
+    # Generator for v1/items_controller
+    class V1Items
+      def index(collection:, items:)
+        CacheKeys::ActiveRecord.new.generate(record: [collection, items])
+      end
+
+      def show(item:, collection:, children:)
+        CacheKeys::ActiveRecord.new.generate(record: [item, collection, children])
+      end
+    end
+
+    # Generator for v1/sections_controller
+    class V1Sections
+      def show(section:, item:, itemChildren:, nextSection:, previousSection:, collection:, showcase:)
+        CacheKeys::ActiveRecord.new.generate(record: [section, item, itemChildren, nextSection, previousSection, collection, showcase])
+      end
+    end
+
+    # Generator for v1/showcases_controller
+    class V1Showcases
+      def index(collection:, showcases:)
+        CacheKeys::ActiveRecord.new.generate(record: [collection, showcases])
+      end
+
+      def show(showcase:, collection:, sections:, items: )
+        CacheKeys::ActiveRecord.new.generate(record: [showcase, collection, sections, items])
       end
     end
   end

--- a/app/values/cache_keys/generator.rb
+++ b/app/values/cache_keys/generator.rb
@@ -9,7 +9,7 @@ module CacheKeys
     end
 
     def generate
-      #print @generator.class.name + "." + @action + "='" + @generator.send(@action, **@args) + "'\n"
+      # print @generator.class.name + "." + @action + "='" + @generator.send(@action, **@args) + "'\n"
       @generator.send(@action, **@args)
     end
 

--- a/app/values/cache_keys/generator.rb
+++ b/app/values/cache_keys/generator.rb
@@ -2,14 +2,15 @@ module CacheKeys
   # Generator handles routing the cache key generation to a given
   # key generator and action for that generator
   class Generator
-    def initialize(keyGenerator:, action: :generate)
-      @generator = keyGenerator
+    def initialize(keyGenerator:, action: :generate, **args)
+      @generator = keyGenerator.new
       @action = action
+      @args = args
     end
 
-    def generate(*args)
-      key = @generator.send(@action, *args)
-      #print @generator.class.name + "." + @action + "='" + key + "'\n"
+    def generate
+      #print @generator.class.name + "." + @action + "='" + @generator.send(@action, **@args) + "'\n"
+      @generator.send(@action, **@args)
     end
 
     # Generator for admin/administrators_controller
@@ -32,30 +33,36 @@ module CacheKeys
 
     # Generator for v1/items_controller
     class V1Items
-      def index(collection:, items:)
-        CacheKeys::ActiveRecord.new.generate(record: [collection, items])
+      def index(collection:)
+        CacheKeys::ActiveRecord.new.generate(record: [collection, collection.items])
       end
 
-      def show(item:, collection:, children:)
-        CacheKeys::ActiveRecord.new.generate(record: [item, collection, children])
+      def show(item:)
+        CacheKeys::ActiveRecord.new.generate(record: [item, item.collection, item.children])
       end
     end
 
     # Generator for v1/sections_controller
     class V1Sections
-      def show(section:, item:, itemChildren:, nextSection:, previousSection:, collection:, showcase:)
-        CacheKeys::ActiveRecord.new.generate(record: [section, item, itemChildren, nextSection, previousSection, collection, showcase])
+      def show(decoratedSection:)
+        CacheKeys::ActiveRecord.new.generate(record: [decoratedSection.object,
+                                                      decoratedSection.item,
+                                                      decoratedSection.item_children,
+                                                      decoratedSection.next,
+                                                      decoratedSection.previous,
+                                                      decoratedSection.collection,
+                                                      decoratedSection.showcase])
       end
     end
 
     # Generator for v1/showcases_controller
     class V1Showcases
-      def index(collection:, showcases:)
-        CacheKeys::ActiveRecord.new.generate(record: [collection, showcases])
+      def index(collection:)
+        CacheKeys::ActiveRecord.new.generate(record: [collection, collection.showcases])
       end
 
-      def show(showcase:, collection:, sections:, items: )
-        CacheKeys::ActiveRecord.new.generate(record: [showcase, collection, sections, items])
+      def show(showcase:)
+        CacheKeys::ActiveRecord.new.generate(record: [showcase, showcase.collection, showcase.sections, showcase.items])
       end
     end
   end

--- a/app/values/cache_keys/generator.rb
+++ b/app/values/cache_keys/generator.rb
@@ -9,7 +9,7 @@ module CacheKeys
 
     def generate(*args)
       key = @generator.send(@action, *args)
-      print @generator.class.name + "." + @action + "='" + key + "'\n"
+      #print @generator.class.name + "." + @action + "='" + key + "'\n"
     end
 
     # Generator for admin/administrators_controller

--- a/app/values/cache_keys/generator.rb
+++ b/app/values/cache_keys/generator.rb
@@ -2,8 +2,8 @@ module CacheKeys
   # Generator handles routing the cache key generation to a given
   # key generator and action for that generator
   class Generator
-    def initialize(keyGenerator:, action: :generate, **args)
-      @generator = keyGenerator.new
+    def initialize(key_generator:, action: :generate, **args)
+      @generator = key_generator.new
       @action = action
       @args = args
     end
@@ -15,8 +15,8 @@ module CacheKeys
 
     # Generator for admin/administrators_controller
     class Administrators
-      def index(decoratedAdministrators:)
-        CacheKeys::DecoratedActiveRecord.new.generate(record: decoratedAdministrators)
+      def index(decorated_administrators:)
+        CacheKeys::DecoratedActiveRecord.new.generate(record: decorated_administrators)
       end
     end
 
@@ -44,14 +44,14 @@ module CacheKeys
 
     # Generator for v1/sections_controller
     class V1Sections
-      def show(decoratedSection:)
-        CacheKeys::ActiveRecord.new.generate(record: [decoratedSection.object,
-                                                      decoratedSection.item,
-                                                      decoratedSection.item_children,
-                                                      decoratedSection.next,
-                                                      decoratedSection.previous,
-                                                      decoratedSection.collection,
-                                                      decoratedSection.showcase])
+      def show(decorated_section:)
+        CacheKeys::ActiveRecord.new.generate(record: [decorated_section.object,
+                                                      decorated_section.item,
+                                                      decorated_section.item_children,
+                                                      decorated_section.next,
+                                                      decorated_section.previous,
+                                                      decorated_section.collection,
+                                                      decorated_section.showcase])
       end
     end
 

--- a/app/values/cache_keys/generator.rb
+++ b/app/values/cache_keys/generator.rb
@@ -12,58 +12,5 @@ module CacheKeys
       # print @generator.class.name + "." + @action + "='" + @generator.send(@action, **@args) + "'\n"
       @generator.send(@action, **@args)
     end
-
-    # Generator for admin/administrators_controller
-    class Administrators
-      def index(decorated_administrators:)
-        CacheKeys::DecoratedActiveRecord.new.generate(record: decorated_administrators)
-      end
-    end
-
-    # Generator for v1/collections_controller
-    class V1Collections
-      def index(collections:)
-        CacheKeys::ActiveRecord.new.generate(record: collections)
-      end
-
-      def show(collection:)
-        CacheKeys::ActiveRecord.new.generate(record: collection)
-      end
-    end
-
-    # Generator for v1/items_controller
-    class V1Items
-      def index(collection:)
-        CacheKeys::ActiveRecord.new.generate(record: [collection, collection.items])
-      end
-
-      def show(item:)
-        CacheKeys::ActiveRecord.new.generate(record: [item, item.collection, item.children])
-      end
-    end
-
-    # Generator for v1/sections_controller
-    class V1Sections
-      def show(decorated_section:)
-        CacheKeys::ActiveRecord.new.generate(record: [decorated_section.object,
-                                                      decorated_section.item,
-                                                      decorated_section.item_children,
-                                                      decorated_section.next,
-                                                      decorated_section.previous,
-                                                      decorated_section.collection,
-                                                      decorated_section.showcase])
-      end
-    end
-
-    # Generator for v1/showcases_controller
-    class V1Showcases
-      def index(collection:)
-        CacheKeys::ActiveRecord.new.generate(record: [collection, collection.showcases])
-      end
-
-      def show(showcase:)
-        CacheKeys::ActiveRecord.new.generate(record: [showcase, showcase.collection, showcase.sections, showcase.items])
-      end
-    end
   end
 end

--- a/app/values/cache_keys/generator.rb
+++ b/app/values/cache_keys/generator.rb
@@ -2,6 +2,8 @@ module CacheKeys
   # Generator handles routing the cache key generation to a given
   # key generator and action for that generator
   class Generator
+    attr_reader :generator, :action, :args
+
     def initialize(key_generator:, action: :generate, **args)
       @generator = key_generator.new
       @action = action
@@ -9,8 +11,8 @@ module CacheKeys
     end
 
     def generate
-      # print @generator.class.name + "." + @action + "='" + @generator.send(@action, **@args) + "'\n"
-      @generator.send(@action, **@args)
+      # print generator.class.name + "." + action + "='" + generator.send(action, **@args) + "'\n"
+      generator.send(@action, **@args)
     end
   end
 end

--- a/app/values/cache_keys/generator.rb
+++ b/app/values/cache_keys/generator.rb
@@ -1,0 +1,37 @@
+module CacheKeys
+  class Generator
+    def initialize(keyGenerator:, action: :generate)
+      @generator = keyGenerator
+      @action = action
+    end
+
+    def generate(*args)
+      @generator.send(@action, args)
+    end
+
+    class Administrators
+      def none(args)
+      end
+
+      def index(args)
+        decoratedAdministrators = args[0]
+        CacheKeys::DecoratedActiveRecord.new.generate(record: decoratedAdministrators)
+      end
+    end
+
+    class V1Collections
+      def none(args)
+      end
+
+      def index(args)
+        collections = args[0]
+        CacheKeys::ActiveRecord.new.generate(record: collections)
+      end
+
+      def show(args)
+        collection = args[0]
+        CacheKeys::ActiveRecord.new.generate(record: collection)
+      end
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,8 +14,8 @@ module ItemAdmin
       Rails.root.join('app', 'decorators'),
       Rails.root.join('app', 'policy'),
       Rails.root.join('app', 'services'),
-      Rails.root.join('app', 'forms'),
-      Rails.root.join('app', 'values')
+      Rails.root.join("app", "forms"),
+      Rails.root.join("app", "values")
     ]
 
     # Settings in config/environments/* take precedence over those specified here.

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,7 +14,8 @@ module ItemAdmin
       Rails.root.join('app', 'decorators'),
       Rails.root.join('app', 'policy'),
       Rails.root.join('app', 'services'),
-      Rails.root.join('app', 'forms')
+      Rails.root.join('app', 'forms'),
+      Rails.root.join('app', 'values')
     ]
 
     # Settings in config/environments/* take precedence over those specified here.

--- a/spec/controllers/admin/administrators_controller_spec.rb
+++ b/spec/controllers/admin/administrators_controller_spec.rb
@@ -31,6 +31,11 @@ RSpec.describe Admin::AdministratorsController, type: :controller do
     it_behaves_like "a private basic custom etag cacher" do
       subject { get :index }
     end
+
+    it "uses the Administrators#index to generate the cache key" do
+      expect_any_instance_of(CacheKeys::Generator::Administrators).to receive(:index)
+      subject
+    end
   end
 
   describe 'POST #create' do

--- a/spec/controllers/admin/administrators_controller_spec.rb
+++ b/spec/controllers/admin/administrators_controller_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Admin::AdministratorsController, type: :controller do
     end
 
     it "uses the Administrators#index to generate the cache key" do
-      expect_any_instance_of(CacheKeys::Generator::Administrators).to receive(:index)
+      expect_any_instance_of(CacheKeys::Custom::Administrators).to receive(:index)
       subject
     end
   end

--- a/spec/controllers/v1/collections_controller_spec.rb
+++ b/spec/controllers/v1/collections_controller_spec.rb
@@ -27,6 +27,11 @@ RSpec.describe V1::CollectionsController, type: :controller do
     end
 
     it_behaves_like "a private basic custom etag cacher"
+
+    it "uses the V1Collections#index to generate the cache key" do
+      expect_any_instance_of(CacheKeys::Generator::V1Collections).to receive(:index)
+      subject
+    end
   end
 
   describe '#show' do
@@ -46,5 +51,10 @@ RSpec.describe V1::CollectionsController, type: :controller do
     end
 
     it_behaves_like "a private basic custom etag cacher"
+
+    it "uses the V1Collections#show to generate the cache key" do
+      expect_any_instance_of(CacheKeys::Generator::V1Collections).to receive(:show)
+      subject
+    end
   end
 end

--- a/spec/controllers/v1/collections_controller_spec.rb
+++ b/spec/controllers/v1/collections_controller_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe V1::CollectionsController, type: :controller do
     it_behaves_like "a private basic custom etag cacher"
 
     it "uses the V1Collections#index to generate the cache key" do
-      expect_any_instance_of(CacheKeys::Generator::V1Collections).to receive(:index)
+      expect_any_instance_of(CacheKeys::Custom::V1Collections).to receive(:index)
       subject
     end
   end
@@ -53,7 +53,7 @@ RSpec.describe V1::CollectionsController, type: :controller do
     it_behaves_like "a private basic custom etag cacher"
 
     it "uses the V1Collections#show to generate the cache key" do
-      expect_any_instance_of(CacheKeys::Generator::V1Collections).to receive(:show)
+      expect_any_instance_of(CacheKeys::Custom::V1Collections).to receive(:show)
       subject
     end
   end

--- a/spec/controllers/v1/items_controller_spec.rb
+++ b/spec/controllers/v1/items_controller_spec.rb
@@ -27,6 +27,11 @@ RSpec.describe V1::ItemsController, type: :controller do
     end
 
     it_behaves_like "a private basic custom etag cacher"
+
+    it "uses the V1Items#index to generate the cache key" do
+      expect_any_instance_of(CacheKeys::Generator::V1Items).to receive(:index)
+      subject
+    end
   end
 
   describe '#show' do
@@ -46,5 +51,10 @@ RSpec.describe V1::ItemsController, type: :controller do
     end
 
     it_behaves_like "a private basic custom etag cacher"
+
+    it "uses the V1Items#show to generate the cache key" do
+      expect_any_instance_of(CacheKeys::Generator::V1Items).to receive(:show)
+      subject
+    end
   end
 end

--- a/spec/controllers/v1/items_controller_spec.rb
+++ b/spec/controllers/v1/items_controller_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe V1::ItemsController, type: :controller do
     it_behaves_like "a private basic custom etag cacher"
 
     it "uses the V1Items#index to generate the cache key" do
-      expect_any_instance_of(CacheKeys::Generator::V1Items).to receive(:index)
+      expect_any_instance_of(CacheKeys::Custom::V1Items).to receive(:index)
       subject
     end
   end
@@ -53,7 +53,7 @@ RSpec.describe V1::ItemsController, type: :controller do
     it_behaves_like "a private basic custom etag cacher"
 
     it "uses the V1Items#show to generate the cache key" do
-      expect_any_instance_of(CacheKeys::Generator::V1Items).to receive(:show)
+      expect_any_instance_of(CacheKeys::Custom::V1Items).to receive(:show)
       subject
     end
   end

--- a/spec/controllers/v1/sections_controller_spec.rb
+++ b/spec/controllers/v1/sections_controller_spec.rb
@@ -3,10 +3,13 @@ require "cache_spec_helper"
 
 RSpec.describe V1::SectionsController, type: :controller do
   let(:collection) { instance_double(Collection, id: '1') }
-  let(:section) { instance_double(Section, id: "1", updated_at: nil, item: nil, collection: nil, showcase: nil) }
+  let(:item) { instance_double(Item, id: "1", children: nil)}
+  let(:section) { instance_double(Section, id: "1", updated_at: nil, item: item, collection: nil, showcase: nil) }
 
   before(:each) do
     allow_any_instance_of(SectionQuery).to receive(:public_find).and_return(section)
+    allow_any_instance_of(SectionQuery).to receive(:previous).and_return(nil)
+    allow_any_instance_of(SectionQuery).to receive(:next).and_return(nil)
   end
 
   describe '#show' do

--- a/spec/controllers/v1/sections_controller_spec.rb
+++ b/spec/controllers/v1/sections_controller_spec.rb
@@ -3,7 +3,7 @@ require "cache_spec_helper"
 
 RSpec.describe V1::SectionsController, type: :controller do
   let(:collection) { instance_double(Collection, id: '1') }
-  let(:item) { instance_double(Item, id: "1", children: nil)}
+  let(:item) { instance_double(Item, id: "1", children: nil) }
   let(:section) { instance_double(Section, id: "1", updated_at: nil, item: item, collection: nil, showcase: nil) }
 
   before(:each) do

--- a/spec/controllers/v1/sections_controller_spec.rb
+++ b/spec/controllers/v1/sections_controller_spec.rb
@@ -29,5 +29,10 @@ RSpec.describe V1::SectionsController, type: :controller do
     end
 
     it_behaves_like "a private basic custom etag cacher"
+
+    it "uses the V1Sections#show to generate the cache key" do
+      expect_any_instance_of(CacheKeys::Generator::V1Sections).to receive(:show)
+      subject
+    end
   end
 end

--- a/spec/controllers/v1/sections_controller_spec.rb
+++ b/spec/controllers/v1/sections_controller_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe V1::SectionsController, type: :controller do
     it_behaves_like "a private basic custom etag cacher"
 
     it "uses the V1Sections#show to generate the cache key" do
-      expect_any_instance_of(CacheKeys::Generator::V1Sections).to receive(:show)
+      expect_any_instance_of(CacheKeys::Custom::V1Sections).to receive(:show)
       subject
     end
   end

--- a/spec/controllers/v1/showcases_controller_spec.rb
+++ b/spec/controllers/v1/showcases_controller_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe V1::ShowcasesController, type: :controller do
     it_behaves_like "a private basic custom etag cacher"
 
     it "uses the V1Showcases#index to generate the cache key" do
-      expect_any_instance_of(CacheKeys::Generator::V1Showcases).to receive(:index)
+      expect_any_instance_of(CacheKeys::Custom::V1Showcases).to receive(:index)
       subject
     end
   end
@@ -53,7 +53,7 @@ RSpec.describe V1::ShowcasesController, type: :controller do
     it_behaves_like "a private basic custom etag cacher"
 
     it "uses the V1Showcases#show to generate the cache key" do
-      expect_any_instance_of(CacheKeys::Generator::V1Showcases).to receive(:show)
+      expect_any_instance_of(CacheKeys::Custom::V1Showcases).to receive(:show)
       subject
     end
   end

--- a/spec/controllers/v1/showcases_controller_spec.rb
+++ b/spec/controllers/v1/showcases_controller_spec.rb
@@ -27,6 +27,11 @@ RSpec.describe V1::ShowcasesController, type: :controller do
     end
 
     it_behaves_like "a private basic custom etag cacher"
+
+    it "uses the V1Showcases#index to generate the cache key" do
+      expect_any_instance_of(CacheKeys::Generator::V1Showcases).to receive(:index)
+      subject
+    end
   end
 
   describe '#show' do
@@ -46,5 +51,10 @@ RSpec.describe V1::ShowcasesController, type: :controller do
     end
 
     it_behaves_like "a private basic custom etag cacher"
+
+    it "uses the V1Showcases#show to generate the cache key" do
+      expect_any_instance_of(CacheKeys::Generator::V1Showcases).to receive(:show)
+      subject
+    end
   end
 end

--- a/spec/values/cache_keys/active_record_spec.rb
+++ b/spec/values/cache_keys/active_record_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe CacheKeys::ActiveRecord do
+  it "uses ActiveSupport to generate the key" do
+    object = nil
+    expect(ActiveSupport::Cache).to receive(:expand_cache_key).with(object)
+    subject.generate(record: object)
+  end
+end

--- a/spec/values/cache_keys/custom/administrators_spec.rb
+++ b/spec/values/cache_keys/custom/administrators_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+
+RSpec.describe CacheKeys::Custom::Administrators do
+  context "index" do
+    it "uses CacheKeys::DecoratedActiveRecord" do
+      expect_any_instance_of(CacheKeys::DecoratedActiveRecord).to receive(:generate)
+      subject.index(decorated_administrators: nil)
+    end
+  end
+end

--- a/spec/values/cache_keys/custom/v1_collections_spec.rb
+++ b/spec/values/cache_keys/custom/v1_collections_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe CacheKeys::Custom::V1Collections do
   context "index" do
-    let(:collections) { instance_double(Collection)}
+    let(:collections) { instance_double(Collection) }
 
     it "uses CacheKeys::ActiveRecord" do
       expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate)
@@ -10,7 +10,7 @@ RSpec.describe CacheKeys::Custom::V1Collections do
     end
 
     it "uses the correct data" do
-      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with({record: collections})
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with({ record: collections })
       subject.index(collections: collections)
     end
   end
@@ -24,7 +24,7 @@ RSpec.describe CacheKeys::Custom::V1Collections do
     end
 
     it "uses the correct data" do
-      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with({record: collection})
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with({ record: collection })
       subject.show(collection: collection)
     end
   end

--- a/spec/values/cache_keys/custom/v1_collections_spec.rb
+++ b/spec/values/cache_keys/custom/v1_collections_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe CacheKeys::Custom::V1Collections do
     end
 
     it "uses the correct data" do
-      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with( record: collections )
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with(record: collections)
       subject.index(collections: collections)
     end
   end
@@ -24,7 +24,7 @@ RSpec.describe CacheKeys::Custom::V1Collections do
     end
 
     it "uses the correct data" do
-      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with( record: collection )
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with(record: collection)
       subject.show(collection: collection)
     end
   end

--- a/spec/values/cache_keys/custom/v1_collections_spec.rb
+++ b/spec/values/cache_keys/custom/v1_collections_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe CacheKeys::Custom::V1Collections do
+  context "index" do
+    let(:collections) { instance_double(Collection)}
+
+    it "uses CacheKeys::ActiveRecord" do
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate)
+      subject.index(collections: collections)
+    end
+
+    it "uses the correct data" do
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with({record: collections})
+      subject.index(collections: collections)
+    end
+  end
+
+  context "show" do
+    let(:collection) { instance_double(Collection)}
+
+    it "uses CacheKeys::ActiveRecord" do
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate)
+      subject.show(collection: collection)
+    end
+
+    it "uses the correct data" do
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with({record: collection})
+      subject.show(collection: collection)
+    end
+  end
+end

--- a/spec/values/cache_keys/custom/v1_collections_spec.rb
+++ b/spec/values/cache_keys/custom/v1_collections_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe CacheKeys::Custom::V1Collections do
   end
 
   context "show" do
-    let(:collection) { instance_double(Collection)}
+    let(:collection) { instance_double(Collection) }
 
     it "uses CacheKeys::ActiveRecord" do
       expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate)

--- a/spec/values/cache_keys/custom/v1_collections_spec.rb
+++ b/spec/values/cache_keys/custom/v1_collections_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe CacheKeys::Custom::V1Collections do
     end
 
     it "uses the correct data" do
-      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with({ record: collections })
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with( record: collections )
       subject.index(collections: collections)
     end
   end
@@ -24,7 +24,7 @@ RSpec.describe CacheKeys::Custom::V1Collections do
     end
 
     it "uses the correct data" do
-      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with({ record: collection })
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with( record: collection )
       subject.show(collection: collection)
     end
   end

--- a/spec/values/cache_keys/custom/v1_items_spec.rb
+++ b/spec/values/cache_keys/custom/v1_items_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe CacheKeys::Custom::V1Items do
     end
 
     it "uses the correct data" do
-      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with({record: [collection, "items"]})
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with({ record: [collection, "items"] })
       subject.index(collection: collection)
     end
   end
@@ -24,7 +24,7 @@ RSpec.describe CacheKeys::Custom::V1Items do
     end
 
     it "uses the correct data" do
-      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with({record: [item, "collection", "children"]})
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with({ record: [item, "collection", "children"] })
       subject.show(item: item)
     end
   end

--- a/spec/values/cache_keys/custom/v1_items_spec.rb
+++ b/spec/values/cache_keys/custom/v1_items_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe CacheKeys::Custom::V1Items do
     end
 
     it "uses the correct data" do
-      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with({ record: [collection, "items"] })
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with( record: [collection, "items"] )
       subject.index(collection: collection)
     end
   end
@@ -24,7 +24,7 @@ RSpec.describe CacheKeys::Custom::V1Items do
     end
 
     it "uses the correct data" do
-      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with({ record: [item, "collection", "children"] })
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with( record: [item, "collection", "children"] )
       subject.show(item: item)
     end
   end

--- a/spec/values/cache_keys/custom/v1_items_spec.rb
+++ b/spec/values/cache_keys/custom/v1_items_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe CacheKeys::Custom::V1Items do
   context "index" do
-    let(:collection) { instance_double(Collection, items: "items")}
+    let(:collection) { instance_double(Collection, items: "items") }
 
     it "uses CacheKeys::ActiveRecord" do
       expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate)
@@ -16,7 +16,7 @@ RSpec.describe CacheKeys::Custom::V1Items do
   end
 
   context "show" do
-    let(:item) { instance_double(Item, collection: "collection", children: "children")}
+    let(:item) { instance_double(Item, collection: "collection", children: "children") }
 
     it "uses CacheKeys::ActiveRecord" do
       expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate)

--- a/spec/values/cache_keys/custom/v1_items_spec.rb
+++ b/spec/values/cache_keys/custom/v1_items_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe CacheKeys::Custom::V1Items do
+  context "index" do
+    let(:collection) { instance_double(Collection, items: "items")}
+
+    it "uses CacheKeys::ActiveRecord" do
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate)
+      subject.index(collection: collection)
+    end
+
+    it "uses the correct data" do
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with({record: [collection, "items"]})
+      subject.index(collection: collection)
+    end
+  end
+
+  context "show" do
+    let(:item) { instance_double(Item, collection: "collection", children: "children")}
+
+    it "uses CacheKeys::ActiveRecord" do
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate)
+      subject.show(item: item)
+    end
+
+    it "uses the correct data" do
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with({record: [item, "collection", "children"]})
+      subject.show(item: item)
+    end
+  end
+end

--- a/spec/values/cache_keys/custom/v1_items_spec.rb
+++ b/spec/values/cache_keys/custom/v1_items_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe CacheKeys::Custom::V1Items do
     end
 
     it "uses the correct data" do
-      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with( record: [collection, "items"] )
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with(record: [collection, "items"])
       subject.index(collection: collection)
     end
   end
@@ -24,7 +24,7 @@ RSpec.describe CacheKeys::Custom::V1Items do
     end
 
     it "uses the correct data" do
-      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with( record: [item, "collection", "children"] )
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with(record: [item, "collection", "children"])
       subject.show(item: item)
     end
   end

--- a/spec/values/cache_keys/custom/v1_sections_spec.rb
+++ b/spec/values/cache_keys/custom/v1_sections_spec.rb
@@ -3,7 +3,13 @@ require "rails_helper"
 RSpec.describe CacheKeys::Custom::V1Sections do
   context "show" do
     let(:decorated_section) do
-      method_stubs = { object: "object", item: "item", item_children: "item_children", next: "next", previous: "previous", collection: "collection", showcase: "showcase" }
+      method_stubs = { object: "object",
+                       item: "item",
+                       item_children: "item_children",
+                       next: "next",
+                       previous: "previous",
+                       collection: "collection",
+                       showcase: "showcase" }
       instance_double(V1::SectionJSONDecorator, method_stubs)
     end
 

--- a/spec/values/cache_keys/custom/v1_sections_spec.rb
+++ b/spec/values/cache_keys/custom/v1_sections_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe CacheKeys::Custom::V1Sections do
+
+
+  context "show" do
+    let(:decorated_section) { instance_double(V1::SectionJSONDecorator, object: "object", item: "item", item_children: "item_children", next: "next", previous: "previous", collection: "collection", showcase: "showcase")}
+
+    it "uses CacheKeys::ActiveRecord" do
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate)
+      subject.show(decorated_section: decorated_section)
+    end
+
+    it "uses the correct data" do
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with({record: ["object", "item", "item_children", "next", "previous", "collection", "showcase"]})
+      subject.show(decorated_section: decorated_section)
+    end
+  end
+end

--- a/spec/values/cache_keys/custom/v1_sections_spec.rb
+++ b/spec/values/cache_keys/custom/v1_sections_spec.rb
@@ -2,7 +2,13 @@ require "rails_helper"
 
 RSpec.describe CacheKeys::Custom::V1Sections do
   context "show" do
-    let(:decorated_section) { instance_double(V1::SectionJSONDecorator, object: "object", item: "item", item_children: "item_children", next: "next", previous: "previous", collection: "collection", showcase: "showcase") }
+    let(:decorated_section) { instance_double(V1::SectionJSONDecorator, object: "object",
+                                                                        item: "item",
+                                                                        item_children: "item_children",
+                                                                        next: "next",
+                                                                        previous: "previous",
+                                                                        collection: "collection",
+                                                                        showcase: "showcase") }
 
     it "uses CacheKeys::ActiveRecord" do
       expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate)
@@ -10,7 +16,13 @@ RSpec.describe CacheKeys::Custom::V1Sections do
     end
 
     it "uses the correct data" do
-      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with( record: ["object", "item", "item_children", "next", "previous", "collection", "showcase"] )
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with( record: ["object",
+                                                                                           "item",
+                                                                                           "item_children",
+                                                                                           "next",
+                                                                                           "previous",
+                                                                                           "collection",
+                                                                                           "showcase"] )
       subject.show(decorated_section: decorated_section)
     end
   end

--- a/spec/values/cache_keys/custom/v1_sections_spec.rb
+++ b/spec/values/cache_keys/custom/v1_sections_spec.rb
@@ -2,13 +2,16 @@ require "rails_helper"
 
 RSpec.describe CacheKeys::Custom::V1Sections do
   context "show" do
-    let(:decorated_section) { instance_double(V1::SectionJSONDecorator, object: "object",
-                                                                        item: "item",
-                                                                        item_children: "item_children",
-                                                                        next: "next",
-                                                                        previous: "previous",
-                                                                        collection: "collection",
-                                                                        showcase: "showcase") }
+    let(:decorated_section)
+    {
+      instance_double(V1::SectionJSONDecorator, object: "object",
+                                                item: "item",
+                                                item_children: "item_children",
+                                                next: "next",
+                                                previous: "previous",
+                                                collection: "collection",
+                                                showcase: "showcase")
+    }
 
     it "uses CacheKeys::ActiveRecord" do
       expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate)
@@ -16,13 +19,13 @@ RSpec.describe CacheKeys::Custom::V1Sections do
     end
 
     it "uses the correct data" do
-      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with( record: ["object",
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with(record: ["object",
                                                                                            "item",
                                                                                            "item_children",
                                                                                            "next",
                                                                                            "previous",
                                                                                            "collection",
-                                                                                           "showcase"] )
+                                                                                           "showcase"])
       subject.show(decorated_section: decorated_section)
     end
   end

--- a/spec/values/cache_keys/custom/v1_sections_spec.rb
+++ b/spec/values/cache_keys/custom/v1_sections_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe CacheKeys::Custom::V1Sections do
 
 
   context "show" do
-    let(:decorated_section) { instance_double(V1::SectionJSONDecorator, object: "object", item: "item", item_children: "item_children", next: "next", previous: "previous", collection: "collection", showcase: "showcase")}
+    let(:decorated_section) { instance_double(V1::SectionJSONDecorator, object: "object", item: "item", item_children: "item_children", next: "next", previous: "previous", collection: "collection", showcase: "showcase") }
 
     it "uses CacheKeys::ActiveRecord" do
       expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate)
@@ -12,7 +12,7 @@ RSpec.describe CacheKeys::Custom::V1Sections do
     end
 
     it "uses the correct data" do
-      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with({record: ["object", "item", "item_children", "next", "previous", "collection", "showcase"]})
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with({ record: ["object", "item", "item_children", "next", "previous", "collection", "showcase"] })
       subject.show(decorated_section: decorated_section)
     end
   end

--- a/spec/values/cache_keys/custom/v1_sections_spec.rb
+++ b/spec/values/cache_keys/custom/v1_sections_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.describe CacheKeys::Custom::V1Sections do
-
-
   context "show" do
     let(:decorated_section) { instance_double(V1::SectionJSONDecorator, object: "object", item: "item", item_children: "item_children", next: "next", previous: "previous", collection: "collection", showcase: "showcase") }
 

--- a/spec/values/cache_keys/custom/v1_sections_spec.rb
+++ b/spec/values/cache_keys/custom/v1_sections_spec.rb
@@ -2,16 +2,10 @@ require "rails_helper"
 
 RSpec.describe CacheKeys::Custom::V1Sections do
   context "show" do
-    let(:decorated_section)
-    {
-      instance_double(V1::SectionJSONDecorator, object: "object",
-                                                item: "item",
-                                                item_children: "item_children",
-                                                next: "next",
-                                                previous: "previous",
-                                                collection: "collection",
-                                                showcase: "showcase")
-    }
+    let(:decorated_section) do
+      method_stubs = { object: "object", item: "item", item_children: "item_children", next: "next", previous: "previous", collection: "collection", showcase: "showcase" }
+      instance_double(V1::SectionJSONDecorator, method_stubs)
+    end
 
     it "uses CacheKeys::ActiveRecord" do
       expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate)
@@ -19,13 +13,8 @@ RSpec.describe CacheKeys::Custom::V1Sections do
     end
 
     it "uses the correct data" do
-      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with(record: ["object",
-                                                                                           "item",
-                                                                                           "item_children",
-                                                                                           "next",
-                                                                                           "previous",
-                                                                                           "collection",
-                                                                                           "showcase"])
+      params = ["object", "item", "item_children", "next", "previous", "collection", "showcase"]
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with(record: params)
       subject.show(decorated_section: decorated_section)
     end
   end

--- a/spec/values/cache_keys/custom/v1_sections_spec.rb
+++ b/spec/values/cache_keys/custom/v1_sections_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe CacheKeys::Custom::V1Sections do
     end
 
     it "uses the correct data" do
-      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with({ record: ["object", "item", "item_children", "next", "previous", "collection", "showcase"] })
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with( record: ["object", "item", "item_children", "next", "previous", "collection", "showcase"] )
       subject.show(decorated_section: decorated_section)
     end
   end

--- a/spec/values/cache_keys/custom/v1_showcases_spec.rb
+++ b/spec/values/cache_keys/custom/v1_showcases_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe CacheKeys::Custom::V1Showcases do
     end
 
     it "uses the correct data" do
-      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with( record: [collection, "showcases"] )
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with(record: [collection, "showcases"])
       subject.index(collection: collection)
     end
   end
@@ -24,7 +24,7 @@ RSpec.describe CacheKeys::Custom::V1Showcases do
     end
 
     it "uses the correct data" do
-      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with( record: [showcase, "collection", "sections", "items"] )
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with(record: [showcase, "collection", "sections", "items"])
       subject.show(showcase: showcase)
     end
   end

--- a/spec/values/cache_keys/custom/v1_showcases_spec.rb
+++ b/spec/values/cache_keys/custom/v1_showcases_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe CacheKeys::Custom::V1Showcases do
     end
 
     it "uses the correct data" do
-      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with({record: [collection, "showcases"]})
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with({ record: [collection, "showcases"] })
       subject.index(collection: collection)
     end
   end
@@ -24,7 +24,7 @@ RSpec.describe CacheKeys::Custom::V1Showcases do
     end
 
     it "uses the correct data" do
-      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with({record: [showcase, "collection", "sections", "items"]})
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with({ record: [showcase, "collection", "sections", "items"] })
       subject.show(showcase: showcase)
     end
   end

--- a/spec/values/cache_keys/custom/v1_showcases_spec.rb
+++ b/spec/values/cache_keys/custom/v1_showcases_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe CacheKeys::Custom::V1Showcases do
     end
 
     it "uses the correct data" do
-      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with({ record: [collection, "showcases"] })
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with( record: [collection, "showcases"] )
       subject.index(collection: collection)
     end
   end
@@ -24,7 +24,7 @@ RSpec.describe CacheKeys::Custom::V1Showcases do
     end
 
     it "uses the correct data" do
-      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with({ record: [showcase, "collection", "sections", "items"] })
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with( record: [showcase, "collection", "sections", "items"] )
       subject.show(showcase: showcase)
     end
   end

--- a/spec/values/cache_keys/custom/v1_showcases_spec.rb
+++ b/spec/values/cache_keys/custom/v1_showcases_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe CacheKeys::Custom::V1Showcases do
+  context "index" do
+    let(:collection) { instance_double(Collection, showcases: "showcases")}
+
+    it "uses CacheKeys::ActiveRecord" do
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate)
+      subject.index(collection: collection)
+    end
+
+    it "uses the correct data" do
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with({record: [collection, "showcases"]})
+      subject.index(collection: collection)
+    end
+  end
+
+  context "show" do
+    let(:showcase) { instance_double(Showcase, collection: "collection", sections: "sections", items: "items")}
+
+    it "uses CacheKeys::ActiveRecord" do
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate)
+      subject.show(showcase: showcase)
+    end
+
+    it "uses the correct data" do
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with({record: [showcase, "collection", "sections", "items"]})
+      subject.show(showcase: showcase)
+    end
+  end
+end

--- a/spec/values/cache_keys/custom/v1_showcases_spec.rb
+++ b/spec/values/cache_keys/custom/v1_showcases_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe CacheKeys::Custom::V1Showcases do
   context "index" do
-    let(:collection) { instance_double(Collection, showcases: "showcases")}
+    let(:collection) { instance_double(Collection, showcases: "showcases") }
 
     it "uses CacheKeys::ActiveRecord" do
       expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate)
@@ -16,7 +16,7 @@ RSpec.describe CacheKeys::Custom::V1Showcases do
   end
 
   context "show" do
-    let(:showcase) { instance_double(Showcase, collection: "collection", sections: "sections", items: "items")}
+    let(:showcase) { instance_double(Showcase, collection: "collection", sections: "sections", items: "items") }
 
     it "uses CacheKeys::ActiveRecord" do
       expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate)

--- a/spec/values/cache_keys/decorated_active_record_spec.rb
+++ b/spec/values/cache_keys/decorated_active_record_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe CacheKeys::DecoratedActiveRecord do
-  let(:decoratedObject)  { instance_double(Draper::Decorator, object: 1) }
+  let(:decoratedObject) { instance_double(Draper::Decorator, object: 1) }
 
   it "uses ActiveSupport to generate the key" do
     expect(ActiveSupport::Cache).to receive(:expand_cache_key)

--- a/spec/values/cache_keys/decorated_active_record_spec.rb
+++ b/spec/values/cache_keys/decorated_active_record_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe CacheKeys::DecoratedActiveRecord do
+  let(:decoratedObject)  { instance_double(Draper::Decorator, object: 1) }
+
+  it "uses ActiveSupport to generate the key" do
+    expect(ActiveSupport::Cache).to receive(:expand_cache_key)
+    subject.generate(record: decoratedObject)
+  end
+
+  it "uses the decorated object, not the decorator, to generate the key" do
+    expect(ActiveSupport::Cache).to receive(:expand_cache_key).with(decoratedObject.object)
+    subject.generate(record: decoratedObject)
+  end
+end

--- a/spec/values/cache_keys/generator_spec.rb
+++ b/spec/values/cache_keys/generator_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe CacheKeys::Generator do
+  let(:subject) { CacheKeys::Generator.new(key_generator: Class,
+                                           action: "specificmethod",
+                                           arg1: 1) }
+
+  it "calls the chosen generator method" do
+    expect_any_instance_of(Class).to receive(:specificmethod)
+    subject.generate
+  end
+
+  it "passes any additional arguments to the chosen generator method" do
+    expect_any_instance_of(Class).to receive(:specificmethod).with({arg1: 1})
+    subject.generate
+  end
+
+  it "is the generator's return value" do
+    allow_any_instance_of(Class).to receive(:specificmethod).and_return("one")
+    expect(subject.generate).to eq("one")
+  end
+end

--- a/spec/values/cache_keys/generator_spec.rb
+++ b/spec/values/cache_keys/generator_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe CacheKeys::Generator do
   end
 
   it "passes any additional arguments to the chosen generator method" do
-    expect_any_instance_of(Class).to receive(:specificmethod).with({arg1: 1})
+    expect_any_instance_of(Class).to receive(:specificmethod).with(arg1: 1)
     subject.generate
   end
 

--- a/spec/values/cache_keys/generator_spec.rb
+++ b/spec/values/cache_keys/generator_spec.rb
@@ -1,9 +1,7 @@
 require "rails_helper"
 
 RSpec.describe CacheKeys::Generator do
-  let(:subject) { CacheKeys::Generator.new(key_generator: Class,
-                                           action: "specificmethod",
-                                           arg1: 1) }
+  let(:subject) { CacheKeys::Generator.new(key_generator: Class, action: "specificmethod", arg1: 1) }
 
   it "calls the chosen generator method" do
     expect_any_instance_of(Class).to receive(:specificmethod)


### PR DESCRIPTION
Cache keys used for etag generation are now being handled by CacheKeys::Generator classes. For now I only have the v1 controllers implemented so that we can review how this is being handled. If we like this, then I can do the rest of the controllers.