### PR TITLE
Add about text

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,9 @@ gem 'hesburgh_api', git: 'https://github.com/ndlib/hesburgh_api.git'
 
 gem 'simple_form', '~> 3.1.0rc1'
 
+gem 'curly-templates'
 gem 'draper'
+
 # used to normaize the characters in a title sort
 gem 'sort_alphabetical'
 
@@ -43,6 +45,7 @@ gem 'faraday_middleware'
 
 # For Errbit
 gem 'airbrake'
+
 
 # Javascript assets
 # Use Uglifier as compressor for JavaScript assets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,6 +119,8 @@ GEM
       simplecov (>= 0.7)
       term-ansicolor
       thor
+    curly-templates (2.4.1)
+      actionpack (>= 3.1, < 5.0)
     dalli (2.7.4)
     debug_inspector (0.0.2)
     devise (3.4.1)
@@ -391,6 +393,7 @@ DEPENDENCIES
   capybara
   coffee-rails (~> 4.0.0)
   coveralls
+  curly-templates
   dalli
   devise
   devise_cas_authenticatable

--- a/app/controllers/exhibits_controller.rb
+++ b/app/controllers/exhibits_controller.rb
@@ -6,7 +6,7 @@ class ExhibitsController < ApplicationController
   def edit
     @exhibit = ExhibitQuery.new.find(params[:id])
     check_user_edits!(@exhibit.collection)
-    #fresh_when([@exhibit, @exhibit.collection])
+    fresh_when([@exhibit, @exhibit.collection])
   end
 
   def update

--- a/app/controllers/exhibits_controller.rb
+++ b/app/controllers/exhibits_controller.rb
@@ -6,7 +6,7 @@ class ExhibitsController < ApplicationController
   def edit
     @exhibit = ExhibitQuery.new.find(params[:id])
     check_user_edits!(@exhibit.collection)
-    fresh_when([@exhibit, @exhibit.collection])
+    #fresh_when([@exhibit, @exhibit.collection])
   end
 
   def update

--- a/app/controllers/exhibits_controller.rb
+++ b/app/controllers/exhibits_controller.rb
@@ -24,6 +24,6 @@ class ExhibitsController < ApplicationController
   private
 
   def save_params
-    params.require(:exhibit).permit([:description, :image, :short_description])
+    params.require(:exhibit).permit([:description, :image, :short_description, :about])
   end
 end

--- a/app/decorators/v1/collection_json_decorator.rb
+++ b/app/decorators/v1/collection_json_decorator.rb
@@ -1,7 +1,7 @@
 
 module V1
   class CollectionJSONDecorator < Draper::Decorator
-    delegate :id, :title, :unique_id, :updated_at
+    delegate :id, :about, :unique_id, :updated_at
 
     def self.display(collection, json)
       new(collection).display(json)

--- a/app/decorators/v1/collection_json_decorator.rb
+++ b/app/decorators/v1/collection_json_decorator.rb
@@ -1,7 +1,7 @@
 
 module V1
   class CollectionJSONDecorator < Draper::Decorator
-    delegate :id, :about, :unique_id, :updated_at
+    delegate :id, :unique_id, :updated_at
 
     def self.display(collection, json)
       new(collection).display(json)
@@ -29,6 +29,10 @@ module V1
 
     def short_intro
       object.exhibit.short_description.to_s
+    end
+
+    def about
+      object.exhibit.about.to_s
     end
 
     def slug

--- a/app/presenters/exhibits/side_nav_presenter.rb
+++ b/app/presenters/exhibits/side_nav_presenter.rb
@@ -6,15 +6,15 @@ class Exhibits::SideNavPresenter < Curly::Presenter
   end
 
   def exhibit_introduction_link
-    link_to("Exhibit Introduction", edit_exhibit_form_exhibit_path(@exhibit, form: 'exhibit_introduction'))
+    link_to("Exhibit Introduction", edit_exhibit_form_exhibit_path(@exhibit, form: "exhibit_introduction"))
   end
 
   def about_text_link
