### PR TITLE
DEC-392: Add showcases to the item edit view

### DIFF
--- a/app/assets/javascripts/components/ShowcasesPanel.js.jsx
+++ b/app/assets/javascripts/components/ShowcasesPanel.js.jsx
@@ -1,0 +1,65 @@
+/** @jsx React.DOM */
+
+var ShowcasesPanel = React.createClass({
+  mixins: [TitleConcatMixin],
+  propTypes: {
+    showcases: React.PropTypes.array.isRequired,
+    panelTitle: React.PropTypes.string.isRequired,
+  },
+
+  getInitialState: function() {
+    return {
+      showcases: [],
+    };
+  },
+
+  imageStyle: function() {
+    return {
+      height: '100',
+    };
+  },
+
+  showcaseNodes: function () {
+    if(this.props.showcases.length <= 0)
+      return <div>No showcases found.</div>;
+
+    return this.props.showcases.map(function(showcase, index) {
+      key = "showcase-" + showcase.id;
+      return (
+        <div key={key} className="row">
+          <a href={showcase["@id"]}>
+            <div className="image">
+              <HoneypotImage honeypot_image={showcase.image} style="small" />
+            </div>
+            <div className="name">
+              {this.titleConcat(showcase.name_line_1, showcase.name_line_2)}
+            </div>
+          </a>
+        </div>
+      )
+    }.bind(this));
+  },
+
+  embedPanel: function () {
+
+    return (
+      <Panel>
+        <PanelHeading>{this.props.panelTitle}</PanelHeading>
+        <PanelBody>
+          <div className="showcases-panel">
+          {this.showcaseNodes()}
+          </div>
+        </PanelBody>
+      </Panel>
+    )
+  },
+
+  render: function () {
+    return (
+      <div>
+        {this.embedPanel()}
+      </div>
+    )
+  }
+
+});

--- a/app/assets/javascripts/mixins/TitleConcatMixin.js.jsx
+++ b/app/assets/javascripts/mixins/TitleConcatMixin.js.jsx
@@ -1,0 +1,18 @@
+// Concats a title and subtitle using the format specified here http://dissertation.laerd.com/style-guides-for-dissertation-titles-p2.php
+var TitleConcatMixin = {
+  titleConcat: function(title, subtitle) {
+    if(subtitle)
+      return title + this.titleSpacer(title) + subtitle;
+    return title;
+  },
+
+  // Gets the spacer to use after the title. Will
+  // be a : unless there is already a ':' or
+  // there is a '?' at the end
+  titleSpacer: function(title) {
+    var last = title.trim().slice(-1)
+    if(last == "?" || last == ":")
+      return " "
+    return ": "
+  }
+}

--- a/app/assets/stylesheets/ui-customizations.css.scss
+++ b/app/assets/stylesheets/ui-customizations.css.scss
@@ -355,6 +355,38 @@ div.dataTables_filter {
 	background: $blue;
 }
 
+.overflow-ellipsis {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.showcases-panel {
+
+  .row {
+    display: inline-block;
+    width: 100%;
+  }
+
+  .image {
+    float: left;
+    height: 3em;
+
+    img {
+      border: 1px solid Black;
+      margin: 5px;
+      width: 70px;
+    }
+  }
+
+  .name {
+    display: block;
+    height: 3em;
+    line-height: 1.5em;
+    margin-top: 1px;
+    overflow: hidden;
+  }
+}
 
 
 .panel-heading .pull-right .btn {

--- a/app/decorators/item_decorator.rb
+++ b/app/decorators/item_decorator.rb
@@ -47,6 +47,15 @@ class ItemDecorator < Draper::Decorator
       })
   end
 
+  def showcases_json
+    json_string = h.render :partial => "showcases/showcases", formats: [:json], locals: { showcases: object.showcases }
+    if json_string
+      ActiveSupport::JSON.decode(json_string)
+    else
+      {}
+    end
+  end
+
   def edit_path
     h.edit_item_path(object.id)
   end

--- a/app/decorators/showcase_json_decorator.rb
+++ b/app/decorators/showcase_json_decorator.rb
@@ -1,0 +1,10 @@
+
+class ShowcaseJSONDecorator < V1::ShowcaseJSONDecorator
+  def at_id
+    h.showcase_url(object.id)
+  end
+
+  def collection_url
+    h.collection_url(object.collection.id)
+  end
+end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -51,6 +51,12 @@
       </div>
     </div>
 
+    <%= react_component("ShowcasesPanel", {
+          showcases: @item.showcases_json,
+          panelTitle: "Showcases"
+        })
+    %>
+
     <%= ItemPublishEmbedPanel.display(@item.object) %>
 
   </div>

--- a/app/views/showcases/_showcases.json.jbuilder
+++ b/app/views/showcases/_showcases.json.jbuilder
@@ -1,0 +1,3 @@
+json.array! @item.showcases do |showcase|
+  ShowcaseJSONDecorator.display(showcase, json)
+end

--- a/spec/decorators/item_decorator_spec.rb
+++ b/spec/decorators/item_decorator_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe ItemDecorator do
       id: 1,
       collection_id: collection.id,
       collection: collection,
-      image: "image.jpg"
+      image: "image.jpg",
+      showcases: { showcases: {} }
     }
   end
   let(:item) { instance_double(Item, item_stubs) }
@@ -113,6 +114,13 @@ RSpec.describe ItemDecorator do
       it "is the collection items index" do
         expect(subject.back_path).to eq("/collections/#{collection.id}")
       end
+    end
+  end
+
+  context "showcases_json" do
+    it "renders the json partial from the showcases view" do
+      expect(subject.h).to receive(:render).with(partial: "showcases/showcases", formats: [:json], locals: { showcases: item.showcases })
+      subject.showcases_json
     end
   end
 

--- a/spec/decorators/showcase_json_decorator_spec.rb
+++ b/spec/decorators/showcase_json_decorator_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe ShowcaseJSONDecorator do
+  subject { described_class.new(showcase) }
+
+  let(:showcase) { double(Showcase) }
+
+  describe "#at_id" do
+    let(:showcase) { double(Showcase, id: "showcase_id") }
+
+    it "returns the path to the id" do
+      expect(subject.at_id).to eq("http://test.host/showcases/showcase_id")
+    end
+  end
+
+  describe "#collection_url" do
+    let(:collection) { double(Collection, id: "collection_id") }
+    let(:showcase) { double(Showcase, collection: collection) }
+
+    it "returns the path to the items" do
+      expect(subject.collection_url).to eq("http://test.host/collections/collection_id")
+    end
+  end
+end


### PR DESCRIPTION
Why: Need to add the list of showcases that are using the item to the item edit view
How:
- Created a ShowcasesPanel to handle rendering the showcase list. This is not tied to items in anyway, so it can be reused to show other brief showcase lists
- Added a title concat mixin (from beehive) to handle generation of the full name of the showcase
- Since we are unable to use the api for this yet, I had to recreate the json generation that was happening inside of the v1 controllers, except this one uses id instead of unique id and links to the non v1 controllers. So ItemDecorator now has a showcases_json method that renders a json with all the needed data for the item's related showcases