### PR TITLE
DEC-359: Updating an exhibit does not show changes on refresh

### DIFF
--- a/app/values/cache_keys/custom/v1_showcases.rb
+++ b/app/values/cache_keys/custom/v1_showcases.rb
@@ -3,7 +3,7 @@ module CacheKeys
     # Generator for v1/showcases_controller
     class V1Showcases
       def index(collection:)
-        CacheKeys::ActiveRecord.new.generate(record: [collection, collection.showcases])
+        CacheKeys::ActiveRecord.new.generate(record: [collection, collection.exhibit, collection.showcases])
       end
 
       def show(showcase:)

--- a/app/values/cache_keys/generator.rb
+++ b/app/values/cache_keys/generator.rb
@@ -11,7 +11,8 @@ module CacheKeys
     end
 
     def generate
-      key = Rails.application.config.cache_key_header + generator.send(action, **args).to_s
+      Rails.application.config.cache_key_header + generator.send(action, **args).to_s
+      # key = Rails.application.config.cache_key_header + generator.send(action, **args).to_s
       # print generator.class.name + "." + action + "='" + key + "'\n"
       # key
     end

--- a/app/values/cache_keys/generator.rb
+++ b/app/values/cache_keys/generator.rb
@@ -11,8 +11,9 @@ module CacheKeys
     end
 
     def generate
-      Rails.application.config.cache_key_header + generator.send(action, **args).to_s
+      key = Rails.application.config.cache_key_header + generator.send(action, **args).to_s
       # print generator.class.name + "." + action + "='" + key + "'\n"
+      # key
     end
   end
 end

--- a/spec/controllers/v1/showcases_controller_spec.rb
+++ b/spec/controllers/v1/showcases_controller_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 require "cache_spec_helper"
 
 RSpec.describe V1::ShowcasesController, type: :controller do
-  let(:collection) { instance_double(Collection, id: "1", updated_at: nil, showcases: nil) }
+  let(:collection) { instance_double(Collection, id: "1", updated_at: nil, showcases: nil, exhibit: nil) }
   let(:showcase) { instance_double(Showcase, id: "1", updated_at: nil, sections: nil, items: nil, collection: nil) }
 
   before(:each) do

--- a/spec/values/cache_keys/custom/v1_showcases_spec.rb
+++ b/spec/values/cache_keys/custom/v1_showcases_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe CacheKeys::Custom::V1Showcases do
   context "index" do
-    let(:collection) { instance_double(Collection, showcases: "showcases") }
+    let(:collection) { instance_double(Collection, showcases: "showcases", exhibit: "exhibit") }
 
     it "uses CacheKeys::ActiveRecord" do
       expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate)
@@ -10,7 +10,7 @@ RSpec.describe CacheKeys::Custom::V1Showcases do
     end
 
     it "uses the correct data" do
-      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with(record: [collection, "showcases"])
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with(record: [collection, "exhibit", "showcases"])
       subject.index(collection: collection)
     end
   end


### PR DESCRIPTION
WHY: Problem was with v1::showcases#index. View used exhibit data but cache key generation was not including this. 
HOW: Changed the v1::showcases#index to use the associated exhibit when generating the cache key.