-    link_to('About Text', edit_exhibit_form_exhibit_path(@exhibit, form: 'about_text'))
+    link_to("About Text", edit_exhibit_form_exhibit_path(@exhibit, form: "about_text"))
   end
 
   def copyright_link
-    link_to('Copyright Text', edit_exhibit_form_exhibit_path(@exhibit, form: 'copyright_text'))
+    link_to("Copyright Text", edit_exhibit_form_exhibit_path(@exhibit, form: "copyright_text"))
   end
 
   def active_tab_class(tab:)

--- a/app/presenters/exhibits/side_nav_presenter.rb
+++ b/app/presenters/exhibits/side_nav_presenter.rb
@@ -20,6 +20,6 @@ class Exhibits::SideNavPresenter < Curly::Presenter
   def active_tab_class(tab:)
     return "active" if tab == @form
     return "active" if tab == "edit" && @form.nil?
-    return ""
+    ""
   end
 end

--- a/app/presenters/exhibits/side_nav_presenter.rb
+++ b/app/presenters/exhibits/side_nav_presenter.rb
@@ -20,5 +20,6 @@ class Exhibits::SideNavPresenter < Curly::Presenter
   def active_tab_class(tab:)
     return "active" if tab == @form
     return "active" if tab == "edit" && @form.nil?
+    return ""
   end
 end

--- a/app/presenters/exhibits/side_nav_presenter.rb
+++ b/app/presenters/exhibits/side_nav_presenter.rb
@@ -1,0 +1,24 @@
+class Exhibits::SideNavPresenter < Curly::Presenter
+  presents :exhibit, :form
+
+  def site_intro_link
+    link_to("Site Introduction", edit_exhibit_path(@exhibit))
+  end
+
+  def exhibit_introduction_link
+    link_to("Exhibit Introduction", edit_exhibit_form_exhibit_path(@exhibit, form: 'exhibit_introduction'))
+  end
+
+  def about_text_link
+    link_to('About Text', edit_exhibit_form_exhibit_path(@exhibit, form: 'about_text'))
+  end
+
+  def copyright_link
+    link_to('Copyright Text', edit_exhibit_form_exhibit_path(@exhibit, form: 'copyright_text'))
+  end
+
+  def active_tab_class(tab:)
+    return "active" if tab == @form
+    return "active" if tab == "edit" && @form.nil?
+  end
+end

--- a/app/views/exhibits/_about_text_form.html.erb
+++ b/app/views/exhibits/_about_text_form.html.erb
@@ -1,0 +1,11 @@
+
+<%= f.input :about, input_html: { class: 'honeycomb_redactor'  } %>
+
+<h3>Copy and Paste Example</h3>
+<hr>
+
+<h3>Name of Curator</h3>
+<p><em>Title or Position</em><br/>Hesburgh Libraries</p>
+<p>p: 124-123-1234<br/>e: name@nd.edu</p>
+
+<hr>

--- a/app/views/exhibits/_copyright_text_form.html.erb
+++ b/app/views/exhibits/_copyright_text_form.html.erb
@@ -1,0 +1,1 @@
+COPYRIGHTS are cool

--- a/app/views/exhibits/_exhibit_introduction_form.html.erb
+++ b/app/views/exhibits/_exhibit_introduction_form.html.erb
@@ -1,0 +1,1 @@
+<%= f.input :description, input_html: { class: 'honeycomb_redactor'  } %>

--- a/app/views/exhibits/_form.html.erb
+++ b/app/views/exhibits/_form.html.erb
@@ -1,10 +1,5 @@
-<%= display_errors(f.object) %>
 
 <%= f.input :short_description, input_html: { class: 'honeycomb_redactor'  } %>
-
-<%= f.input :description, input_html: { class: 'honeycomb_redactor'  } %>
-
-<%= f.input :about, input_html: { class: 'honeycomb_redactor'  } %>
 
 <%= HoneypotThumbnail.display(f.object.honeypot_image) %>
 <%= f.input :image, as: :file %>

