### PR TITLE
DEC-279: Rewrite remaining controllers to use cache key generators

### DIFF
--- a/app/controllers/admin/administrators_controller.rb
+++ b/app/controllers/admin/administrators_controller.rb
@@ -7,7 +7,7 @@ module Admin
 
       cache_key = CacheKeys::Generator.new(key_generator: CacheKeys::Custom::Administrators,
                                            action: "index",
-                                           decorated_administrators: @administrators)
+                                           users: administrators)
       fresh_when(etag: cache_key.generate)
     end
 
@@ -41,7 +41,7 @@ module Admin
       search_results = PersonAPISearch.call(params[:q])
       cache_key = CacheKeys::Generator.new(key_generator: CacheKeys::Custom::Administrators,
                                            action: "user_search",
-                                           users: search_results)
+                                           formatted_users: search_results)
       if stale?(etag: cache_key.generate)
         respond_to do |format|
           format.any { render json: search_results.to_json, content_type: "application/json" }

--- a/app/controllers/admin/administrators_controller.rb
+++ b/app/controllers/admin/administrators_controller.rb
@@ -39,7 +39,10 @@ module Admin
       check_admin_permission!
 
       search_results = PersonAPISearch.call(params[:q])
-      if stale?(search_results)
+      cache_key = CacheKeys::Generator.new(key_generator: CacheKeys::Custom::Administrators,
+                                           action: "user_search",
+                                           users: search_results)
+      if stale?(etag: cache_key.generate)
         respond_to do |format|
           format.any { render json: search_results.to_json, content_type: "application/json" }
         end

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -1,7 +1,10 @@
 class CollectionsController < ApplicationController
   def index
     @collections = CollectionQuery.new.for_editor(current_user)
-    fresh_when(@collections)
+    cache_key = CacheKeys::Generator.new(key_generator: CacheKeys::Custom::Collections,
+                                         action: "index",
+                                         collections: @collections)
+    fresh_when(etag: cache_key.generate)
   end
 
   def show
@@ -30,7 +33,11 @@ class CollectionsController < ApplicationController
   def edit
     @collection = CollectionQuery.new.find(params[:id])
     check_user_edits!(@collection)
-    fresh_when(@collection)
+
+    cache_key = CacheKeys::Generator.new(key_generator: CacheKeys::Custom::Collections,
+                                         action: "edit",
+                                         collection: @collection)
+    fresh_when(etag: cache_key.generate)
   end
 
   def update

--- a/app/controllers/editors_controller.rb
+++ b/app/controllers/editors_controller.rb
@@ -50,9 +50,9 @@ class EditorsController < ApplicationController
     search_results = PersonAPISearch.call(params[:q])
 
     cache_key = CacheKeys::Generator.new(key_generator: CacheKeys::Custom::Editors,
-                                     action: "user_search",
-                                     collection: @collection,
-                                     formatted_users: search_results)
+                                         action: "user_search",
+                                         collection: @collection,
+                                         formatted_users: search_results)
     if stale?(etag: cache_key.generate)
       respond_to do |format|
         format.any { render json: search_results.to_json, content_type: "application/json" }

--- a/app/controllers/editors_controller.rb
+++ b/app/controllers/editors_controller.rb
@@ -52,7 +52,7 @@ class EditorsController < ApplicationController
     cache_key = CacheKeys::Generator.new(key_generator: CacheKeys::Custom::Editors,
                                      action: "user_search",
                                      collection: @collection,
-                                     users: search_results)
+                                     formatted_users: search_results)
     if stale?(etag: cache_key.generate)
       respond_to do |format|
         format.any { render json: search_results.to_json, content_type: "application/json" }

--- a/app/controllers/exhibits_controller.rb
+++ b/app/controllers/exhibits_controller.rb
@@ -6,7 +6,10 @@ class ExhibitsController < ApplicationController
   def edit
     @exhibit = ExhibitQuery.new.find(params[:id])
     check_user_edits!(@exhibit.collection)
-    fresh_when([@exhibit, @exhibit.collection])
+    cache_key = CacheKeys::Generator.new(key_generator: CacheKeys::Custom::Exhibits,
+                                         action: "edit",
+                                         exhibit: @exhibit)
+    fresh_when(etag: cache_key.generate)
   end
 
   def update

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -5,7 +5,10 @@ class ItemsController < ApplicationController
     items = ItemQuery.new(collection.items).only_top_level
     @items = ItemsDecorator.new(items)
 
-    fresh_when([collection, @items])
+    cache_key = CacheKeys::Generator.new(key_generator: CacheKeys::Custom::Items,
+                                         action: "index",
+                                         collection: collection)
+    fresh_when(etag: cache_key.generate)
   end
 
   def new
@@ -31,7 +34,11 @@ class ItemsController < ApplicationController
     check_user_edits!(item.collection)
 
     @item = ItemDecorator.new(item)
