### PR TITLE
DEC-354: Item preview link is broken in honeycomb 

### DIFF
--- a/app/services/create_beehive_url.rb
+++ b/app/services/create_beehive_url.rb
@@ -13,6 +13,8 @@ class CreateBeehiveURL
   def create
     if @object.is_a?(Collection)
       collection_url(@object)
+    elsif @object.is_a?(Item)
+      item_url
     else
       object_url
     end
@@ -22,6 +24,10 @@ class CreateBeehiveURL
 
   def collection_url(collection)
     "#{Rails.configuration.settings.beehive_url}/#{collection.unique_id}/#{CreateURLSlug.call(collection.title)}"
+  end
+
+  def item_url
+    "#{collection_url(object.collection)}/#{object.class.name.pluralize.downcase}#modal-#{object.unique_id}"
   end
 
   def object_url

--- a/spec/services/create_beehive_url_spec.rb
+++ b/spec/services/create_beehive_url_spec.rb
@@ -25,13 +25,11 @@ RSpec.describe CreateBeehiveURL do
       let(:object) { double(Item, unique_id: "87654321", title: "An Item", collection: collection) }
 
       it "returns a beehive item url" do
-        expect(object).to receive(:is_a?).and_return(false)
-        expect(subject).to receive(:create).and_return("http://localhost:3018/12345678/a-collection/items/87654321/an-item")
+        expect(subject).to receive(:create).and_return("http://localhost:3018/12345678/a-collection/items#modal-87654321")
         subject.create
       end
 
       it "calls CreateURLSlug on the collection and item titles" do
-        expect(object).to receive(:is_a?).and_return(false)
         expect(CreateURLSlug).to receive(:call).with(object.collection.title).and_return("a-collection")
         expect(CreateURLSlug).to receive(:call).with(object.title).and_return("an-item")
         subject


### PR DESCRIPTION
WHY: The preview button for an item linked to a dead route
HOW: Changed the way CreateBeehiveURL handles creating the url for items.