--- a/app/views/exhibits/_side_nav.html.curly
+++ b/app/views/exhibits/_side_nav.html.curly
@@ -1,0 +1,7 @@
+<h4>Site Content</h4>
+<ul class="nav nav-pills nav-stacked">
+  <li class="{{active_tab_class tab=edit}}">{{site_intro_link}}</li>
+  <li class="{{active_tab_class tab=exhibit_introduction}}">{{exhibit_introduction_link}}</li>
+  <li class="{{active_tab_class tab=about_text}}">{{about_text_link}}</li>
+  <li class="{{active_tab_class tab=copyright_text}}">{{copyright_link}}</li>
+</ul>

--- a/app/views/exhibits/edit.html.erb
+++ b/app/views/exhibits/edit.html.erb
@@ -4,16 +4,24 @@
 <%= back_action_bar(edit_exhibit_path(@exhibit.id), '#' ) %>
 <%= link_to("PREVIEW", @exhibit.collection.beehive_url, class: "btn btn-large btn-hollow", :target => "_blank") %>
 
-<%= simple_form_for @exhibit do |f| %>
-  <div class="panel panel-default">
-    <div class="panel-heading">
-      <h3 class="panel-title"><%= f.object.collection.title %></h3>
-    </div>
-    <div class="panel-body">
-      <%= render partial: 'form', locals: { f: f } %>
-    </div>
-    <div class="panel-footer">
-      <%= f.button :submit, "Save", class: 'btn btn-primary'%>
-    </div>
+<div class="row">
+  <div class="col-md-10">
+    <%= simple_form_for @exhibit do |f| %>
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          <h3 class="panel-title">Site Setup</h3>
+        </div>
+        <div class="panel-body">
+          <%= render partial: 'form', locals: { f: f } %>
+        </div>
+        <div class="panel-footer">
+          <%= f.button :submit, "Save", class: 'btn btn-primary'%>
+        </div>
+      </div>
+    <% end %>
   </div>
-<% end %>
+  <div class="col-md-2">
+
+    <%= render "side_nav", exhibit: @exhibit, form: params[:form] %>
+  </div>
+</div>

--- a/app/views/exhibits/edit.html.erb
+++ b/app/views/exhibits/edit.html.erb
@@ -7,12 +7,14 @@
 <div class="row">
   <div class="col-md-10">
     <%= simple_form_for @exhibit do |f| %>
+      <%= display_errors(f.object) %>
+
       <div class="panel panel-default">
         <div class="panel-heading">
           <h3 class="panel-title">Site Setup</h3>
         </div>
         <div class="panel-body">
-          <%= render partial: 'form', locals: { f: f } %>
+          <%= render partial: (params[:form] ? "#{params[:form]}_form" : 'form'), locals: { f: f } %>
         </div>
         <div class="panel-footer">
           <%= f.button :submit, "Save", class: 'btn btn-primary'%>
@@ -21,7 +23,7 @@
     <% end %>
   </div>
   <div class="col-md-2">
-
     <%= render "side_nav", exhibit: @exhibit, form: params[:form] %>
   </div>
 </div>
+

--- a/app/views/v1/collections/_collection.json.jbuilder
+++ b/app/views/v1/collections/_collection.json.jbuilder
@@ -8,7 +8,8 @@ json.slug collection_object.slug
 json.title collection_object.title
 json.title_line_1 collection_object.title_line_1
 json.title_line_2 collection_object.title_line_2
-json.description collection_object.site_intro
 json.short_description collection_object.short_intro
+json.description collection_object.site_intro
+json.about collection_object.about
 json.image collection_object.image
 json.last_updated collection_object.updated_at

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,7 +14,8 @@ module ItemAdmin
       Rails.root.join('app', 'decorators'),
       Rails.root.join('app', 'policy'),
       Rails.root.join('app', 'services'),
