### PR TITLE
DEC-313: API Item Update

### DIFF
--- a/app/controllers/v1/items_controller.rb
+++ b/app/controllers/v1/items_controller.rb
@@ -26,9 +26,9 @@ module V1
       #check_user_edits!(@item.collection)
 
       if SaveItem.call(@item, save_params)
-        render action: :show
+        render partial: "item"
       else
-        render action: :show, status: :unprocessable_entity
+        render :errors, status: :unprocessable_entity
       end
     end
 

--- a/app/controllers/v1/items_controller.rb
+++ b/app/controllers/v1/items_controller.rb
@@ -23,7 +23,7 @@ module V1
 
     def update
       @item = ItemQuery.new.find(params[:id])
-      #check_user_edits!(@item.collection)
+      # check_user_edits!(@item.collection)
 
       if SaveItem.call(@item, save_params)
         render partial: "item"
@@ -32,11 +32,10 @@ module V1
       end
     end
 
-  protected
+    protected
 
     def save_params
       params.require(:item).permit(:title, :description, :image, :manuscript_url, :transcription)
     end
-
   end
 end

--- a/app/controllers/v1/items_controller.rb
+++ b/app/controllers/v1/items_controller.rb
@@ -20,5 +20,23 @@ module V1
                                            item: @item)
       fresh_when(etag: cache_key.generate)
     end
+
+    def update
+      @item = ItemQuery.new.find(params[:id])
+      #check_user_edits!(@item.collection)
+
+      if SaveItem.call(@item, save_params)
+        render action: :show
+      else
+        render action: :show, status: :unprocessable_entity
+      end
+    end
+
+  protected
+
+    def save_params
+      params.require(:item).permit(:title, :description, :image, :manuscript_url, :transcription)
+    end
+
   end
 end

--- a/app/views/v1/items/errors.json.jbuilder
+++ b/app/views/v1/items/errors.json.jbuilder
@@ -1,0 +1,3 @@
+# Display item with errors
+V1::ItemJSONDecorator.display(@item, json)
+json.set! "errors", @item.errors

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,7 +65,7 @@ Rails.application.routes.draw do
       resources :items, only: [:index], defaults: { format: :json }
       resources :showcases, only: [:index], defaults: { format: :json }
     end
-    resources :items, only: [:show], defaults: { format: :json }
+    resources :items, only: [:show, :update], defaults: { format: :json }
     resources :showcases, only: [:show], defaults: { format: :json }
     resources :sections, only: [:show], defaults: { format: :json }
   end

--- a/spec/controllers/v1/items_controller_spec.rb
+++ b/spec/controllers/v1/items_controller_spec.rb
@@ -57,4 +57,54 @@ RSpec.describe V1::ItemsController, type: :controller do
       subject
     end
   end
+
+  describe "PUT #update" do
+    let(:collection) { double(Collection, id: "1") }
+    let(:item) { double(Item, id: 1, parent: nil, collection: collection,  errors: "Errors" ) }
+    let(:update_params) { { format: :json, id: item.id, item: { title: "title" } } }
+
+    subject { put :update, update_params }
+
+    before(:each) do
+      sign_in_admin
+      allow_any_instance_of(ItemQuery).to receive(:find).and_return(item)
+      allow(SaveItem).to receive(:call).and_return(true)
+    end
+
+    #it "checks the editor permissions" do
+    #  expect_any_instance_of(described_class).to receive(:check_user_edits!).with(collection)
+    #  subject
+    #end
+
+    it "uses item query " do
+      expect_any_instance_of(ItemQuery).to receive(:find).with("1").and_return(item)
+      subject
+    end
+
+    it "renders the item on success" do
+      subject
+      expect(response).to render_template("show")
+    end
+
+    it "unprocessable on failure" do
+      allow(SaveItem).to receive(:call).and_return(false)
+      subject
+      expect(response).to be_unprocessable
+    end
+
+    it "assigns and item" do
+      subject
+
+      assigns(:item)
+      expect(assigns(:item)).to eq(item)
+    end
+
+    it "uses the save item service" do
+      expect(SaveItem).to receive(:call).and_return(true)
+
+      subject
+    end
+
+    it_behaves_like "a private content-based etag cacher"
+  end
 end

--- a/spec/controllers/v1/items_controller_spec.rb
+++ b/spec/controllers/v1/items_controller_spec.rb
@@ -62,13 +62,12 @@ RSpec.describe V1::ItemsController, type: :controller do
     let(:collection) { double(Collection, id: "1") }
     let(:item) { double(Item, id: 1, parent: nil, collection: collection,  errors: "Errors" ) }
     let(:update_params) { { format: :json, id: item.id, item: { title: "title" } } }
-
     subject { put :update, update_params }
 
     before(:each) do
-      sign_in_admin
-      allow_any_instance_of(ItemQuery).to receive(:find).and_return(item)
+      #sign_in_admin
       allow(SaveItem).to receive(:call).and_return(true)
+      allow_any_instance_of(ItemQuery).to receive(:find).and_return(item)
     end
 
     #it "checks the editor permissions" do
@@ -81,15 +80,26 @@ RSpec.describe V1::ItemsController, type: :controller do
       subject
     end
 
-    it "renders the item on success" do
+    it "returns ok on success" do
       subject
-      expect(response).to render_template("show")
+      expect(response).to be_success
     end
 
-    it "unprocessable on failure" do
+    it "renders the item only on success" do
+      subject
+      expect(response).to render_template(partial: "_item")
+    end
+
+    it "returns unprocessable on failure" do
       allow(SaveItem).to receive(:call).and_return(false)
       subject
       expect(response).to be_unprocessable
+    end
+
+    it "renders with errors" do
+      allow(SaveItem).to receive(:call).and_return(false)
+      subject
+      expect(item).to render_template("errors")
     end
 
     it "assigns and item" do

--- a/spec/controllers/v1/items_controller_spec.rb
+++ b/spec/controllers/v1/items_controller_spec.rb
@@ -60,20 +60,20 @@ RSpec.describe V1::ItemsController, type: :controller do
 
   describe "PUT #update" do
     let(:collection) { double(Collection, id: "1") }
-    let(:item) { double(Item, id: 1, parent: nil, collection: collection,  errors: "Errors" ) }
+    let(:item) { double(Item, id: 1, parent: nil, collection: collection) }
     let(:update_params) { { format: :json, id: item.id, item: { title: "title" } } }
     subject { put :update, update_params }
 
     before(:each) do
-      #sign_in_admin
+      # sign_in_admin
       allow(SaveItem).to receive(:call).and_return(true)
       allow_any_instance_of(ItemQuery).to receive(:find).and_return(item)
     end
 
-    #it "checks the editor permissions" do
-    #  expect_any_instance_of(described_class).to receive(:check_user_edits!).with(collection)
-    #  subject
-    #end
+    # it "checks the editor permissions" do
+    #   expect_any_instance_of(described_class).to receive(:check_user_edits!).with(collection)
+    #   subject
+    # end
 
     it "uses item query " do
       expect_any_instance_of(ItemQuery).to receive(:find).with("1").and_return(item)


### PR DESCRIPTION
**Why:** We want to start moving these types of data operations to the api. We are starting with this one since we are modifying the save operation to include the metadata fields for an item. This needs to be done in order to continue progress on that ticket (https://jira.library.nd.edu/browse/DEC-273)
**How:** For the most part this was a copy/paste from the other ItemsController, except that here we render the item data only for the json and we also include error information since any services that use this will need this info to deal with the unsuccessful save.