-    fresh_when([@item.collection, @item.recent_children, @item])
+
+    cache_key = CacheKeys::Generator.new(key_generator: CacheKeys::Custom::Items,
+                                         action: "edit",
+                                         decorated_item: @item)
+    fresh_when(etag: cache_key.generate)
   end
 
   def update

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -3,7 +3,6 @@ class SectionsController < ApplicationController
     ### TODO: API ONLY remove in favor of the actual api.
     @section_list = ShowcaseList.new(showcase)
     check_user_edits!(@section_list.collection)
-    fresh_when([@section_list, @section_list.collection])
   end
 
   def new
@@ -29,7 +28,10 @@ class SectionsController < ApplicationController
   def edit
     @section_form = SectionForm.build_from_params(self)
     check_user_edits!(@section_form.collection)
-    fresh_when([@section_form, @section_form.collection])
+    cache_key = CacheKeys::Generator.new(key_generator: CacheKeys::Custom::Sections,
+                                         action: "edit",
+                                         section: @section_form.section)
+    fresh_when(etag: cache_key.generate)
   end
 
   def update

--- a/app/controllers/showcases_controller.rb
+++ b/app/controllers/showcases_controller.rb
@@ -2,7 +2,10 @@ class ShowcasesController < ApplicationController
   def index
     check_user_edits!(exhibit.collection)
     @showcases = ShowcaseQuery.new(exhibit.showcases).admin_list
-    fresh_when([@showcases, exhibit.collection])
+    cache_key = CacheKeys::Generator.new(key_generator: CacheKeys::Custom::Showcases,
+                                         action: "index",
+                                         exhibit: exhibit)
+    fresh_when(etag: cache_key.generate)
   end
 
   def new
@@ -39,7 +42,10 @@ class ShowcasesController < ApplicationController
   def edit
     @showcase = ShowcaseQuery.new.find(params[:id])
     check_user_edits!(@showcase.collection)
-    fresh_when([@showcase, @showcase.collection])
+    cache_key = CacheKeys::Generator.new(key_generator: CacheKeys::Custom::Showcases,
+                                         action: "default",
+                                         showcase: @showcase)
+    fresh_when(etag: cache_key.generate)
   end
 
   def update
@@ -57,7 +63,10 @@ class ShowcasesController < ApplicationController
   def title
     @showcase = ShowcaseQuery.new.find(params[:id])
     check_user_edits!(@showcase.collection)
-    fresh_when([@showcase, @showcase.collection])
+    cache_key = CacheKeys::Generator.new(key_generator: CacheKeys::Custom::Showcases,
+                                         action: "default",
+                                         showcase: @showcase)
+    fresh_when(etag: cache_key.generate)
   end
 
   def destroy

--- a/app/controllers/showcases_controller.rb
+++ b/app/controllers/showcases_controller.rb
@@ -43,7 +43,7 @@ class ShowcasesController < ApplicationController
     @showcase = ShowcaseQuery.new.find(params[:id])
     check_user_edits!(@showcase.collection)
     cache_key = CacheKeys::Generator.new(key_generator: CacheKeys::Custom::Showcases,
-                                         action: "default",
+                                         action: "edit",
                                          showcase: @showcase)
     fresh_when(etag: cache_key.generate)
   end
@@ -64,7 +64,7 @@ class ShowcasesController < ApplicationController
     @showcase = ShowcaseQuery.new.find(params[:id])
     check_user_edits!(@showcase.collection)
     cache_key = CacheKeys::Generator.new(key_generator: CacheKeys::Custom::Showcases,
-                                         action: "default",
+                                         action: "title",
                                          showcase: @showcase)
     fresh_when(etag: cache_key.generate)
   end

--- a/app/values/cache_keys/custom/administrators.rb
+++ b/app/values/cache_keys/custom/administrators.rb
@@ -2,11 +2,12 @@ module CacheKeys
   module Custom
     # Generator for admin/administrators_controller
     class Administrators
-      def index(decorated_administrators:)
-        CacheKeys::DecoratedActiveRecord.new.generate(record: decorated_administrators)
-      end
-      def user_search(users:)
+      def index(users:)
         CacheKeys::ActiveRecord.new.generate(record: users)
+      end
+      # Expects an array of hashes where the hash is of the format: {id:, label:, value:} for formatted_users
+      def user_search(formatted_users:)
+        CacheKeys::ActiveRecord.new.generate(record: formatted_users)
       end
     end
   end

--- a/app/values/cache_keys/custom/administrators.rb
+++ b/app/values/cache_keys/custom/administrators.rb
@@ -5,6 +5,9 @@ module CacheKeys
       def index(decorated_administrators:)
         CacheKeys::DecoratedActiveRecord.new.generate(record: decorated_administrators)
       end
+      def user_search(users:)
+        CacheKeys::ActiveRecord.new.generate(record: users)
+      end
     end
   end
 end

--- a/app/values/cache_keys/custom/collections.rb
+++ b/app/values/cache_keys/custom/collections.rb
@@ -5,6 +5,7 @@ module CacheKeys
       def index(collections:)
         CacheKeys::ActiveRecord.new.generate(record: collections)
       end
+
       def edit(collection:)
         CacheKeys::ActiveRecord.new.generate(record: collection)
       end

