### PR TITLE
DEC-262: Allow the copyright text to be changed

### DIFF
--- a/app/controllers/exhibits_controller.rb
+++ b/app/controllers/exhibits_controller.rb
@@ -27,6 +27,6 @@ class ExhibitsController < ApplicationController
   private
 
   def save_params
-    params.require(:exhibit).permit([:description, :image, :short_description, :about])
+    params.require(:exhibit).permit([:description, :image, :short_description, :about, :copyright])
   end
 end

--- a/app/decorators/v1/collection_json_decorator.rb
+++ b/app/decorators/v1/collection_json_decorator.rb
@@ -36,8 +36,9 @@ module V1
     end
 
     def copyright
-      if(!object.exhibit.copyright.to_s.empty?)
-        object.exhibit.copyright.to_s
+      val = object.exhibit.copyright.to_s
+      if(!val.empty?)
+        val
       else
         "<p><a href=\"http://www.nd.edu/copyright/\">Copyright</a> #{Date.today.year} <a href=\"http://www.nd.edu\">University of Notre Dame</a></p>"
       end

--- a/app/decorators/v1/collection_json_decorator.rb
+++ b/app/decorators/v1/collection_json_decorator.rb
@@ -36,11 +36,11 @@ module V1
     end
 
     def copyright
-      val = object.exhibit.copyright.to_s
-      if(!val.empty?)
-        val
-      else
+      exhibit_copyright = object.exhibit.copyright.to_s
+      if exhibit_copyright.empty?
         "<p><a href=\"http://www.nd.edu/copyright/\">Copyright</a> #{Date.today.year} <a href=\"http://www.nd.edu\">University of Notre Dame</a></p>"
+      else
+        exhibit_copyright
       end
     end
 

--- a/app/decorators/v1/collection_json_decorator.rb
+++ b/app/decorators/v1/collection_json_decorator.rb
@@ -35,6 +35,10 @@ module V1
       object.exhibit.about.to_s
     end
 
+    def copyright
+      object.exhibit.copyright.to_s
+    end
+
     def slug
       CreateURLSlug.call(object.title)
     end

--- a/app/decorators/v1/collection_json_decorator.rb
+++ b/app/decorators/v1/collection_json_decorator.rb
@@ -36,7 +36,11 @@ module V1
     end
 
     def copyright
-      object.exhibit.copyright.to_s
+      if(!object.exhibit.copyright.to_s.empty?)
+        object.exhibit.copyright.to_s
+      else
+        "<p><a href=\"http://www.nd.edu/copyright/\">Copyright</a> #{Date.today.year} <a href=\"http://www.nd.edu\">University of Notre Dame</a></p>"
+      end
     end
 
     def slug

--- a/app/services/ensure_collection_has_exhibit.rb
+++ b/app/services/ensure_collection_has_exhibit.rb
@@ -20,7 +20,9 @@ class EnsureCollectionHasExhibit
   private
 
   def create!
-    copyright_default = '<p><a href="http://www.nd.edu/copyright/">Copyright</a> ' + Date.today.year.to_s + ' <a href="http://www.nd.edu">University of Notre Dame</a></p>'
+    copyright_default = '<p><a href="http://www.nd.edu/copyright/">Copyright</a> ' +
+                        Date.today.year.to_s +
+                        ' <a href="http://www.nd.edu">University of Notre Dame</a></p>'
     collection.create_exhibit(title: collection.title, copyright: copyright_default)
   end
 end

--- a/app/services/ensure_collection_has_exhibit.rb
+++ b/app/services/ensure_collection_has_exhibit.rb
@@ -20,6 +20,7 @@ class EnsureCollectionHasExhibit
   private
 
   def create!
-    collection.create_exhibit(title: collection.title)
+    copyright_default = '<p><a href="http://www.nd.edu/copyright/">Copyright</a> ' + Date.today.year.to_s + ' <a href="http://www.nd.edu">University of Notre Dame</a></p>'
+    collection.create_exhibit(title: collection.title, copyright: copyright_default)
   end
 end

--- a/app/views/exhibits/_copyright_text_form.html.erb
+++ b/app/views/exhibits/_copyright_text_form.html.erb
@@ -1,1 +1,4 @@
-COPYRIGHTS are cool
+<%= f.input :copyright, input_html: { class: "honeycomb_redactor" } %>
+<h3>Copy and Paste Example</h3>
+<hr>
+<p><a href="http://www.nd.edu/copyright/">Copyright</a> <%= Date.today.year.to_s %> <a href="http://www.nd.edu">University of Notre Dame</a></p>

--- a/app/views/v1/collections/_collection.json.jbuilder
+++ b/app/views/v1/collections/_collection.json.jbuilder
@@ -13,3 +13,4 @@ json.description collection_object.site_intro
 json.about collection_object.about
 json.image collection_object.image
 json.last_updated collection_object.updated_at
