### PR TITLE
DEC-265: Title -> Name

### DIFF
--- a/app/decorators/v1/item_json_decorator.rb
+++ b/app/decorators/v1/item_json_decorator.rb
@@ -3,7 +3,7 @@ module V1
     delegate :id, :title, :children, :parent, :collection, :unique_id, :updated_at
 
     METADATA_MAP = [
-      ["Title", :title],
+      ["Name", :title],
       ["Description", :description],
       ["Manuscript", :manuscript_url],
       ["Transcription", :transcription]

--- a/app/views/v1/collections/_collection.json.jbuilder
+++ b/app/views/v1/collections/_collection.json.jbuilder
@@ -5,9 +5,9 @@ json.set! 'hasPart/items', collection_object.items_url
 json.set! 'hasPart/showcases', collection_object.showcases_url
 json.id collection_object.unique_id
 json.slug collection_object.slug
-json.title collection_object.title
-json.title_line_1 collection_object.title_line_1
-json.title_line_2 collection_object.title_line_2
+json.name collection_object.title
+json.name_line_1 collection_object.title_line_1
+json.name_line_2 collection_object.title_line_2
 json.short_description collection_object.short_intro
 json.description collection_object.site_intro
 json.about collection_object.about

--- a/app/views/v1/items/_item.json.jbuilder
+++ b/app/views/v1/items/_item.json.jbuilder
@@ -4,7 +4,7 @@ json.set! '@id', item_object.at_id
 json.set! 'isPartOf/collection', item_object.collection_url
 json.id item_object.unique_id
 json.slug item_object.slug
-json.title item_object.title
+json.name item_object.title
 json.description item_object.description.to_s
 json.image item_object.image
 json.metadata item_object.metadata

--- a/app/views/v1/sections/_section.json.jbuilder
+++ b/app/views/v1/sections/_section.json.jbuilder
@@ -5,7 +5,7 @@ json.set! 'isPartOf/showcase', section_object.showcase_url
 json.set! 'isPartOf/collection', section_object.collection_url
 json.id section_object.unique_id
 json.slug section_object.slug
-json.title section_object.title
+json.name section_object.title
 json.order section_object.order
 json.description section_object.description
 json.caption section_object.caption

--- a/app/views/v1/showcases/_showcase.json.jbuilder
+++ b/app/views/v1/showcases/_showcase.json.jbuilder
@@ -4,9 +4,9 @@ json.set! '@id', showcase_object.at_id
 json.set! 'isPartOf/collection', showcase_object.collection_url
 json.id showcase_object.unique_id
 json.slug showcase_object.slug
-json.title showcase_object.title
-json.title_line_1 showcase_object.title_line_1
-json.title_line_2 showcase_object.title_line_2
+json.name showcase_object.title
+json.name_line_1 showcase_object.title_line_1
+json.name_line_2 showcase_object.title_line_2
 json.description showcase_object.description
 json.image showcase_object.image
 json.last_updated showcase_object.updated_at

--- a/spec/decorators/v1/item_json_decorator_spec.rb
+++ b/spec/decorators/v1/item_json_decorator_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe V1::ItemJSONDecorator do
 
     it "creates a metadata hash of all metadata" do
       results = [
-        { label: "Title", value: "title" },
+        { label: "Name", value: "title" },
         { label: "Description", value: "desc" },
         { label: "Manuscript", value: "url" },
         { label: "Transcription", value: "trans" }


### PR DESCRIPTION
Changes all API objects to use 'Name' instead of 'Title' for all fields. This is simply a remapping of name to title, ie it does not change the schema or models, just the front-end facing jsons and metadata.
This must be merged with https://github.com/ndlib/beehive/pull/92