--- a/app/values/cache_keys/custom/collections.rb
+++ b/app/values/cache_keys/custom/collections.rb
@@ -1,0 +1,13 @@
+module CacheKeys
+  module Custom
+    # Generator for collections_controller
+    class Collections
+      def index(collections:)
+        CacheKeys::ActiveRecord.new.generate(record: collections)
+      end
+      def edit(collection:)
+        CacheKeys::ActiveRecord.new.generate(record: collection)
+      end
+    end
+  end
+end

--- a/app/values/cache_keys/custom/editors.rb
+++ b/app/values/cache_keys/custom/editors.rb
@@ -5,8 +5,9 @@ module CacheKeys
       def index(collection:)
         CacheKeys::ActiveRecord.new.generate(record: [collection, collection.collection_users])
       end
-      def user_search(collection:, users:)
-        CacheKeys::ActiveRecord.new.generate(record: [collection, users])
+      # Expects an array of hashes where the hash is of the format: {id:, label:, value:} for formatted_users
+      def user_search(collection:, formatted_users:)
+        CacheKeys::ActiveRecord.new.generate(record: [collection, formatted_users])
       end
     end
   end

--- a/app/values/cache_keys/custom/editors.rb
+++ b/app/values/cache_keys/custom/editors.rb
@@ -5,6 +5,7 @@ module CacheKeys
       def index(collection:)
         CacheKeys::ActiveRecord.new.generate(record: [collection, collection.collection_users])
       end
+
       # Expects an array of hashes where the hash is of the format: {id:, label:, value:} for formatted_users
       def user_search(collection:, formatted_users:)
         CacheKeys::ActiveRecord.new.generate(record: [collection, formatted_users])

--- a/app/values/cache_keys/custom/editors.rb
+++ b/app/values/cache_keys/custom/editors.rb
@@ -1,0 +1,13 @@
+module CacheKeys
+  module Custom
+    # Generator for collections_controller
+    class Editors
+      def index(collection:)
+        CacheKeys::ActiveRecord.new.generate(record: [collection, collection.collection_users])
+      end
+      def user_search(collection:, users:)
+        CacheKeys::ActiveRecord.new.generate(record: [collection, users])
+      end
+    end
+  end
+end

--- a/app/values/cache_keys/custom/editors.rb
+++ b/app/values/cache_keys/custom/editors.rb
@@ -1,6 +1,6 @@
 module CacheKeys
   module Custom
-    # Generator for collections_controller
+    # Generator for editors_controller
     class Editors
       def index(collection:)
         CacheKeys::ActiveRecord.new.generate(record: [collection, collection.collection_users])

--- a/app/values/cache_keys/custom/exhibits.rb
+++ b/app/values/cache_keys/custom/exhibits.rb
@@ -1,6 +1,6 @@
 module CacheKeys
   module Custom
-    # Generator for collections_controller
+    # Generator for exhibits_controller
     class Exhibits
       def edit(exhibit:)
         CacheKeys::ActiveRecord.new.generate(record: [exhibit, exhibit.collection])

--- a/app/values/cache_keys/custom/exhibits.rb
+++ b/app/values/cache_keys/custom/exhibits.rb
@@ -1,0 +1,10 @@
+module CacheKeys
+  module Custom
+    # Generator for collections_controller
+    class Exhibits
+      def edit(exhibit:)
+        CacheKeys::ActiveRecord.new.generate(record: [exhibit, exhibit.collection])
+      end
+    end
+  end
+end

--- a/app/values/cache_keys/custom/items.rb
+++ b/app/values/cache_keys/custom/items.rb
@@ -1,0 +1,13 @@
+module CacheKeys
+  module Custom
+    # Generator for items_controller
+    class Items
+      def index(collection:)
+        CacheKeys::ActiveRecord.new.generate(record: [collection, collection.items])
+      end
+      def edit(decorated_item:)
+        CacheKeys::ActiveRecord.new.generate(record: [decorated_item.collection, decorated_item.recent_children, decorated_item.object])
+      end
+    end
+  end
+end

--- a/app/values/cache_keys/custom/items.rb
+++ b/app/values/cache_keys/custom/items.rb
@@ -5,6 +5,7 @@ module CacheKeys
       def index(collection:)
         CacheKeys::ActiveRecord.new.generate(record: [collection, collection.items])
       end
+
       def edit(decorated_item:)
         CacheKeys::ActiveRecord.new.generate(record: [decorated_item.collection, decorated_item.recent_children, decorated_item.object])
       end

--- a/app/values/cache_keys/custom/sections.rb
+++ b/app/values/cache_keys/custom/sections.rb
@@ -1,0 +1,10 @@
+module CacheKeys
+  module Custom
+    # Generator for sections_controller
+    class Sections
+      def edit(section:)
+        CacheKeys::ActiveRecord.new.generate(record: [section, section.collection])
+      end
+    end
+  end
+end

