### PR TITLE
Dec 315 add react fields

### DIFF
--- a/app/assets/javascripts/components/embed/EmbedCode.js.jsx
+++ b/app/assets/javascripts/components/embed/EmbedCode.js.jsx
@@ -22,7 +22,7 @@ var EmbedCode = React.createClass({
         <PanelHeading>Embed This Item</PanelHeading>
         <PanelBody>
           <p>Copy and Paste this code into any site you want this item to be viewable.</p>
-          <textarea value={embedString} style={this.style()} rows="5" />
+          <textarea readOnly={true} value={embedString} style={this.style()} rows="5" />
         </PanelBody>
       </Panel>
     )

--- a/app/assets/javascripts/components/forms/ItemMetaDataForm.js.jsx
+++ b/app/assets/javascripts/components/forms/ItemMetaDataForm.js.jsx
@@ -18,13 +18,17 @@ var ItemMetaDataForm = React.createClass({
   },
 
   getInitialState: function() {
-    console.log(this.props.data);
     return {
       formValues: this.props.data,
       formState: "new",
       dataState: "clean",
       formErrors: false,
-      displayedFields: this.props.data.key,
+      displayedFields: _.mapObject(this.props.data, function(val, key) {
+        if (val) {
+          return true;
+        }
+        return false;
+      }),
     };
   },
 
@@ -144,9 +148,8 @@ var ItemMetaDataForm = React.createClass({
   },
 
   additionalFields: function() {
-
     var map_function = function(fieldConfig, field) {
-      if (this.state.formValues[field]){
+      if (this.state.displayedFields[field]){
         return (<StringField key={field} objectType={this.props.objectType} name={field} title={fieldConfig["title"]} value={this.state.formValues[field]} handleFieldChange={this.handleFieldChange} errorMsg={this.fieldError(field)} placeholder={fieldConfig["placeholder"]} />);
       }
       return "";

--- a/app/assets/javascripts/components/forms/ItemMetaDataForm.js.jsx
+++ b/app/assets/javascripts/components/forms/ItemMetaDataForm.js.jsx
@@ -14,6 +14,13 @@ var ItemMetaDataForm = React.createClass({
     return {
       method: "post",
       objectType: "item",
+      additionalFieldConfiguration: {
+        "creator": {"title": "Creator", "placeholder": 'Example "Leonardo da Vinci"'},
+        "alternate_name": {"title": "Alternate Name", "placeholder": "An additional name this work is known as."},
+        "rights": {"title": "Rights", "placeholder": 'Example "Copyright held by Hesburgh Libraries"'},
+        "publisher": {"title": "Publisher", "placeholder": 'Example "Ballantine Books"'},
+        "original_language": {"title": "Original Language", "placeholder": 'Example: "French"'},
+      }
     };
   },
 
@@ -156,15 +163,33 @@ var ItemMetaDataForm = React.createClass({
     };
     map_function = _.bind(map_function, this);
 
-    return _.map(this.additionalFieldConfiguration(), map_function);;
+    return _.map(this.props.additionalFieldConfiguration, map_function);;
   },
 
-  additionalFieldConfiguration: function() {
-    return {
-      "creator": {"title": "Creator", "placeholder": "Placey the holder"},
-      "alternate_name": {"title": "Alternate Name", "placeholder": "another name"},
+
+  addFieldsSelectOptions: function () {
+    var map_function = function (data, field) {
+      if (!this.state.displayedFields[field]) {
+        return (<option key={field} value={field}>{this.props.additionalFieldConfiguration[field]["title"]}</option>);
+      }
+      return;
     };
+    map_function = _.bind(map_function, this);
+
+    return [<option key="add-option">Add a New Field</option>].concat(_.map(this.props.additionalFieldConfiguration, map_function));
   },
+
+  changeAddField: function(event) {
+    if (!event.target.value) {
+      return
+    }
+
+    this.state.displayedFields[event.target.value] = true;
+    this.setState({
+      displayedFields: this.state.displayedFields,
+    });
+  },
+
   render: function () {
     return (
       <Form id="meta_data_form" url={this.props.url} authenticityToken={this.props.authenticityToken} method={this.props.method} >
@@ -182,6 +207,9 @@ var ItemMetaDataForm = React.createClass({
 
               {this.additionalFields()}
 
+              <select onChange={this.changeAddField}>
+                {this.addFieldsSelectOptions()}
+              </select>
           </PanelBody>
           <PanelFooter>
             <SubmitButton disabled={this.formDisabled()} handleClick={this.handleSave} />

--- a/app/assets/javascripts/components/forms/ItemMetaDataForm.js.jsx
+++ b/app/assets/javascripts/components/forms/ItemMetaDataForm.js.jsx
@@ -18,11 +18,13 @@ var ItemMetaDataForm = React.createClass({
   },
 
   getInitialState: function() {
+    console.log(this.props.data);
     return {
       formValues: this.props.data,
       formState: "new",
       dataState: "clean",
       formErrors: false,
+      displayedFields: this.props.data.key,
     };
   },
 
@@ -141,6 +143,25 @@ var ItemMetaDataForm = React.createClass({
     return []
   },
 
+  additionalFields: function() {
+
+    var map_function = function(fieldConfig, field) {
+      if (this.state.formValues[field]){
+        return (<StringField key={field} objectType={this.props.objectType} name={field} title={fieldConfig["title"]} value={this.state.formValues[field]} handleFieldChange={this.handleFieldChange} errorMsg={this.fieldError(field)} placeholder={fieldConfig["placeholder"]} />);
+      }
+      return "";
+    };
+    map_function = _.bind(map_function, this);
+
+    return _.map(this.additionalFieldConfiguration(), map_function);;
+  },
+
+  additionalFieldConfiguration: function() {
+    return {
+      "creator": {"title": "Creator", "placeholder": "Placey the holder"},
+      "alternate_name": {"title": "Alternate Name", "placeholder": "another name"},
+    };
+  },
   render: function () {
     return (
       <Form id="meta_data_form" url={this.props.url} authenticityToken={this.props.authenticityToken} method={this.props.method} >
@@ -155,6 +176,8 @@ var ItemMetaDataForm = React.createClass({
               <TextField objectType={this.props.objectType} name="transcription" title="Transcription" value={this.state.formValues["transcription"]} handleFieldChange={this.handleFieldChange} errorMsg={this.fieldError('transcription')}  />
 
               <StringField objectType={this.props.objectType} name="manuscript_url" title="Digitized Manuscript URL" value={this.state.formValues["manuscript_url"]} handleFieldChange={this.handleFieldChange} placeholder="http://" help="Link to externally hosted manuscript viewer." errorMsg={this.fieldError('manuscript_url')}  />
+
+              {this.additionalFields()}
 
           </PanelBody>
           <PanelFooter>

--- a/app/decorators/item_decorator.rb
+++ b/app/decorators/item_decorator.rb
@@ -40,7 +40,6 @@ class ItemDecorator < Draper::Decorator
         description: object.description,
         transcription: object.transcription,
         manuscript_url: object.manuscript_url,
-        metadata: object.metadata,
         creator: object.creator,
         alternate_name: object.alternate_name,
         rights: object.rights,

--- a/app/decorators/item_decorator.rb
+++ b/app/decorators/item_decorator.rb
@@ -40,6 +40,11 @@ class ItemDecorator < Draper::Decorator
         description: object.description,
         transcription: object.transcription,
         manuscript_url: object.manuscript_url,
+        metadata: object.metadata,
+        creator: object.creator,
+        alternate_name: object.alternate_name,
+        rights: object.rights,
+        original_language: object.original_language,
       })
   end
 

--- a/app/decorators/v1/item_json_decorator.rb
+++ b/app/decorators/v1/item_json_decorator.rb
@@ -1,6 +1,6 @@
 module V1
   class ItemJSONDecorator < Draper::Decorator
-    delegate :id, :name, :children, :parent, :collection, :unique_id, :updated_at
+    delegate :id, :name, :children, :parent, :collection, :unique_id, :updated_at, :creator, :alternate_name, :publisher, :rights, :original_language
 
     METADATA_MAP = [
       ["Name", :name],

--- a/app/views/v1/items/_item.json.jbuilder
+++ b/app/views/v1/items/_item.json.jbuilder
@@ -8,4 +8,9 @@ json.name item_object.name
 json.description item_object.description.to_s
 json.image item_object.image
 json.metadata item_object.metadata
+json.creator item_object.creator
+json.publisher item_object.publisher
+json.alternateName item_object.alternate_name
+json.rights item_object.rights
+json.originalLanguage item_object.original_language
 json.last_updated item_object.updated_at

--- a/spec/decorators/item_decorator_spec.rb
+++ b/spec/decorators/item_decorator_spec.rb
@@ -51,6 +51,10 @@ RSpec.describe ItemDecorator do
         description: "description",
         transcription: "transcription",
         manuscript_url: "manuscript_url",
+        creator: "creator",
+        alternate_name: "alternate_name",
+        rights: "rights",
+        original_language: "original_language",
         collection: collection)
     end
 
@@ -65,7 +69,11 @@ RSpec.describe ItemDecorator do
           name: "name",
           description: "description",
           transcription: "transcription",
-          manuscript_url: "manuscript_url"
+          manuscript_url: "manuscript_url",
+          creator: "creator",
+          alternate_name: "alternate_name",
+          rights: "rights",
+          original_language: "original_language",
         }
       )
 

--- a/spec/decorators/v1/item_json_decorator_spec.rb
+++ b/spec/decorators/v1/item_json_decorator_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe V1::ItemJSONDecorator do
   let(:json) { double }
 
   describe "generic fields" do
-    [:id, :name, :collection, :unique_id, :description, :updated_at].each do |field|
+    [:id, :name, :collection, :unique_id, :description, :updated_at,  :creator, :alternate_name, :publisher, :rights, :original_language].each do |field|
       it "responds to #{field}" do
         expect(subject).to respond_to(field)
       end

--- a/spec/decorators/v1/item_json_decorator_spec.rb
+++ b/spec/decorators/v1/item_json_decorator_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe V1::ItemJSONDecorator do
   let(:json) { double }
 
   describe "generic fields" do
-    [:id, :name, :collection, :unique_id, :description, :updated_at,  :creator, :alternate_name, :publisher, :rights, :original_language].each do |field|
+    [:id, :name, :collection, :unique_id, :description, :updated_at, :creator, :alternate_name, :publisher, :rights, :original_language].each do |field|
       it "responds to #{field}" do
         expect(subject).to respond_to(field)
       end


### PR DESCRIPTION
Update to have a select box to add 5 new meta data fields to item.  

The things I want to say about this branch are more informational since I am leaving.  I think I would like to get it merged in while I am gone so that master does not drift so much.  There are several unpolished parts that I have added tickets for.  
1.  It is a select box and it should probably be a drop button.
2.  The select box does not disappear when there are no items in it. 
3.  new fields appear in the order they are listed in the additionalFieldConfiguration hash and not at the bottom of the form.  
4.  I also think the mechanism for doing this needs some refactoring but I am expecting that to happen with the other tickets revolving around the metadata display.  