-      Rails.root.join('app', 'forms')
+      Rails.root.join('app', 'forms'),
+      Rails.root.join('app', 'presenters')
     ]
 
     # Settings in config/environments/* take precedence over those specified here.

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,22 +1,22 @@
-require File.expand_path('../boot', __FILE__)
+require File.expand_path("../boot", __FILE__)
 
-require 'rails/all'
+require "rails/all"
 
 # Require the gems listed in Gemfile, including any gems
-# you've limited to :test, :development, or :production.
+# you"ve limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
 module ItemAdmin
   class Application < Rails::Application
     additional_autoload_directories = [
-      Rails.root.join('lib'),
-      Rails.root.join('app', 'queries'),
-      Rails.root.join('app', 'decorators'),
-      Rails.root.join('app', 'policy'),
-      Rails.root.join('app', 'services'),
+      Rails.root.join("lib"),
+      Rails.root.join("app", "queries"),
+      Rails.root.join("app", "decorators"),
+      Rails.root.join("app", "policy"),
+      Rails.root.join("app", "services"),
       Rails.root.join("app", "forms"),
       Rails.root.join("app", "values"),
-      Rails.root.join('app', 'presenters')
+      Rails.root.join("app", "presenters")
     ]
 
     # Settings in config/environments/* take precedence over those specified here.
@@ -25,15 +25,15 @@ module ItemAdmin
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
-    # config.time_zone = 'Central Time (US & Canada)'
+    # config.time_zone = "Central Time (US & Canada)"
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
-    # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
+    # config.i18n.load_path += Dir[Rails.root.join("my", "locales", "*.{rb,yml}").to_s]
     # config.i18n.default_locale = :de
 
     config.react.addons = true
 
-    config.assets.precompile = [proc { |path| !File.extname(path).in?(['.js', '.css', '.map', '.gzip', '']) }, /(?:\/|\\|\A)application\.(css|js)$/]
+    config.assets.precompile = [proc { |path| !File.extname(path).in?([".js", ".css", ".map", ".gzip", ""]) }, /(?:\/|\\|\A)application\.(css|js)$/]
 
     config.active_record.raise_in_transactional_callbacks = true
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,12 @@ Rails.application.routes.draw do
   end
 
   resources :exhibits, only: [:show, :edit, :update] do
+    member do
+      get 'edit/:form', to: 'exhibits#edit', as: :edit_exhibit_form, constraints: { form: /exhibit_introduction|about_text|copyright_text/ }
+      #get :edit_about, to: 'exhibits#edit', form: :edit_about
+      #get :edit_copyright, to: 'exhibits#edit', form: :edit_copyright
+    end
+
     resources :showcases, only: [:index, :new, :create]
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,11 @@
 Rails.application.routes.draw do
-  devise_for :users, controllers: { cas_sessions: 'simple_cas' }
-  root to: 'collections#index'
+  devise_for :users, controllers: { cas_sessions: "simple_cas" }
+  root to: "collections#index"
 
-  get 'help', to: 'help#help'
+  get "help", to: "help#help"
 
-  get '404', to: 'errors#catch_404'
-  get '500', to: 'errors#catch_500'
+  get "404", to: "errors#catch_404"
+  get "500", to: "errors#catch_500"
 
   resource :masquerades, only: [:new, :create] do
     get :cancel
@@ -36,14 +36,12 @@ Rails.application.routes.draw do
       put :publish
       put :unpublish
     end
-    resources :children, controller: 'item_children', only: [:new, :create]
+    resources :children, controller: "item_children", only: [:new, :create]
   end
 
   resources :exhibits, only: [:show, :edit, :update] do
     member do
-      get 'edit/:form', to: 'exhibits#edit', as: :edit_exhibit_form, constraints: { form: /exhibit_introduction|about_text|copyright_text/ }
-      #get :edit_about, to: 'exhibits#edit', form: :edit_about
-      #get :edit_copyright, to: 'exhibits#edit', form: :edit_copyright
+      get "edit/:form", to: "exhibits#edit", as: :edit_exhibit_form, constraints: { form: /exhibit_introduction|about_text|copyright_text/ }
     end
 
     resources :showcases, only: [:index, :new, :create]