--- a/app/values/cache_keys/custom/showcases.rb
+++ b/app/values/cache_keys/custom/showcases.rb
@@ -5,9 +5,11 @@ module CacheKeys
       def index(exhibit:)
         CacheKeys::ActiveRecord.new.generate(record: [exhibit.showcases, exhibit.collection])
       end
+
       def edit(showcase:)
         CacheKeys::ActiveRecord.new.generate(record: [showcase, showcase.collection])
       end
+
       def title(showcase:)
         CacheKeys::ActiveRecord.new.generate(record: [showcase, showcase.collection])
       end

--- a/app/values/cache_keys/custom/showcases.rb
+++ b/app/values/cache_keys/custom/showcases.rb
@@ -1,0 +1,14 @@
+module CacheKeys
+  module Custom
+    # Generator for showcases_controller
+    class Showcases
+      def index(exhibit:)
+        CacheKeys::ActiveRecord.new.generate(record: [exhibit.showcases, exhibit.collection])
+      end
+      # Default cache key using the showcase and it's associated collection
+      def default(showcase:)
+        CacheKeys::ActiveRecord.new.generate(record: [showcase, showcase.collection])
+      end
+    end
+  end
+end

--- a/app/values/cache_keys/custom/showcases.rb
+++ b/app/values/cache_keys/custom/showcases.rb
@@ -5,8 +5,10 @@ module CacheKeys
       def index(exhibit:)
         CacheKeys::ActiveRecord.new.generate(record: [exhibit.showcases, exhibit.collection])
       end
-      # Default cache key using the showcase and it's associated collection
-      def default(showcase:)
+      def edit(showcase:)
+        CacheKeys::ActiveRecord.new.generate(record: [showcase, showcase.collection])
+      end
+      def title(showcase:)
         CacheKeys::ActiveRecord.new.generate(record: [showcase, showcase.collection])
       end
     end

--- a/spec/controllers/admin/administrators_controller_spec.rb
+++ b/spec/controllers/admin/administrators_controller_spec.rb
@@ -118,5 +118,11 @@ RSpec.describe Admin::AdministratorsController, type: :controller do
       end
       subject { get :user_search, q: query }
     end
+
+
+    it "uses the Administrators#user_search to generate the cache key" do
+      expect_any_instance_of(CacheKeys::Custom::Administrators).to receive(:user_search)
+      get :user_search, q: query
+    end
   end
 end

--- a/spec/controllers/admin/administrators_controller_spec.rb
+++ b/spec/controllers/admin/administrators_controller_spec.rb
@@ -121,6 +121,7 @@ RSpec.describe Admin::AdministratorsController, type: :controller do
 
 
     it "uses the Administrators#user_search to generate the cache key" do
+      allow(PersonAPISearch).to receive(:call).and_return([])
       expect_any_instance_of(CacheKeys::Custom::Administrators).to receive(:user_search)
       get :user_search, q: query
     end

--- a/spec/controllers/admin/administrators_controller_spec.rb
+++ b/spec/controllers/admin/administrators_controller_spec.rb
@@ -119,7 +119,6 @@ RSpec.describe Admin::AdministratorsController, type: :controller do
       subject { get :user_search, q: query }
     end
 
-
     it "uses the Administrators#user_search to generate the cache key" do
       allow(PersonAPISearch).to receive(:call).and_return([])
       expect_any_instance_of(CacheKeys::Custom::Administrators).to receive(:user_search)

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -27,6 +27,11 @@ RSpec.describe CollectionsController, type: :controller do
     end
 
     it_behaves_like "a private basic custom etag cacher"
+
+    it "uses the Collections#index to generate the cache key" do
+      expect_any_instance_of(CacheKeys::Custom::Collections).to receive(:index)
+      subject
+    end
   end
 
   describe 'show' do
@@ -129,6 +134,11 @@ RSpec.describe CollectionsController, type: :controller do
 
     it_behaves_like "a private basic custom etag cacher" do
       subject { get :edit, id: 1 }
+    end
+
+    it "uses the Collections#edit to generate the cache key" do
+      expect_any_instance_of(CacheKeys::Custom::Collections).to receive(:edit)
+      get :edit, id: 1
     end
   end
 

--- a/spec/controllers/editors_controller_spec.rb
+++ b/spec/controllers/editors_controller_spec.rb
@@ -30,6 +30,11 @@ RSpec.describe EditorsController, type: :controller do
     it_behaves_like "a private basic custom etag cacher" do
       subject { get :index, collection_id: 1 }
     end
+
+    it "uses the Editors#index to generate the cache key" do
+      expect_any_instance_of(CacheKeys::Custom::Editors).to receive(:index)
+      get :index, collection_id: 1
+    end
   end
 
   describe '#create' do
@@ -114,6 +119,11 @@ RSpec.describe EditorsController, type: :controller do
         allow(PersonAPISearch).to receive(:call).and_return([])
       end
       subject { get :user_search, collection_id: 1, q: query }
+    end
+
+    it "uses the Editors#user_search to generate the cache key" do
+      expect_any_instance_of(CacheKeys::Custom::Editors).to receive(:user_search)
+      get :user_search, collection_id: 1, q: query
     end
   end
 end

