### PR TITLE
DEC-352: Delete showcase translation error

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -177,6 +177,9 @@ en:
       updated_at: 'Last Modified At'
     update:
       success: "Showcase updated"
+    destroy:
+      success: "Showcase deleted"
+      failure: "There was a problem deleting this showcase"
   exhibits:
     update:
       success: 'Website updated'


### PR DESCRIPTION
Deleting a showcase gives this flash message: "translation missing: en.showcases.destroy.success". Added a showcase destroy success and failure message.