@@ -88,7 +86,7 @@ Rails.application.routes.draw do
     end
   end
 
-  scope '/admin_old' do
+  scope "/admin_old" do
     resources :users do
       put :set_admin
       put :revoke_admin
@@ -100,6 +98,6 @@ Rails.application.routes.draw do
     # be passed in as query params and not as part of the
     # get string that is not /discovery_test_id/i,adf.adsfwe.adsfsdf
     # but as /discovery_test_id?id=i,adf.adsfwe.adsfsdf
-    get 'discovery_id_test', to: 'discovery_id_test#show'
+    get "discovery_id_test", to: "discovery_id_test#show"
   end
 end

--- a/spec/decorators/v1/collection_json_decorator_spec.rb
+++ b/spec/decorators/v1/collection_json_decorator_spec.rb
@@ -69,6 +69,20 @@ RSpec.describe V1::CollectionJSONDecorator do
     end
   end
 
+  describe "#about" do
+    let(:exhibit) { double(Exhibit, about: nil) }
+    let(:collection) { double(Collection, exhibit: exhibit) }
+
+    it "converts null to empty string" do
+      expect(subject.about).to eq("")
+    end
+
+    it "gets the value from the exhibit" do
+      expect(exhibit).to receive(:about).and_return("about")
+      expect(subject.about).to eq("about")
+    end
+  end
+
   describe "#site_intro" do
     let(:exhibit) { double(Exhibit, description: nil) }
     let(:collection) { double(Collection, exhibit: exhibit) }

--- a/spec/decorators/v1/collection_json_decorator_spec.rb
+++ b/spec/decorators/v1/collection_json_decorator_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe V1::CollectionJSONDecorator do
   describe "generic fields" do
     [:id,
      :unique_id,
+     :about,
      :updated_at].each do |field|
       it "responds to #{field}" do
         expect(subject).to respond_to(field)

--- a/spec/models/exhibit_spec.rb
+++ b/spec/models/exhibit_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Exhibit do
-  [:title, :description, :showcases, :collection_id, :updated_at, :created_at].each do |field|
+  [:title, :description, :short_description, :showcases, :collection_id, :about, :updated_at, :created_at].each do |field|
     it "has the field #{field}" do
       expect(subject).to respond_to(field)
       expect(subject).to respond_to("#{field}=")

--- a/spec/presenters/exhibits/side_nav_presenter_spec.rb
+++ b/spec/presenters/exhibits/side_nav_presenter_spec.rb
@@ -1,7 +1,6 @@
 require "rails_helper"
 
 RSpec.describe Exhibits::SideNavPresenter do
-
   let(:exhibit) { double(Exhibit, id: 1) }
 
   describe "#site_intro_link" do