+json.copyright collection_object.copyright

--- a/db/migrate/20150527193045_add_copyright_to_exhibits.rb
+++ b/db/migrate/20150527193045_add_copyright_to_exhibits.rb
@@ -1,0 +1,5 @@
+class AddCopyrightToExhibits < ActiveRecord::Migration
+  def change
+    add_column :exhibits, :copyright, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150505171443) do
+ActiveRecord::Schema.define(version: 20150527193045) do
 
   create_table "collection_users", force: :cascade do |t|
     t.integer  "user_id",       limit: 4, null: false
@@ -46,9 +46,10 @@ ActiveRecord::Schema.define(version: 20150505171443) do
     t.integer  "image_file_size",    limit: 4
     t.datetime "image_updated_at"
     t.text     "short_description",  limit: 65535
+    t.text     "about",              limit: 65535
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.text     "about",              limit: 65535
+    t.text     "copyright",          limit: 65535
   end
 
   create_table "honeypot_images", force: :cascade do |t|

--- a/spec/decorators/v1/collection_json_decorator_spec.rb
+++ b/spec/decorators/v1/collection_json_decorator_spec.rb
@@ -83,6 +83,26 @@ RSpec.describe V1::CollectionJSONDecorator do
     end
   end
 
+  describe "#copyright" do
+    let(:exhibit) { double(Exhibit) }
+    let(:collection) { double(Collection, exhibit: exhibit) }
+
+    it "converts null to default string" do
+      expect(exhibit).to receive(:copyright).and_return(nil)
+      expect(subject.copyright).to eq("<p><a href=\"http://www.nd.edu/copyright/\">Copyright</a> #{Date.today.year} <a href=\"http://www.nd.edu\">University of Notre Dame</a></p>")
+    end
+
+    it "converts empty string to default string" do
+      expect(exhibit).to receive(:copyright).and_return("")
+      expect(subject.copyright).to eq("<p><a href=\"http://www.nd.edu/copyright/\">Copyright</a> #{Date.today.year} <a href=\"http://www.nd.edu\">University of Notre Dame</a></p>")
+    end
+
+    it "gets the value from the exhibit" do
+      expect(exhibit).to receive(:copyright).and_return("copyright")
+      expect(subject.copyright).to eq("copyright")
+    end
+  end
+
   describe "#site_intro" do
     let(:exhibit) { double(Exhibit, description: nil) }
     let(:collection) { double(Collection, exhibit: exhibit) }

--- a/spec/decorators/v1/collection_json_decorator_spec.rb
+++ b/spec/decorators/v1/collection_json_decorator_spec.rb
@@ -86,15 +86,18 @@ RSpec.describe V1::CollectionJSONDecorator do
   describe "#copyright" do
     let(:exhibit) { double(Exhibit) }
     let(:collection) { double(Collection, exhibit: exhibit) }
+    let(:default) { "<p><a href=\"http://www.nd.edu/copyright/\">Copyright</a> " +
+                    Date.today.year.to_s +
+                    " <a href=\"http://www.nd.edu\">University of Notre Dame</a></p>" }
 
     it "converts null to default string" do
       expect(exhibit).to receive(:copyright).and_return(nil)
-      expect(subject.copyright).to eq("<p><a href=\"http://www.nd.edu/copyright/\">Copyright</a> #{Date.today.year} <a href=\"http://www.nd.edu\">University of Notre Dame</a></p>")
+      expect(subject.copyright).to eq(default)
     end
 
     it "converts empty string to default string" do
       expect(exhibit).to receive(:copyright).and_return("")
-      expect(subject.copyright).to eq("<p><a href=\"http://www.nd.edu/copyright/\">Copyright</a> #{Date.today.year} <a href=\"http://www.nd.edu\">University of Notre Dame</a></p>")
+      expect(subject.copyright).to eq(default)
     end
 
     it "gets the value from the exhibit" do

--- a/spec/decorators/v1/collection_json_decorator_spec.rb
+++ b/spec/decorators/v1/collection_json_decorator_spec.rb
@@ -88,8 +88,8 @@ RSpec.describe V1::CollectionJSONDecorator do
     let(:collection) { double(Collection, exhibit: exhibit) }
     let(:default) do
       "<p><a href=\"http://www.nd.edu/copyright/\">Copyright</a> " +
-      Date.today.year.to_s +
-      " <a href=\"http://www.nd.edu\">University of Notre Dame</a></p>"
+        Date.today.year.to_s +
+        " <a href=\"http://www.nd.edu\">University of Notre Dame</a></p>"
     end
 
     it "converts null to default string" do

