### PR TITLE
Exhibits updated/created dates

### DIFF
--- a/app/controllers/exhibits_controller.rb
+++ b/app/controllers/exhibits_controller.rb
@@ -6,7 +6,7 @@ class ExhibitsController < ApplicationController
   def edit
     @exhibit = ExhibitQuery.new.find(params[:id])
     check_user_edits!(@exhibit.collection)
-    #fresh_when([@exhibit, @exhibit.collection])
+    fresh_when([@exhibit, @exhibit.collection])
   end
 
   def update

--- a/db/migrate/20150505125702_add_created_updated_dates_to_exhibits.rb
+++ b/db/migrate/20150505125702_add_created_updated_dates_to_exhibits.rb
@@ -1,0 +1,6 @@
+class AddCreatedUpdatedDatesToExhibits < ActiveRecord::Migration
+  def change
+    add_column(:exhibits, :created_at, :datetime)
+    add_column(:exhibits, :updated_at, :datetime)
+  end
+end

--- a/db/migrate/20150505125702_add_created_updated_dates_to_exhibits.rb
+++ b/db/migrate/20150505125702_add_created_updated_dates_to_exhibits.rb
@@ -2,5 +2,10 @@ class AddCreatedUpdatedDatesToExhibits < ActiveRecord::Migration
   def change
     add_column(:exhibits, :created_at, :datetime)
     add_column(:exhibits, :updated_at, :datetime)
+    Exhibit.find_each do |e|
+      e.created_at = e.collection.created_at
+      e.updated_at = e.collection.updated_at
+      e.save!
+    end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150504153937) do
+ActiveRecord::Schema.define(version: 20150505125702) do
 
   create_table "collection_users", force: :cascade do |t|
     t.integer  "user_id",       limit: 4, null: false
@@ -46,6 +46,8 @@ ActiveRecord::Schema.define(version: 20150504153937) do
     t.integer  "image_file_size",    limit: 4
     t.datetime "image_updated_at"
     t.text     "short_description",  limit: 65535
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
   create_table "honeypot_images", force: :cascade do |t|

--- a/spec/controllers/exhibits_controller_spec.rb
+++ b/spec/controllers/exhibits_controller_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe ExhibitsController, type: :controller do
       expect(assigns(:exhibit)).to eq(exhibit)
     end
 
-    it_behaves_like "a private content-based etag cacher"
+    it_behaves_like "a private basic custom etag cacher"
   end
 
   describe 'update' do

--- a/spec/models/exhibit_spec.rb
+++ b/spec/models/exhibit_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Exhibit do
-  [:title, :description, :showcases, :collection_id].each do |field|
+  [:title, :description, :showcases, :collection_id, :updated_at, :created_at].each do |field|
     it "has the field #{field}" do
       expect(subject).to respond_to(field)
       expect(subject).to respond_to("#{field}=")


### PR DESCRIPTION
This will add updated_at and created_at date fields so that caching will work properly. Please note that it does perform a data update within the migration.