--- a/spec/controllers/editors_controller_spec.rb
+++ b/spec/controllers/editors_controller_spec.rb
@@ -122,6 +122,7 @@ RSpec.describe EditorsController, type: :controller do
     end
 
     it "uses the Editors#user_search to generate the cache key" do
+      allow(PersonAPISearch).to receive(:call).and_return([])
       expect_any_instance_of(CacheKeys::Custom::Editors).to receive(:user_search)
       get :user_search, collection_id: 1, q: query
     end

--- a/spec/controllers/exhibits_controller_spec.rb
+++ b/spec/controllers/exhibits_controller_spec.rb
@@ -45,6 +45,11 @@ RSpec.describe ExhibitsController, type: :controller do
     end
 
     it_behaves_like "a private basic custom etag cacher"
+
+    it "uses the Exhibits#edit to generate the cache key" do
+      expect_any_instance_of(CacheKeys::Custom::Exhibits).to receive(:edit)
+      subject
+    end
   end
 
   describe 'update' do

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -43,6 +43,11 @@ RSpec.describe ItemsController, type: :controller do
     end
 
     it_behaves_like "a private basic custom etag cacher"
+
+    it "uses the Items#index to generate the cache key" do
+      expect_any_instance_of(CacheKeys::Custom::Items).to receive(:index)
+      subject
+    end
   end
 
   describe 'GET #new' do
@@ -174,6 +179,11 @@ RSpec.describe ItemsController, type: :controller do
     end
 
     it_behaves_like "a private basic custom etag cacher"
+
+    it "uses the Items#edit to generate the cache key" do
+      expect_any_instance_of(CacheKeys::Custom::Items).to receive(:edit)
+      subject
+    end
   end
 
   describe 'PUT #update' do

--- a/spec/controllers/sections_controller_spec.rb
+++ b/spec/controllers/sections_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe SectionsController, type: :controller do
   let(:showcase) { double(Showcase, id: 1, title: 'title', sections: relation, exhibit: exhibit) }
   let(:exhibit) { double(Exhibit, id: 1, title: 'title', showcases: relation, collection: collection) }
   let(:collection) { instance_double(Collection, id: 1, title: 'title') }
-  let(:section) { double(Section, id: 1, destroy!: true, showcase: showcase, :order= => true, order: 1) }
+  let(:section) { double(Section, id: 1, destroy!: true, showcase: showcase, :order= => true, order: 1, collection: collection) }
   let(:relation) { Section.all }
   let(:create_params) { { showcase_id: showcase.id, section: { title: 'title', order: 1 } } }
 
@@ -42,7 +42,7 @@ RSpec.describe SectionsController, type: :controller do
       expect(assigns(:section_list)).to be_a(ShowcaseList)
     end
 
-    it_behaves_like "a private basic custom etag cacher"
+    it_behaves_like "a private content-based etag cacher"
   end
 
   describe 'GET #new' do

--- a/spec/controllers/sections_controller_spec.rb
+++ b/spec/controllers/sections_controller_spec.rb
@@ -146,6 +146,11 @@ RSpec.describe SectionsController, type: :controller do
     end
 
     it_behaves_like "a private basic custom etag cacher"
+
+    it "uses the Sections#edit to generate the cache key" do
+      expect_any_instance_of(CacheKeys::Custom::Sections).to receive(:edit)
+      subject
+    end
   end
 
   describe 'PUT #update' do

--- a/spec/controllers/showcases_controller_spec.rb
+++ b/spec/controllers/showcases_controller_spec.rb
@@ -46,6 +46,11 @@ RSpec.describe ShowcasesController, type: :controller do
     end
 
     it_behaves_like "a private basic custom etag cacher"
+
+    it "uses the Showcases#index to generate the cache key" do
+      expect_any_instance_of(CacheKeys::Custom::Showcases).to receive(:index)
+      subject
+    end
   end
 
   describe 'GET #new' do
@@ -219,6 +224,11 @@ RSpec.describe ShowcasesController, type: :controller do
     end
 
     it_behaves_like "a private basic custom etag cacher"
+
+    it "uses the Showcases#default to generate the cache key" do
+      expect_any_instance_of(CacheKeys::Custom::Showcases).to receive(:default)
+      subject
+    end
   end
 
   describe 'GET #title' do
@@ -242,6 +252,11 @@ RSpec.describe ShowcasesController, type: :controller do
     end
 
     it_behaves_like "a private basic custom etag cacher"
+
+    it "uses the Showcases#default to generate the cache key" do
+      expect_any_instance_of(CacheKeys::Custom::Showcases).to receive(:default)
+      subject
+    end
   end
 
   describe 'DELETE #destroy' do

--- a/spec/controllers/showcases_controller_spec.rb
+++ b/spec/controllers/showcases_controller_spec.rb
@@ -226,7 +226,7 @@ RSpec.describe ShowcasesController, type: :controller do
     it_behaves_like "a private basic custom etag cacher"
 
     it "uses the Showcases#default to generate the cache key" do
