### PR TITLE
DEC-388: Showcase order caching

### DIFF
--- a/app/controllers/v1/showcases_controller.rb
+++ b/app/controllers/v1/showcases_controller.rb
@@ -16,7 +16,7 @@ module V1
 
       cache_key = CacheKeys::Generator.new(key_generator: CacheKeys::Custom::V1Showcases,
                                            action: "show",
-                                           showcase: showcase)
+                                           showcase: @showcase)
       fresh_when(etag: cache_key.generate)
     end
   end

--- a/app/decorators/v1/showcase_json_decorator.rb
+++ b/app/decorators/v1/showcase_json_decorator.rb
@@ -1,7 +1,7 @@
 
 module V1
   class ShowcaseJSONDecorator < Draper::Decorator
-    delegate :id, :description, :collection, :unique_id, :updated_at
+    delegate :id, :description, :collection, :unique_id, :updated_at, :items
 
     def self.display(showcase, json)
       new(showcase).display(json)

--- a/app/values/cache_keys/custom/v1_showcases.rb
+++ b/app/values/cache_keys/custom/v1_showcases.rb
@@ -7,7 +7,7 @@ module CacheKeys
       end
 
       def show(showcase:)
-        CacheKeys::ActiveRecord.new.generate(record: [showcase, showcase.collection, showcase.sections, showcase.items])
+        CacheKeys::ActiveRecord.new.generate(record: [showcase, showcase.collection, showcase.sections, showcase.items, showcase.next])
       end
     end
   end

--- a/spec/controllers/v1/showcases_controller_spec.rb
+++ b/spec/controllers/v1/showcases_controller_spec.rb
@@ -36,6 +36,12 @@ RSpec.describe V1::ShowcasesController, type: :controller do
 
   describe "#show" do
     subject { get :show, id: "id", format: :json }
+
+    before(:each) do
+      allow_any_instance_of(V1::ShowcaseJSONDecorator).to receive(:sections).and_return([])
+      allow_any_instance_of(V1::ShowcaseJSONDecorator).to receive(:next).and_return(nil)
+    end
+
     it "calls ShowcaseQuery" do
       expect_any_instance_of(ShowcaseQuery).to receive(:public_find).with("id").and_return(showcase)
 

--- a/spec/values/cache_keys/custom/v1_showcases_spec.rb
+++ b/spec/values/cache_keys/custom/v1_showcases_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe CacheKeys::Custom::V1Showcases do
   end
 
   context "show" do
-    let(:showcase) { instance_double(Showcase, collection: "collection", sections: "sections", items: "items") }
+    let(:showcase) { instance_double(V1::ShowcaseJSONDecorator, collection: "collection", sections: "sections", items: "items", next: "next") }
 
     it "uses CacheKeys::ActiveRecord" do
       expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate)
@@ -24,7 +24,7 @@ RSpec.describe CacheKeys::Custom::V1Showcases do
     end
 
     it "uses the correct data" do
-      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with(record: [showcase, "collection", "sections", "items"])
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with(record: [showcase, "collection", "sections", "items", "next"])
       subject.show(showcase: showcase)
     end
   end


### PR DESCRIPTION
WHY: Changing the order of showcases does not show changes on front end. 
HOW:
-Had to start passing the decorated showcase to the cache key generator so that it could pull in the next showcase when generating the cache key.
-Changed the specs now that the cache key generator uses a ShowcaseJSONDecorator object and not just a Showcase object.