### PR TITLE
DEC-308-Bust the cache on redeploy

### DIFF
--- a/app/values/cache_keys/generator.rb
+++ b/app/values/cache_keys/generator.rb
@@ -11,8 +11,9 @@ module CacheKeys
     end
 
     def generate
-      # print generator.class.name + "." + action + "='" + generator.send(action, **@args) + "'\n"
-      generator.send(action, **args)
+      key = Rails.application.config.cache_key_header + generator.send(action, **args).to_s
+      # print generator.class.name + "." + action + "='" + key + "'\n"
+      # key
     end
   end
 end

--- a/app/values/cache_keys/generator.rb
+++ b/app/values/cache_keys/generator.rb
@@ -11,9 +11,8 @@ module CacheKeys
     end
 
     def generate
-      key = Rails.application.config.cache_key_header + generator.send(action, **args).to_s
+      Rails.application.config.cache_key_header + generator.send(action, **args).to_s
       # print generator.class.name + "." + action + "='" + key + "'\n"
-      # key
     end
   end
 end

--- a/config/initializers/caching.rb
+++ b/config/initializers/caching.rb
@@ -1,0 +1,5 @@
+Rails.application.configure do
+  # cache_key_header is a value that will get prepended
+  # to all generated cache key strings prior to MD5 digesting
+  config.cache_key_header = (Time.now + rand).to_i.to_s + "/"
+end

--- a/spec/values/cache_keys/generator_spec.rb
+++ b/spec/values/cache_keys/generator_spec.rb
@@ -15,6 +15,6 @@ RSpec.describe CacheKeys::Generator do
 
   it "is the generator's return value" do
     allow_any_instance_of(Class).to receive(:specificmethod).and_return("one")
-    expect(subject.generate).to eq("one")
+    expect(subject.generate).to include("one")
   end
 end


### PR DESCRIPTION
On start, the application will now generate a unique key that will be prepended to all cache key strings used to generate etags, causing all etags to change after a restart of the server.