-      expect_any_instance_of(CacheKeys::Custom::Showcases).to receive(:default)
+      expect_any_instance_of(CacheKeys::Custom::Showcases).to receive(:edit)
       subject
     end
   end
@@ -254,7 +254,7 @@ RSpec.describe ShowcasesController, type: :controller do
     it_behaves_like "a private basic custom etag cacher"
 
     it "uses the Showcases#default to generate the cache key" do
-      expect_any_instance_of(CacheKeys::Custom::Showcases).to receive(:default)
+      expect_any_instance_of(CacheKeys::Custom::Showcases).to receive(:title)
       subject
     end
   end

--- a/spec/values/cache_keys/custom/administrators_spec.rb
+++ b/spec/values/cache_keys/custom/administrators_spec.rb
@@ -2,9 +2,30 @@ require "rails_helper"
 
 RSpec.describe CacheKeys::Custom::Administrators do
   context "index" do
+    let(:decorated_administrators) { instance_double(Draper::Decorator) }
+
     it "uses CacheKeys::DecoratedActiveRecord" do
       expect_any_instance_of(CacheKeys::DecoratedActiveRecord).to receive(:generate)
       subject.index(decorated_administrators: nil)
+    end
+
+    it "uses the correct data" do
+      expect_any_instance_of(CacheKeys::DecoratedActiveRecord).to receive(:generate).with(record: decorated_administrators)
+      subject.index(decorated_administrators: decorated_administrators)
+    end
+  end
+
+  context "user_search" do
+    let(:users) { [{ id: 1, label: "one", value: "one" }, { id: 2, label: "two", value: "two" }] }
+
+    it "uses CacheKeys::ActiveRecord" do
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate)
+      subject.user_search(users: users)
+    end
+
+    it "uses the correct data" do
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with(record: users)
+      subject.user_search(users: users)
     end
   end
 end

--- a/spec/values/cache_keys/custom/administrators_spec.rb
+++ b/spec/values/cache_keys/custom/administrators_spec.rb
@@ -2,30 +2,30 @@ require "rails_helper"
 
 RSpec.describe CacheKeys::Custom::Administrators do
   context "index" do
-    let(:decorated_administrators) { instance_double(Draper::Decorator) }
+    let(:administrators) { instance_double(User) }
 
     it "uses CacheKeys::DecoratedActiveRecord" do
-      expect_any_instance_of(CacheKeys::DecoratedActiveRecord).to receive(:generate)
-      subject.index(decorated_administrators: nil)
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate)
+      subject.index(users: administrators)
     end
 
     it "uses the correct data" do
-      expect_any_instance_of(CacheKeys::DecoratedActiveRecord).to receive(:generate).with(record: decorated_administrators)
-      subject.index(decorated_administrators: decorated_administrators)
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with(record: administrators)
+      subject.index(users: administrators)
     end
   end
 
   context "user_search" do
-    let(:users) { [{ id: 1, label: "one", value: "one" }, { id: 2, label: "two", value: "two" }] }
+    let(:formatted_users) { [{ id: 1, label: "one", value: "one" }, { id: 2, label: "two", value: "two" }] }
 
     it "uses CacheKeys::ActiveRecord" do
       expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate)
-      subject.user_search(users: users)
+      subject.user_search(formatted_users: formatted_users)
     end
 
     it "uses the correct data" do
-      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with(record: users)
-      subject.user_search(users: users)
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with(record: formatted_users)
+      subject.user_search(formatted_users: formatted_users)
     end
   end
 end

--- a/spec/values/cache_keys/custom/collections_spec.rb
+++ b/spec/values/cache_keys/custom/collections_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe CacheKeys::Custom::Collections do
+  context "index" do
+    let(:collections) { instance_double(Collection) }
+
+    it "uses CacheKeys::DecoratedActiveRecord" do
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate)
+      subject.index(collections: collections)
+    end
+
+    it "uses the correct data" do
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with(record: collections)
+      subject.index(collections: collections)
+    end
+  end
+
+  context "edit" do
+    let(:collection) { instance_double(Collection) }
+
+    it "uses CacheKeys::ActiveRecord" do
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate)
+      subject.edit(collection: collection)
+    end
+
+    it "uses the correct data" do
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with(record: collection)
+      subject.edit(collection: collection)
+    end
+  end
+end

--- a/spec/values/cache_keys/custom/editors_spec.rb
+++ b/spec/values/cache_keys/custom/editors_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe CacheKeys::Custom::Editors do
+  context "index" do
+    let(:collection) { instance_double(Collection, collection_users: "collection_users" ) }
+
+    it "uses CacheKeys::ActiveRecord" do
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate)
+      subject.index(collection: collection)
+    end
+
+    it "uses the correct data" do
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with(record: [collection, collection.collection_users])
+      subject.index(collection: collection)
+    end
+  end
+
+  context "user_search" do
+    let(:collection) { instance_double(Collection, collection_users: "collection_users" ) }
+    let(:users) { [{ id: 1, label: "one", value: "one" }, { id: 2, label: "two", value: "two" }] }
+
+    it "uses CacheKeys::ActiveRecord" do
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate)
+      subject.user_search(collection: collection, users: users)
+    end
+
+    it "uses the correct data" do
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with(record: [collection, users])
+      subject.user_search(collection: collection, users: users)
+    end
+  end
+end

