### PR TITLE
DEC-421: Add strong item delete warning

### DIFF
--- a/app/decorators/delete_panel.rb
+++ b/app/decorators/delete_panel.rb
@@ -3,7 +3,7 @@ require "draper"
 class DeletePanel < Draper::Decorator
   attr_accessor :path
 
-  # If providing a query_object, it must implement "can_delete"
+  # If providing a query_object, it must implement "can_delete?"
   def display(query_object = nil)
     yield(self) if block_given?
 
@@ -11,7 +11,7 @@ class DeletePanel < Draper::Decorator
     # retain the current behavior for all other objects
     can_delete = true
     if query_object
-      can_delete = query_object.can_delete
+      can_delete = query_object.can_delete?
     end
     h.render partial: "shared/delete_panel", locals: { default_name: default_name, path: path, i18n_key_base: i18n_key_base, can_delete: can_delete }
   end

--- a/app/decorators/delete_panel.rb
+++ b/app/decorators/delete_panel.rb
@@ -3,10 +3,17 @@ require "draper"
 class DeletePanel < Draper::Decorator
   attr_accessor :path
 
-  def display
+  # If providing a query_object, it must implement "can_delete"
+  def display(query_object = nil)
     yield(self) if block_given?
 
-    h.render partial: "shared/delete_panel", locals: { default_name: default_name, path: path, i18n_key_base: i18n_key_base }
+    # for now allow the delete when no query object is given to
+    # retain the current behavior for all other objects
+    can_delete = true
+    if query_object
+      can_delete = query_object.can_delete
+    end
+    h.render partial: "shared/delete_panel", locals: { default_name: default_name, path: path, i18n_key_base: i18n_key_base, can_delete: can_delete }
   end
 
   def default_name

--- a/app/queries/item_query.rb
+++ b/app/queries/item_query.rb
@@ -27,7 +27,7 @@ class ItemQuery
     relation.find_by!(unique_id: id)
   end
 
-  def can_delete
+  def can_delete?
     relation.showcases.count == 0
   end
 end

--- a/app/queries/item_query.rb
+++ b/app/queries/item_query.rb
@@ -26,4 +26,8 @@ class ItemQuery
   def public_find(id)
     relation.find_by!(unique_id: id)
   end
+
+  def can_delete
+    relation.showcases.count == 0
+  end
 end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -35,7 +35,7 @@
       </div>
     <% end %>
 
-    <%= DeletePanel.new(@item.object).display %>
+    <%= DeletePanel.new(@item.object).display(ItemQuery.new(@item)) %>
 
   </div>
   <div class="col-md-4">

--- a/app/views/shared/_delete_panel.html.erb
+++ b/app/views/shared/_delete_panel.html.erb
@@ -1,10 +1,26 @@
+<%
+if can_delete
+  message = "message"
+  button_class = "btn btn-small btn-default btn-danger"
+else
+  message = "cannot_delete_message"
+  button_class = "btn btn-small btn-default btn-danger disabled"
+end
+%>
+
 <div class="panel panel-danger">
   <div class="panel-heading">
     <h3 class="panel-title"><%= t('.title', default: 'Proceed with caution') %></h3>
   </div>
   <div class="panel-body">
     <h4 class=""><%= t("#{i18n_key_base}.heading", default: "Delete this #{default_name}") %></h4>
-    <p class=""><%= t("#{i18n_key_base}.message", default: "Proceed with caution. This will remove the #{default_name} and all associated data. ") %></p>
-    <%= link_to content_tag('span', t("#{i18n_key_base}.heading", default: "Delete this #{default_name}") , class: ''), path, class: "btn btn-small btn-default btn-danger", method: :delete, data: { confirm: "#{t("#{i18n_key_base}.message", default: "Proceed with caution. This will remove the #{default_name} and all associated data. ")} Are you sure you wish to continue?" } %>
+    <p class=""><%= t("#{i18n_key_base}.#{message}", default: "Proceed with caution. This will remove the #{default_name} and all associated data. ") %></p>
+    <%= link_to content_tag('span', t("#{i18n_key_base}.heading", default: "Delete this #{default_name}") , class: ''),
+                path,
+                class: button_class,
+                method: :delete,
+                data: { confirm: "#{t("#{i18n_key_base}.message",
+                        default: "Proceed with caution. This will remove the #{default_name} and all associated data. ")} Are you sure you wish to continue?" }
+    %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -142,7 +142,8 @@ en:
       success: "Item deleted"
     delete_panel:
       heading: Delete this Item
-      message: "Proceed with caution. This will also remove all the items information from the site ."
+      message: "Proceed with caution. This will also remove all the items information from the site."
+      cannot_delete_message: "Deleting this item is disabled due to its usage in one or more showcases. Please first remove the item from these showcases."
   item_children:
     new:
       title: "Upload Additional Resources"

--- a/spec/decorators/delete_panel_spec.rb
+++ b/spec/decorators/delete_panel_spec.rb
@@ -6,8 +6,22 @@ RSpec.describe DeletePanel do
 
   it "renders the delete section template" do
     # removed because it errors in a strange way
-    expect(subject.h).to receive(:render).with(partial: "shared/delete_panel", locals: { default_name: "Object", path: object, i18n_key_base: "objects.delete_panel" })
+    required_locals = { default_name: "Object", path: object, i18n_key_base: "objects.delete_panel", can_delete: true }
+    expect(subject.h).to receive(:render).with(partial: "shared/delete_panel", locals: required_locals)
     subject.display
+  end
+
+  it "allows delete by default" do
+    required_locals = { default_name: "Object", path: object, i18n_key_base: "objects.delete_panel", can_delete: true }
+    expect(subject.h).to receive(:render).with(partial: "shared/delete_panel", locals: required_locals)
+    subject.display
+  end
+
+  it "uses a custom query object to check if it can be deleted" do
+    expect(object).to receive(:can_delete).and_return(false)
+    required_locals = { default_name: "Object", path: object, i18n_key_base: "objects.delete_panel", can_delete: false }
+    allow(subject.h).to receive(:render).with(partial: "shared/delete_panel", locals: required_locals)
+    subject.display(object)
   end
 
   it "allows the path to be set" do

--- a/spec/decorators/delete_panel_spec.rb
+++ b/spec/decorators/delete_panel_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe DeletePanel do
   end
 
   it "uses a custom query object to check if it can be deleted" do
-    expect(object).to receive(:can_delete).and_return(false)
+    expect(object).to receive(:can_delete?).and_return(false)
     required_locals = { default_name: "Object", path: object, i18n_key_base: "objects.delete_panel", can_delete: false }
     allow(subject.h).to receive(:render).with(partial: "shared/delete_panel", locals: required_locals)
     subject.display(object)


### PR DESCRIPTION
**Why**: We are adding a list of related showcases to the item edit view, but we also want to additionally give a stronger warning to the user near the delete button if the item is in use by a showcase.

**How**: There are several pages that use the DeletePanel object to render this panel. I extended this class to allow injection of a query object that implements a can_delete method. I wanted to make this as abstract as possible to let those queries answer a high level question of whether or not an object can or cannot be deleted. I also changed it to disable the delete button for now until we implement a cascading delete for items. Once we implement that it will be easy enough to change the warning message in en.yml to give a strong message about what will happen when they hit delete.

In the future, we may need to also change this a bit more to allow those queries to customize the message that gets printed. For instance, if it checks multiple associations, then which one(s) have related records? For now I didn't think this was necessary.