--- a/spec/decorators/v1/collection_json_decorator_spec.rb
+++ b/spec/decorators/v1/collection_json_decorator_spec.rb
@@ -86,9 +86,11 @@ RSpec.describe V1::CollectionJSONDecorator do
   describe "#copyright" do
     let(:exhibit) { double(Exhibit) }
     let(:collection) { double(Collection, exhibit: exhibit) }
-    let(:default) { "<p><a href=\"http://www.nd.edu/copyright/\">Copyright</a> " +
-                    Date.today.year.to_s +
-                    " <a href=\"http://www.nd.edu\">University of Notre Dame</a></p>" }
+    let(:default) do
+      "<p><a href=\"http://www.nd.edu/copyright/\">Copyright</a> " +
+      Date.today.year.to_s +
+      " <a href=\"http://www.nd.edu\">University of Notre Dame</a></p>"
+    end
 
     it "converts null to default string" do
       expect(exhibit).to receive(:copyright).and_return(nil)

--- a/spec/models/exhibit_spec.rb
+++ b/spec/models/exhibit_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Exhibit do
-  [:title, :description, :short_description, :showcases, :collection_id, :about, :updated_at, :created_at].each do |field|
+  [:title, :description, :short_description, :showcases, :collection_id, :about, :updated_at, :created_at, :copyright].each do |field|
     it "has the field #{field}" do
       expect(subject).to respond_to(field)
       expect(subject).to respond_to("#{field}=")

--- a/spec/services/ensure_collection_has_exhibit_spec.rb
+++ b/spec/services/ensure_collection_has_exhibit_spec.rb
@@ -32,7 +32,10 @@ describe EnsureCollectionHasExhibit do
     end
 
     it "uses the correct copyright as a default" do
-      expect(collection).to receive(:create_exhibit).with(hash_including(copyright: "<p><a href=\"http://www.nd.edu/copyright/\">Copyright</a> #{Date.today.year} <a href=\"http://www.nd.edu\">University of Notre Dame</a></p>"))
+      default_copyright = "<p><a href=\"http://www.nd.edu/copyright/\">Copyright</a> " +
+                          Date.today.year.to_s +
+                          " <a href=\"http://www.nd.edu\">University of Notre Dame</a></p>"
+      expect(collection).to receive(:create_exhibit).with(hash_including(copyright: default_copyright))
       subject
     end
   end

--- a/spec/services/ensure_collection_has_exhibit_spec.rb
+++ b/spec/services/ensure_collection_has_exhibit_spec.rb
@@ -22,7 +22,17 @@ describe EnsureCollectionHasExhibit do
     let(:collection) { double(Collection, id: 1, exhibit: nil, title: "title", create_exhibit: true)  }
 
     it "creates the exhibit" do
-      expect(collection).to receive(:create_exhibit).with(title: collection.title, copyright: "<p><a href=\"http://www.nd.edu/copyright/\">Copyright</a> #{Date.today.year} <a href=\"http://www.nd.edu\">University of Notre Dame</a></p>")
+      expect(collection).to receive(:create_exhibit)
+      subject
+    end
+
+    it "uses the collection title" do
+      expect(collection).to receive(:create_exhibit).with(hash_including(title: collection.title))
+      subject
+    end
+
+    it "uses the correct copyright as a default" do
+      expect(collection).to receive(:create_exhibit).with(hash_including(copyright: "<p><a href=\"http://www.nd.edu/copyright/\">Copyright</a> #{Date.today.year} <a href=\"http://www.nd.edu\">University of Notre Dame</a></p>"))
       subject
     end
   end

--- a/spec/services/ensure_collection_has_exhibit_spec.rb
+++ b/spec/services/ensure_collection_has_exhibit_spec.rb
@@ -22,7 +22,7 @@ describe EnsureCollectionHasExhibit do
     let(:collection) { double(Collection, id: 1, exhibit: nil, title: "title", create_exhibit: true)  }
 
     it "creates the exhibit" do
-      expect(collection).to receive(:create_exhibit).with(title: collection.title)
+      expect(collection).to receive(:create_exhibit).with(title: collection.title, copyright: "<p><a href=\"http://www.nd.edu/copyright/\">Copyright</a> #{Date.today.year} <a href=\"http://www.nd.edu\">University of Notre Dame</a></p>")
       subject
     end
   end


### PR DESCRIPTION
WHY: The user may need to include additional copyright details for their exhibit
HOW: Added a copyright field to the exhibits schema and modified honeycomb to allow editing of this field. If the user specifies a custom copyright, it will use it, otherwise, it will use the previously defined copyright text. As an additional note, when the user first creates an exhibit, it will create a default value so that the copyright year is associated with the year in which the exhibit was originally created, as opposed to a dynamically changing value. They can of course always modify this after it's created.