--- a/spec/values/cache_keys/custom/editors_spec.rb
+++ b/spec/values/cache_keys/custom/editors_spec.rb
@@ -17,16 +17,16 @@ RSpec.describe CacheKeys::Custom::Editors do
 
   context "user_search" do
     let(:collection) { instance_double(Collection, collection_users: "collection_users" ) }
-    let(:users) { [{ id: 1, label: "one", value: "one" }, { id: 2, label: "two", value: "two" }] }
+    let(:formatted_users) { [{ id: 1, label: "one", value: "one" }, { id: 2, label: "two", value: "two" }] }
 
     it "uses CacheKeys::ActiveRecord" do
       expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate)
-      subject.user_search(collection: collection, users: users)
+      subject.user_search(collection: collection, formatted_users: formatted_users)
     end
 
     it "uses the correct data" do
-      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with(record: [collection, users])
-      subject.user_search(collection: collection, users: users)
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with(record: [collection, formatted_users])
+      subject.user_search(collection: collection, formatted_users: formatted_users)
     end
   end
 end

--- a/spec/values/cache_keys/custom/editors_spec.rb
+++ b/spec/values/cache_keys/custom/editors_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe CacheKeys::Custom::Editors do
   context "index" do
-    let(:collection) { instance_double(Collection, collection_users: "collection_users" ) }
+    let(:collection) { instance_double(Collection, collection_users: "collection_users") }
 
     it "uses CacheKeys::ActiveRecord" do
       expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate)
@@ -16,7 +16,7 @@ RSpec.describe CacheKeys::Custom::Editors do
   end
 
   context "user_search" do
-    let(:collection) { instance_double(Collection, collection_users: "collection_users" ) }
+    let(:collection) { instance_double(Collection, collection_users: "collection_users") }
     let(:formatted_users) { [{ id: 1, label: "one", value: "one" }, { id: 2, label: "two", value: "two" }] }
 
     it "uses CacheKeys::ActiveRecord" do

--- a/spec/values/cache_keys/custom/exhibits_spec.rb
+++ b/spec/values/cache_keys/custom/exhibits_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe CacheKeys::Custom::Exhibits do
   context "edit" do
-    let(:exhibit) { instance_double(Exhibit, collection: "collection" ) }
+    let(:exhibit) { instance_double(Exhibit, collection: "collection") }
 
     it "uses CacheKeys::ActiveRecord" do
       expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate)
@@ -14,5 +14,4 @@ RSpec.describe CacheKeys::Custom::Exhibits do
       subject.edit(exhibit: exhibit)
     end
   end
-
 end

--- a/spec/values/cache_keys/custom/exhibits_spec.rb
+++ b/spec/values/cache_keys/custom/exhibits_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe CacheKeys::Custom::Exhibits do
+  context "edit" do
+    let(:exhibit) { instance_double(Exhibit, collection: "collection" ) }
+
+    it "uses CacheKeys::ActiveRecord" do
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate)
+      subject.edit(exhibit: exhibit)
+    end
+
+    it "uses the correct data" do
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with(record: [exhibit, exhibit.collection])
+      subject.edit(exhibit: exhibit)
+    end
+  end
+
+end

--- a/spec/values/cache_keys/custom/items_spec.rb
+++ b/spec/values/cache_keys/custom/items_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe CacheKeys::Custom::Items do
+  context "index" do
+    let(:collection) { instance_double(Collection, items: "items" ) }
+
+    it "uses CacheKeys::ActiveRecord" do
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate)
+      subject.index(collection: collection)
+    end
+
+    it "uses the correct data" do
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with(record: [collection, collection.items])
+      subject.index(collection: collection)
+    end
+  end
+
+  context "edit" do
+    let(:collection) { instance_double(Collection, items: "items" ) }
+    let(:item) { instance_double(Item, collection: collection) }
+    let(:decorated_item) { ItemDecorator.new(item) }
+
+    before(:each) do
+      allow(decorated_item).to receive(:recent_children).and_return("recent_children")
+    end
+
+    it "uses CacheKeys::ActiveRecord" do
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate)
+      subject.edit(decorated_item: decorated_item)
+    end
+
+    it "uses the correct data" do
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with(record: [decorated_item.collection, decorated_item.recent_children, decorated_item.object])
+      subject.edit(decorated_item: decorated_item)
+    end
+  end
+end

--- a/spec/values/cache_keys/custom/items_spec.rb
+++ b/spec/values/cache_keys/custom/items_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe CacheKeys::Custom::Items do
   context "index" do
-    let(:collection) { instance_double(Collection, items: "items" ) }
+    let(:collection) { instance_double(Collection, items: "items") }
 
     it "uses CacheKeys::ActiveRecord" do
       expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate)
