### PR TITLE
Dec 371 item model cleanup

### DIFF
--- a/app/decorators/v1/item_json_decorator.rb
+++ b/app/decorators/v1/item_json_decorator.rb
@@ -30,7 +30,7 @@ module V1
     end
 
     def slug
-      CreateURLSlug.call(object.slug)
+      CreateURLSlug.call(object.name)
     end
 
     def image

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -11,7 +11,6 @@ class Item < ActiveRecord::Base
   has_one :honeypot_image
 
   has_attached_file :image, restricted_characters: /[&$+,\/:;=?@<>\[\]{}\|\\^~%#]/
-  # , :styles => { :medium => "300x300>", :thumb => "100x100>" }, :default_url => "/images/:style/missing.png"
 
   validates :name, :collection, presence: true
   validates :image, attachment_presence: true
@@ -19,10 +18,6 @@ class Item < ActiveRecord::Base
   validate :manuscript_url_is_valid_uri
 
   validates_attachment_content_type :image, content_type: /\Aimage\/.*\Z/
-
-  def beehive_url
-    CreateBeehiveURL.call(self)
-  end
 
   private
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -20,10 +20,6 @@ class Item < ActiveRecord::Base
 
   validates_attachment_content_type :image, content_type: /\Aimage\/.*\Z/
 
-  def slug
-    name
-  end
-
   def beehive_url
     CreateBeehiveURL.call(self)
   end

--- a/app/services/create_beehive_url.rb
+++ b/app/services/create_beehive_url.rb
@@ -31,6 +31,6 @@ class CreateBeehiveURL
   end
 
   def object_url
-    "#{collection_url(object.collection)}/#{object.class.name.pluralize.downcase}/#{object.unique_id}/#{CreateURLSlug.call(object.slug)}"
+    "#{collection_url(object.collection)}/#{object.class.name.pluralize.downcase}/#{object.unique_id}/#{CreateURLSlug.call(object.name)}"
   end
 end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -3,7 +3,7 @@
 
 <%= back_action_bar(@item.back_path, "#" ) %>
 
-<%= link_to("PREVIEW", @item.beehive_url, class: "btn btn-large btn-hollow", :target => "_blank") %>
+<%= link_to("PREVIEW", CreateBeehiveURL.call(@item), class: "btn btn-large btn-hollow", :target => "_blank") %>
 
 <div class="row">
   <div class="col-md-8">

--- a/app/views/v1/items/_item.json.jbuilder
+++ b/app/views/v1/items/_item.json.jbuilder
@@ -3,7 +3,7 @@ json.set! "@type", "CreativeWork"
 json.set! "@id", item_object.at_id
 json.set! "isPartOf/collection", item_object.collection_url
 json.id item_object.unique_id
-json.slug item_object.slug
+json.slug CreateURLSlug.call(item_object.name)
 json.name item_object.name
 json.description item_object.description.to_s
 json.image item_object.image

--- a/app/views/v1/items/_item.json.jbuilder
+++ b/app/views/v1/items/_item.json.jbuilder
@@ -3,7 +3,7 @@ json.set! "@type", "CreativeWork"
 json.set! "@id", item_object.at_id
 json.set! "isPartOf/collection", item_object.collection_url
 json.id item_object.unique_id
-json.slug CreateURLSlug.call(item_object.name)
+json.slug item_object.slug
 json.name item_object.name
 json.description item_object.description.to_s
 json.image item_object.image

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -46,9 +46,9 @@ ActiveRecord::Schema.define(version: 20150604150434) do
     t.integer  "image_file_size",    limit: 4
     t.datetime "image_updated_at"
     t.text     "short_description",  limit: 65535
-    t.text     "about",              limit: 65535
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.text     "about",              limit: 65535
     t.text     "copyright",          limit: 65535
   end
 

--- a/spec/decorators/v1/item_json_decorator_spec.rb
+++ b/spec/decorators/v1/item_json_decorator_spec.rb
@@ -60,10 +60,10 @@ RSpec.describe V1::ItemJSONDecorator do
   end
 
   describe "#slug" do
-    let(:item) { double(Item, slug: "sluggish") }
+    let(:item) { double(Item, name: "sluggish") }
 
     it "Calls the slug generator" do
-      expect(CreateURLSlug).to receive(:call).with(item.slug)
+      expect(CreateURLSlug).to receive(:call).with(item.name)
       subject.slug
     end
   end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -99,10 +99,5 @@ RSpec.describe Item do
       subject.collection = Collection.new
       expect(subject.beehive_url).to include(Rails.configuration.settings.beehive_url)
     end
-
-    it "uses name for the slug" do
-      subject.name = "Slug"
-      expect(subject.slug).to eq(subject.name)
-    end
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -93,11 +93,4 @@ RSpec.describe Item do
       expect(subject).to respond_to(:collection)
     end
   end
-
-  describe "#beehive_url" do
-    it "is a url to the beehive server" do
-      subject.collection = Collection.new
-      expect(subject.beehive_url).to include(Rails.configuration.settings.beehive_url)
-    end
-  end
 end


### PR DESCRIPTION
**WHAT** Some methods were removed from the Item model because they had inherent redundancies

**WHY** To simplify the Item model

**HOW** I removed the two methods in question, and changed some of the view and decorator code so that the service classes are called directly instead of having callbacks embedded in the Item model