--- a/spec/presenters/exhibits/side_nav_presenter_spec.rb
+++ b/spec/presenters/exhibits/side_nav_presenter_spec.rb
@@ -1,0 +1,84 @@
+require "rails_helper"
+
+RSpec.describe Exhibits::SideNavPresenter do
+
+  let(:exhibit) { double(Exhibit, id: 1) }
+
+  describe "#site_intro_link" do
+    let(:context) { double('context', edit_exhibit_path: 'path', link_to: 'link') }
+    let(:presenter) { described_class.new(context, exhibit: exhibit, form: nil) }
+
+    it "returns a link to the site_introduction_form" do
+      expect(presenter.site_intro_link).to eq("link")
+    end
+
+    it "calls the correct path method" do
+      expect(context).to receive(:edit_exhibit_path).with(exhibit)
+      presenter.site_intro_link
+    end
+  end
+
+  describe "#exhibit_introduction_link" do
+    let(:context) { double('context', edit_exhibit_form_exhibit_path: 'path', link_to: 'link') }
+    let(:presenter) { described_class.new(context, exhibit: exhibit, form: nil) }
+
+    it "returns a link to the exhibit_introduction_form" do
+      expect(presenter.exhibit_introduction_link).to eq("link")
+    end
+
+    it "calls the correct path method" do
+      expect(context).to receive(:edit_exhibit_form_exhibit_path).with(exhibit, {:form=>"exhibit_introduction"})
+      presenter.exhibit_introduction_link
+    end
+  end
+
+  describe "#about_text_link" do
+    let(:context) { double('context', edit_exhibit_form_exhibit_path: 'path', link_to: 'link') }
+    let(:presenter) { described_class.new(context, exhibit: exhibit, form: nil) }
+
+    it "returns a link to the about_text_form" do
+      expect(presenter.about_text_link).to eq("link")
+    end
+
+    it "calls the correct path method" do
+      expect(context).to receive(:edit_exhibit_form_exhibit_path).with(exhibit, {:form=>"about_text"})
+      presenter.about_text_link
+    end
+  end
+
+  describe "#copyright_link" do
+    let(:context) { double('context', edit_exhibit_form_exhibit_path: 'path', link_to: 'link') }
+    let(:presenter) { described_class.new(context, exhibit: exhibit, form: nil) }
+
+    it "returns a link to the copyright_link" do
+      expect(presenter.copyright_link).to eq("link")
+    end
+
+    it "calls the correct path method" do
+      expect(context).to receive(:edit_exhibit_form_exhibit_path).with(exhibit, {:form=>"copyright_text"})
+      presenter.copyright_link
+    end
+  end
+
+
+  describe "#active_tab_class" do
+    let(:context) { double('context') }
+    let(:presenter) { described_class.new(context, exhibit: exhibit, form: 'form') }
+
+    it "returns active when the tab == the form " do
+      expect(presenter.active_tab_class(tab: 'form')).to eq("active")
+    end
+
+    it "returns empty string when the tab != form " do
+      expect(presenter.active_tab_class(tab: 'not_the_form')).to eq("")
+    end
+
+    it "returns active if the form is nil and the tab == 'edit' " do
+      presenter = described_class.new(context, exhibit: exhibit, form: nil)
+      expect(presenter.active_tab_class(tab: 'edit')).to eq("active")
+    end
+
+  end
+
+
+end

--- a/spec/presenters/exhibits/side_nav_presenter_spec.rb
+++ b/spec/presenters/exhibits/side_nav_presenter_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Exhibits::SideNavPresenter do
   let(:exhibit) { double(Exhibit, id: 1) }
 
   describe "#site_intro_link" do
-    let(:context) { double('context', edit_exhibit_path: 'path', link_to: 'link') }
+    let(:context) { double("context", edit_exhibit_path: "path", link_to: "link") }
     let(:presenter) { described_class.new(context, exhibit: exhibit, form: nil) }
 
     it "returns a link to the site_introduction_form" do
@@ -19,7 +19,7 @@ RSpec.describe Exhibits::SideNavPresenter do
   end
 
   describe "#exhibit_introduction_link" do
-    let(:context) { double('context', edit_exhibit_form_exhibit_path: 'path', link_to: 'link') }
+    let(:context) { double("context", edit_exhibit_form_exhibit_path: "path", link_to: "link") }
     let(:presenter) { described_class.new(context, exhibit: exhibit, form: nil) }
 
     it "returns a link to the exhibit_introduction_form" do
@@ -33,7 +33,7 @@ RSpec.describe Exhibits::SideNavPresenter do
   end
 
   describe "#about_text_link" do
-    let(:context) { double('context', edit_exhibit_form_exhibit_path: 'path', link_to: 'link') }
+    let(:context) { double("context", edit_exhibit_form_exhibit_path: "path", link_to: "link") }
     let(:presenter) { described_class.new(context, exhibit: exhibit, form: nil) }
 
     it "returns a link to the about_text_form" do
@@ -47,7 +47,7 @@ RSpec.describe Exhibits::SideNavPresenter do
   end
 
   describe "#copyright_link" do
