### PR TITLE
Quick fix for Showcase JSON Titles

### DIFF
--- a/app/views/v1/showcases/_showcase.json.jbuilder
+++ b/app/views/v1/showcases/_showcase.json.jbuilder
@@ -5,8 +5,8 @@ json.set! 'isPartOf/collection', showcase_object.collection_url
 json.id showcase_object.unique_id
 json.slug showcase_object.slug
 json.title showcase_object.title
-json.title showcase_object.title_line_1
-json.title showcase_object.title_line_2
+json.title_line_1 showcase_object.title_line_1
+json.title_line_2 showcase_object.title_line_2
 json.description showcase_object.description
 json.image showcase_object.image
 json.last_updated showcase_object.updated_at


### PR DESCRIPTION
Fix a typo in _showcase.json.builder that overwrote title with title_line_2.