@@ -16,7 +16,7 @@ RSpec.describe CacheKeys::Custom::Items do
   end
 
   context "edit" do
-    let(:collection) { instance_double(Collection, items: "items" ) }
+    let(:collection) { instance_double(Collection, items: "items") }
     let(:item) { instance_double(Item, collection: collection) }
     let(:decorated_item) { ItemDecorator.new(item) }
 
@@ -30,7 +30,8 @@ RSpec.describe CacheKeys::Custom::Items do
     end
 
     it "uses the correct data" do
-      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with(record: [decorated_item.collection, decorated_item.recent_children, decorated_item.object])
+      record = [decorated_item.collection, decorated_item.recent_children, decorated_item.object]
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with(record: record)
       subject.edit(decorated_item: decorated_item)
     end
   end

--- a/spec/values/cache_keys/custom/sections_spec.rb
+++ b/spec/values/cache_keys/custom/sections_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe CacheKeys::Custom::Sections do
+  context "edit" do
+    let(:section) { instance_double(Section, collection: "collection") }
+
+    it "uses CacheKeys::ActiveRecord" do
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate)
+      subject.edit(section: section)
+    end
+
+    it "uses the correct data" do
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with(record: [section, section.collection])
+      subject.edit(section: section)
+    end
+  end
+
+end

--- a/spec/values/cache_keys/custom/sections_spec.rb
+++ b/spec/values/cache_keys/custom/sections_spec.rb
@@ -14,5 +14,4 @@ RSpec.describe CacheKeys::Custom::Sections do
       subject.edit(section: section)
     end
   end
-
 end

--- a/spec/values/cache_keys/custom/showcases_spec.rb
+++ b/spec/values/cache_keys/custom/showcases_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe CacheKeys::Custom::Showcases do
   context "index" do
-    let(:exhibit) { instance_double(Exhibit, showcases: "showcases", collection: "collection" ) }
+    let(:exhibit) { instance_double(Exhibit, showcases: "showcases", collection: "collection") }
 
     it "uses CacheKeys::ActiveRecord" do
       expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate)
@@ -16,7 +16,7 @@ RSpec.describe CacheKeys::Custom::Showcases do
   end
 
   context "edit" do
-    let(:showcase) { instance_double(Showcase, collection: "collection" ) }
+    let(:showcase) { instance_double(Showcase, collection: "collection") }
 
     it "uses CacheKeys::ActiveRecord" do
       expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate)
@@ -30,7 +30,7 @@ RSpec.describe CacheKeys::Custom::Showcases do
   end
 
   context "title" do
-    let(:showcase) { instance_double(Showcase, collection: "collection" ) }
+    let(:showcase) { instance_double(Showcase, collection: "collection") }
 
     it "uses CacheKeys::ActiveRecord" do
       expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate)

--- a/spec/values/cache_keys/custom/showcases_spec.rb
+++ b/spec/values/cache_keys/custom/showcases_spec.rb
@@ -15,18 +15,31 @@ RSpec.describe CacheKeys::Custom::Showcases do
     end
   end
 
-  context "default" do
+  context "edit" do
     let(:showcase) { instance_double(Showcase, collection: "collection" ) }
 
     it "uses CacheKeys::ActiveRecord" do
       expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate)
-      subject.default(showcase: showcase)
+      subject.edit(showcase: showcase)
     end
 
     it "uses the correct data" do
       expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with(record: [showcase, showcase.collection])
-      subject.default(showcase: showcase)
+      subject.edit(showcase: showcase)
     end
   end
 
+  context "title" do
+    let(:showcase) { instance_double(Showcase, collection: "collection" ) }
+
+    it "uses CacheKeys::ActiveRecord" do
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate)
+      subject.title(showcase: showcase)
+    end
+
+    it "uses the correct data" do
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with(record: [showcase, showcase.collection])
+      subject.title(showcase: showcase)
+    end
+  end
 end

--- a/spec/values/cache_keys/custom/showcases_spec.rb
+++ b/spec/values/cache_keys/custom/showcases_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe CacheKeys::Custom::Showcases do
+  context "index" do
+    let(:exhibit) { instance_double(Exhibit, showcases: "showcases", collection: "collection" ) }
+
+    it "uses CacheKeys::ActiveRecord" do
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate)
+      subject.index(exhibit: exhibit)
+    end
+
+    it "uses the correct data" do
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with(record: [exhibit.showcases, exhibit.collection])
+      subject.index(exhibit: exhibit)
+    end
+  end
+
+  context "default" do
+    let(:showcase) { instance_double(Showcase, collection: "collection" ) }
+
+    it "uses CacheKeys::ActiveRecord" do
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate)
+      subject.default(showcase: showcase)
+    end
+
+    it "uses the correct data" do
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with(record: [showcase, showcase.collection])
+      subject.default(showcase: showcase)
+    end
+  end
+
+end


### PR DESCRIPTION
V1 controllers were handled with a previous merge. This one finishes converting remaining controllers to use the new cache key generator pattern.