### PR TITLE
DEC-389: Get showcases dependent on item

### DIFF
--- a/app/controllers/v1/items_controller.rb
+++ b/app/controllers/v1/items_controller.rb
@@ -32,6 +32,16 @@ module V1
       end
     end
 
+    # get all showcases that use the given item
+    def showcases
+      @item = ItemQuery.new.public_find(params[:item_id])
+
+      cache_key = CacheKeys::Generator.new(key_generator: CacheKeys::Custom::V1Items,
+                                           action: "showcases",
+                                           item: @item)
+      fresh_when(etag: cache_key.generate)
+    end
+
     protected
 
     def save_params

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -4,6 +4,8 @@ class Item < ActiveRecord::Base
   belongs_to :collection
   belongs_to :parent, class_name: "Item", foreign_key: :parent_id
   has_many :children, class_name: "Item", foreign_key: :parent_id
+  has_many :sections
+  has_many :showcases, -> { distinct }, through: :sections
   has_one :honeypot_image
 
   has_attached_file :image, restricted_characters: /[&$+,\/:;=?@<>\[\]{}\|\\^~%#]/

--- a/app/values/cache_keys/custom/v1_items.rb
+++ b/app/values/cache_keys/custom/v1_items.rb
@@ -9,6 +9,10 @@ module CacheKeys
       def show(item:)
         CacheKeys::ActiveRecord.new.generate(record: [item, item.collection, item.children])
       end
+
+      def showcases(item:)
+        CacheKeys::ActiveRecord.new.generate(record: [item, item.collection, item.showcases])
+      end
     end
   end
 end

--- a/app/views/v1/items/showcases.json.jbuilder
+++ b/app/views/v1/items/showcases.json.jbuilder
@@ -1,0 +1,10 @@
+V1::CollectionJSONDecorator.display(@item.collection, json)
+json.set! :items do
+  V1::ItemJSONDecorator.display(@item, json)
+
+  json.set! :showcases do
+    json.array! @item.showcases do |showcase|
+      V1::ShowcaseJSONDecorator.display(showcase, json)
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,7 +67,11 @@ Rails.application.routes.draw do
       resources :items, only: [:index], defaults: { format: :json }
       resources :showcases, only: [:index], defaults: { format: :json }
     end
-    resources :items, only: [:show, :update], defaults: { format: :json }
+    resources :items,
+              only: [:show, :update],
+              defaults: { format: :json } do
+      get :showcases, defaults: { format: :json }
+    end
     resources :showcases, only: [:show], defaults: { format: :json }
     resources :sections, only: [:show], defaults: { format: :json }
   end

--- a/spec/controllers/v1/items_controller_spec.rb
+++ b/spec/controllers/v1/items_controller_spec.rb
@@ -117,4 +117,37 @@ RSpec.describe V1::ItemsController, type: :controller do
 
     it_behaves_like "a private content-based etag cacher"
   end
+
+  describe "#showcases" do
+    subject { get :showcases, item_id: "id", format: :json }
+    let(:item) { instance_double(Item, id: "1", collection: nil, children: nil, showcases: nil) }
+
+    it "calls ItemQuery" do
+      expect_any_instance_of(ItemQuery).to receive(:public_find).with("id").and_return(item)
+
+      subject
+    end
+
+    it "is successful" do
+      subject
+      expect(response).to be_success
+    end
+
+    it "assigns the item to render" do
+      subject
+      expect(assigns(:item)).to be_present
+    end
+
+    it "renders the correct template" do
+      expect(subject).to render_template("v1/items/showcases")
+      subject
+    end
+
+    it_behaves_like "a private basic custom etag cacher"
+
+    it "uses the V1Items#showcases to generate the cache key" do
+      expect_any_instance_of(CacheKeys::Custom::V1Items).to receive(:showcases)
+      subject
+    end
+  end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -57,6 +57,16 @@ RSpec.describe Item do
     expect(subject.children).to eq([])
   end
 
+  it "has sections" do
+    expect(subject).to respond_to(:sections)
+    expect(subject.sections).to eq([])
+  end
+
+  it "has showcases" do
+    expect(subject).to respond_to(:showcases)
+    expect(subject.showcases).to eq([])
+  end
+
   describe "#has honeypot image interface" do
     it "responds to image" do
       expect(subject).to respond_to(:image)

--- a/spec/values/cache_keys/custom/v1_items_spec.rb
+++ b/spec/values/cache_keys/custom/v1_items_spec.rb
@@ -28,4 +28,18 @@ RSpec.describe CacheKeys::Custom::V1Items do
       subject.show(item: item)
     end
   end
+
+  context "showcases" do
+    let(:item) { instance_double(Item, collection: "collection", children: "children", showcases: "showcases") }
+
+    it "uses CacheKeys::ActiveRecord" do
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate)
+      subject.showcases(item: item)
+    end
+
+    it "uses the correct data" do
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with(record: [item, "collection", "showcases"])
+      subject.showcases(item: item)
+    end
+  end
 end


### PR DESCRIPTION
Need a way of getting a json from the api for all showcases that use an item. To do this, I added a new route v1/items/:id/showcases which hits ItemsController.showcases. This action will render a json with the following structure:
Collection
--Item
----Showcases
where Showcases will only contain showcases that use that item.