### PR TITLE
Dec 313

### DIFF
--- a/app/controllers/v1/items_controller.rb
+++ b/app/controllers/v1/items_controller.rb
@@ -22,11 +22,11 @@ module V1
     end
 
     def update
-      @item = ItemQuery.new.find(params[:id])
+      @item = ItemQuery.new.public_find(params[:id])
       # check_user_edits!(@item.collection)
 
       if SaveItem.call(@item, save_params)
-        render partial: "item"
+        render :update
       else
         render :errors, status: :unprocessable_entity
       end

--- a/app/views/v1/items/update.json.jbuilder
+++ b/app/views/v1/items/update.json.jbuilder
@@ -1,0 +1,1 @@
+V1::ItemJSONDecorator.display(@item, json)

--- a/spec/controllers/v1/items_controller_spec.rb
+++ b/spec/controllers/v1/items_controller_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe V1::ItemsController, type: :controller do
     # end
 
     it "uses item query " do
-      expect_any_instance_of(ItemQuery).to receive(:find).with("1").and_return(item)
+      expect_any_instance_of(ItemQuery).to receive(:public_find).with("1").and_return(item)
       subject
     end
 
@@ -87,7 +87,7 @@ RSpec.describe V1::ItemsController, type: :controller do
 
     it "renders the item only on success" do
       subject
-      expect(response).to render_template(partial: "_item")
+      expect(response).to render_template("update")
     end
 
     it "returns unprocessable on failure" do


### PR DESCRIPTION
This is a dupicate of pull https://github.com/ndlib/honeycomb/pull/120. 120 was merging into master, recreating here to merge into phase2 branch.

**Why:** 
Need to fix two bugs with V1::Item.update:
  1. Cannot find the object by the id given by the api
  1. Has a bug with rendering the partial when the save is successful.

**How:** 
  1. Modified to use public find to find the object since the API objects will always use the public id instead of the internal id
  1. Added an update jbuilder that simply renders the partial after decorating it.