-    let(:context) { double('context', edit_exhibit_form_exhibit_path: 'path', link_to: 'link') }
+    let(:context) { double("context", edit_exhibit_form_exhibit_path: "path", link_to: "link") }
     let(:presenter) { described_class.new(context, exhibit: exhibit, form: nil) }
 
     it "returns a link to the copyright_link" do
@@ -61,20 +61,20 @@ RSpec.describe Exhibits::SideNavPresenter do
   end
 
   describe "#active_tab_class" do
-    let(:context) { double('context') }
-    let(:presenter) { described_class.new(context, exhibit: exhibit, form: 'form') }
+    let(:context) { double("context") }
+    let(:presenter) { described_class.new(context, exhibit: exhibit, form: "form") }
 
     it "returns active when the tab == the form " do
-      expect(presenter.active_tab_class(tab: 'form')).to eq("active")
+      expect(presenter.active_tab_class(tab: "form")).to eq("active")
     end
 
     it "returns empty string when the tab != form " do
-      expect(presenter.active_tab_class(tab: 'not_the_form')).to eq("")
+      expect(presenter.active_tab_class(tab: "not_the_form")).to eq("")
     end
 
-    it "returns active if the form is nil and the tab == 'edit' " do
+    it "returns active if the form is nil and the tab == edit " do
       presenter = described_class.new(context, exhibit: exhibit, form: nil)
-      expect(presenter.active_tab_class(tab: 'edit')).to eq("active")
+      expect(presenter.active_tab_class(tab: "edit")).to eq("active")
     end
   end
 end

--- a/spec/presenters/exhibits/side_nav_presenter_spec.rb
+++ b/spec/presenters/exhibits/side_nav_presenter_spec.rb
@@ -60,7 +60,6 @@ RSpec.describe Exhibits::SideNavPresenter do
     end
   end
 
-
   describe "#active_tab_class" do
     let(:context) { double('context') }
     let(:presenter) { described_class.new(context, exhibit: exhibit, form: 'form') }
@@ -77,8 +76,5 @@ RSpec.describe Exhibits::SideNavPresenter do
       presenter = described_class.new(context, exhibit: exhibit, form: nil)
       expect(presenter.active_tab_class(tab: 'edit')).to eq("active")
     end
-
   end
-
-
 end

--- a/spec/presenters/exhibits/side_nav_presenter_spec.rb
+++ b/spec/presenters/exhibits/side_nav_presenter_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Exhibits::SideNavPresenter do
     end
 
     it "calls the correct path method" do
-      expect(context).to receive(:edit_exhibit_form_exhibit_path).with(exhibit, {:form=>"exhibit_introduction"})
+      expect(context).to receive(:edit_exhibit_form_exhibit_path).with(exhibit, form: "exhibit_introduction")
       presenter.exhibit_introduction_link
     end
   end
@@ -41,7 +41,7 @@ RSpec.describe Exhibits::SideNavPresenter do
     end
 
     it "calls the correct path method" do
-      expect(context).to receive(:edit_exhibit_form_exhibit_path).with(exhibit, {:form=>"about_text"})
+      expect(context).to receive(:edit_exhibit_form_exhibit_path).with(exhibit, form: "about_text")
       presenter.about_text_link
     end
   end
@@ -55,7 +55,7 @@ RSpec.describe Exhibits::SideNavPresenter do
     end
 
     it "calls the correct path method" do
-      expect(context).to receive(:edit_exhibit_form_exhibit_path).with(exhibit, {:form=>"copyright_text"})
+      expect(context).to receive(:edit_exhibit_form_exhibit_path).with(exhibit, form: "copyright_text")
       presenter.copyright_link
     end
   end


### PR DESCRIPTION
We needed a way for the admin to edit the button on the info text. 

To do this I added the a field to the exhibit class, edited the site editor section of the site to have a text area, and I added the about text to the api.  In addition I refactored the way the site editor works so that we can have the different texts on different pages.   

Also I added curly into the project as an example.  You can see how curly was used in side_nav_presenter.rb, _side_nav.html.erb, and side_nav_presenter_spec.rb.   I believe we can easily remove this test if we decide we really don't like it.  



