### PR TITLE
Process uploaded images in the background.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ config/database.yml
 
 # Ignore all logfiles and tempfiles.
 /log/*.log
+/log/*.log.*
 /tmp
 /public/system/*
 /vendor/bundle

--- a/Gemfile
+++ b/Gemfile
@@ -3,13 +3,13 @@ source "https://rubygems.org"
 # Don't load all mime types
 gem "mime-types", "~> 2.6.1", require: "mime/types/columnar"
 
-# Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
+# Bundle edge Rails instead: gem "rails", github: "rails/rails"
 gem "rails", "~> 4.2.0"
 
 gem "responders", "~> 2.0"
 
 # See https://github.com/sstephenson/execjs#readme for more supported runtimes
-# gem 'therubyracer',  platforms: :ruby
+# gem "therubyracer",  platforms: :ruby
 
 gem "mysql2"
 
@@ -19,9 +19,10 @@ gem "jbuilder", "~> 2.0"
 gem "sdoc", "~> 0.4.0",          group: :doc
 
 gem "paperclip"
+gem "fastimage"
 
-gem "hesburgh_infrastructure", git: "https://github.com/ndlib/hesburgh_infrastructure.git"
-gem "hesburgh_api", git: "https://github.com/ndlib/hesburgh_api.git"
+gem "hesburgh_infrastructure", github: "ndlib/hesburgh_infrastructure"
+gem "hesburgh_api", github: "ndlib/hesburgh_api"
 
 gem "simple_form", "~> 3.1.0"
 
@@ -45,6 +46,9 @@ gem "paper_trail", "~> 4.0.0.beta2"
 
 gem "faraday"
 gem "faraday_middleware"
+
+# Background processing
+gem "sneakers"
 
 # For Errbit
 gem "airbrake"
@@ -76,7 +80,7 @@ gem "autoprefixer-rails"
 group :development, :test do
   gem "rubocop", require: false
 
-  gem "i18n-debug"
+  # gem "i18n-debug"
   gem "pry"
   gem "pry-nav"
   gem "rspec-rails"
@@ -109,10 +113,10 @@ gem "rack-cache"
 gem "dalli"
 
 # Use ActiveModel has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
+# gem "bcrypt", "~> 3.1.7"
 
 # Use unicorn as the app server
-# gem 'unicorn'
+# gem "unicorn"
 
 # Use Capistrano for deployment
 gem "capistrano", "~> 3.1"
@@ -120,4 +124,4 @@ gem "capistrano-rails", "~> 1.1"
 gem "capistrano-npm"
 
 # Use debugger
-# gem 'debugger', group: [:development, :test]
+# gem "debugger", group: [:development, :test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,5 @@
 GIT
-  remote: git://github.com/reactjs/react-rails.git
-  revision: 97ae83f089acef19518980c2619feff47f2a0e46
-  specs:
-    react-rails (1.0.0.pre)
-      connection_pool
-      execjs
-      rails (>= 3.1)
-      react-source (~> 0.12)
-
-GIT
-  remote: https://github.com/ndlib/hesburgh_api.git
+  remote: git://github.com/ndlib/hesburgh_api.git
   revision: 7e65d334a0e3262ad51c02670792da44aaa98c3b
   specs:
     hesburgh_api (0.0.3)
@@ -21,11 +11,21 @@ GIT
       typhoeus
 
 GIT
-  remote: https://github.com/ndlib/hesburgh_infrastructure.git
+  remote: git://github.com/ndlib/hesburgh_infrastructure.git
   revision: 2b9af6f2d5f2a588703d03cd1dd91c09e883f183
   specs:
     hesburgh_infrastructure (0.2.5)
       rails
+
+GIT
+  remote: git://github.com/reactjs/react-rails.git
+  revision: 97ae83f089acef19518980c2619feff47f2a0e46
+  specs:
+    react-rails (1.0.0.pre)
+      connection_pool
+      execjs
+      rails (>= 3.1)
+      react-source (~> 0.12)
 
 GEM
   remote: https://rubygems.org/
@@ -69,6 +69,7 @@ GEM
     airbrake (4.1.0)
       builder
       multi_json
+    amq-protocol (1.9.2)
     arel (6.0.0)
     ast (2.0.0)
     astrolabe (1.3.0)
@@ -87,6 +88,8 @@ GEM
     browserify-rails (0.7.2)
       sprockets (~> 2.0)
     builder (3.2.2)
+    bunny (1.7.0)
+      amq-protocol (>= 1.9.2)
     capistrano (3.4.0)
       i18n
       rake (>= 10.0.0)
@@ -151,7 +154,7 @@ GEM
     erubis (2.7.0)
     ethon (0.7.3)
       ffi (>= 1.3.0)
-    excon (0.44.2)
+    excon (0.45.3)
     execjs (2.5.2)
     factory_girl (4.2.0)
       activesupport (>= 3.0.0)
@@ -164,6 +167,8 @@ GEM
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.9.1)
       faraday (>= 0.7.4, < 0.10)
+    fastimage (1.6.4)
+      addressable (~> 2.3, >= 2.3.5)
     ffi (1.9.6)
     formatador (0.2.5)
     globalid (0.3.5)
@@ -191,8 +196,6 @@ GEM
     hike (1.2.3)
     hitimes (1.2.2)
     i18n (0.7.0)
-    i18n-debug (1.0.0)
-      i18n (~> 0.0)
     jbuilder (2.2.3)
       activesupport (>= 3.0.0, < 5)
       multi_json (~> 1.2)
@@ -335,9 +338,12 @@ GEM
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
+    serverengine (1.5.10)
+      sigdump (~> 0.2.2)
     showdown-rails (0.0.4)
       actionpack (>= 3.1)
       railties (>= 3.1)
+    sigdump (0.2.2)
     simple_form (3.1.0)
       actionpack (~> 4.0)
       activemodel (~> 4.0)
@@ -347,6 +353,11 @@ GEM
       simplecov-html (~> 0.8.0)
     simplecov-html (0.8.0)
     slop (3.6.0)
+    sneakers (1.0.4)
+      bunny (~> 1.7.0)
+      serverengine (~> 1.5.5)
+      thor
+      thread (~> 0.1.7)
     sort_alphabetical (1.0.1)
       unicode_utils (>= 1.2.2)
     spring (1.1.3)
@@ -371,6 +382,7 @@ GEM
       libv8 (~> 3.16.14.0)
       ref
     thor (0.19.1)
+    thread (0.1.7)
     thread_safe (0.3.5)
     tilt (1.4.1)
     timers (4.0.1)
@@ -420,6 +432,7 @@ DEPENDENCIES
   faker
   faraday
   faraday_middleware
+  fastimage
   guard
   guard-bundler
   guard-coffeescript
@@ -428,7 +441,6 @@ DEPENDENCIES
   guard-spring
   hesburgh_api!
   hesburgh_infrastructure!
-  i18n-debug
   jbuilder (~> 2.0)
   jquery-datatables-rails (~> 3.3.0)
   jquery-rails (= 3.1.2)
@@ -453,6 +465,7 @@ DEPENDENCIES
   sdoc (~> 0.4.0)
   showdown-rails
   simple_form (~> 3.1.0)
+  sneakers
   sort_alphabetical
   spring
   spring-commands-rspec

--- a/app/assets/javascripts/components/ItemShowImageBox.jsx
+++ b/app/assets/javascripts/components/ItemShowImageBox.jsx
@@ -5,6 +5,7 @@ var ItemShowImageBox = React.createClass({
       React.PropTypes.string,
       React.PropTypes.object,
     ]),
+    thumbnailSrc: React.PropTypes.string,
     itemID: React.PropTypes.string.isRequired,
   },
 
@@ -18,7 +19,7 @@ var ItemShowImageBox = React.createClass({
     return (
       <div className="hc-item-show-image-box">
         <ItemImageZoomButton image={this.props.image} itemID={this.props.itemID} />
-        <Thumbnail image={this.props.image} />
+        <Thumbnail image={this.props.image} thumbnailSrc={this.props.thumbnailSrc} />
       </div>
     );
   }

--- a/app/assets/javascripts/components/OpenSeadragonViewer.jsx
+++ b/app/assets/javascripts/components/OpenSeadragonViewer.jsx
@@ -3,7 +3,7 @@ var React = require("react");
 var OpenSeadragon = require("../openseadragon.js");
 var OpenSeadragonViewer = React.createClass({
   propTypes: {
-    image: React.PropTypes.object,
+    image: React.PropTypes.object.isRequired,
     containerID: React.PropTypes.string.isRequired,
     fullPage: React.PropTypes.bool,
     height: React.PropTypes.number,

--- a/app/assets/javascripts/components/ReactDropzone.jsx
+++ b/app/assets/javascripts/components/ReactDropzone.jsx
@@ -26,7 +26,7 @@ var ReactDropzone = React.createClass({
     return {
       closed: false,
       hasFiles: false,
-    }
+    };
   },
 
   componentDidMount: function() {
@@ -44,7 +44,7 @@ var ReactDropzone = React.createClass({
 
   options: function() {
     return {
-      paramName: "item[image]",
+      paramName: "item[uploaded_image]",
       acceptedFiles: "image/*",
       addRemoveLinks: true,
       autoProcessQueue: true,

--- a/app/assets/javascripts/components/Thumbnail.jsx
+++ b/app/assets/javascripts/components/Thumbnail.jsx
@@ -7,6 +7,7 @@ var Thumbnail = React.createClass({
       React.PropTypes.string,
       React.PropTypes.object,
     ]),
+    thumbnailSrc: React.PropTypes.string,
   },
 
   getInitialState: function() {
@@ -26,17 +27,21 @@ var Thumbnail = React.createClass({
   },
 
   componentDidMount: function() {
-    if (typeof(this.props.image) == 'object') {
-      this.setImage(this.props.image);
-    } else {
-      $.get(this.props.image, function(result) {
-        this.setImage(result);
-      }.bind(this));
+    if (!this.props.thumbnailSrc) {
+      if (typeof(this.props.image) == 'object') {
+        this.setImage(this.props.image);
+      } else {
+        $.get(this.props.image, function(result) {
+          this.setImage(result);
+        }.bind(this));
+      }
     }
   },
 
   thumbnailSrc: function() {
-    if (this.state.image) {
+    if (this.props.thumbnailSrc) {
+      return this.props.thumbnailSrc;
+    } else if (this.state.image) {
       return this.state.image.contentUrl;
     } else {
       return '/images/blank.png';
@@ -46,7 +51,7 @@ var Thumbnail = React.createClass({
   classes: function() {
     var classes = classNames({
       'hc-thumbnail': true,
-      'hc-thumbnail-loading': !this.state.image
+      'hc-thumbnail-loading': !this.props.thumbnailSrc && !this.state.image
     });
     return classes;
   },

--- a/app/assets/javascripts/components/showcase_editor/Item.jsx
+++ b/app/assets/javascripts/components/showcase_editor/Item.jsx
@@ -27,6 +27,10 @@ var Item = React.createClass({
 
   render: function() {
     var honeypot_image = this.props.item.links.image;
+    if (honeypot_image == null) {
+      return null;
+    }
+
     var dragContent = (
       <HoneypotImage honeypot_image={honeypot_image} style="small" cssStyle={{height: '100px', margin: '5px'}} />
     );
@@ -34,7 +38,8 @@ var Item = React.createClass({
       <div className='cursor-grab' onMouseDown={this.onMouseDown} style={this.style()}>
         <DragContent content={dragContent} dragging={this.state.dragging} left={this.state.left} top={this.state.top} />
         <HoneypotImage honeypot_image={honeypot_image} style="small" cssStyle={{height: '100px', margin: '5px'}} />
-      </div>);
+      </div>
+    );
   }
 });
 module.exports = Item;

--- a/app/assets/javascripts/datatables.js.coffee
+++ b/app/assets/javascripts/datatables.js.coffee
@@ -2,11 +2,12 @@ ItemDataTablesIndexes =
   checkbox: 0
   image: 1
   name: 2
-  published: 3
-  updatedAt: 4
-  updatedAtTimestamps: 5
-  sortableName: 6
-  originalFilename: 7
+  status: 3
+  published: 4
+  updatedAt: 5
+  updatedAtTimestamps: 6
+  sortableName: 7
+  originalFilename: 8
 
 class ItemDataTable
   constructor: (@tableElement) ->
@@ -39,9 +40,14 @@ class ItemDataTable
         sortable: false
         searchable: false
       ,
-        targets: ItemDataTablesIndexes['published']
-        sortable: false
+        targets: ItemDataTablesIndexes['status']
+        sortable: true
         searchable: true
+      ,
+        targets: ItemDataTablesIndexes['published']
+        sortable: true
+        searchable: true
+        visible: false
       ,
         targets: ItemDataTablesIndexes['updatedAtTimestamps']
         sortable: false

--- a/app/assets/stylesheets/items.css.scss
+++ b/app/assets/stylesheets/items.css.scss
@@ -23,6 +23,16 @@
     -o-transition: all 0.2s ease-in-out;
     transition: all 0.2s ease-in-out;
   }
+
+  .item-publishing,
+  .item-status {
+    white-space: nowrap;
+  }
+
+  .item-description {
+    max-height: 100px;
+    overflow: hidden;
+  }
 }
 
 .item-show-children {

--- a/app/controllers/exhibits_controller.rb
+++ b/app/controllers/exhibits_controller.rb
@@ -27,6 +27,12 @@ class ExhibitsController < ApplicationController
   private
 
   def save_params
-    params.require(:exhibit).permit([:description, :image, :short_description, :about, :copyright])
+    params.require(:exhibit).permit([
+      :description,
+      :uploaded_image,
+      :short_description,
+      :about,
+      :copyright
+    ])
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -76,7 +76,7 @@ class ItemsController < ApplicationController
   protected
 
   def save_params
-    params.require(:item).permit(:name, :description, :image, :manuscript_url, :transcription)
+    params.require(:item).permit(:name, :description, :uploaded_image, :manuscript_url, :transcription)
   end
 
   def collection

--- a/app/controllers/showcases_controller.rb
+++ b/app/controllers/showcases_controller.rb
@@ -104,7 +104,13 @@ class ShowcasesController < ApplicationController
   protected
 
   def save_params
-    params.require(:showcase).permit([:name_line_1, :name_line_2, :description, :image, :order])
+    params.require(:showcase).permit([
+      :name_line_1,
+      :name_line_2,
+      :description,
+      :uploaded_image,
+      :order
+    ])
   end
 
   def showcase

--- a/app/decorators/item_decorator.rb
+++ b/app/decorators/item_decorator.rb
@@ -17,6 +17,20 @@ class ItemDecorator < Draper::Decorator
     end
   end
 
+  def status_text
+    if object.honeypot_image
+      status_text_span(className: "text-success", icon: "ok", text: h.t("status.complete"))
+    else
+      status_text_span(className: "text-info", icon: "minus", text: h.t("status.processing"))
+    end
+  end
+
+  def status_text_span(className:, icon:, text:)
+    h.content_tag("span", class: className) do
+      h.content_tag("i", "", class: "glyphicon glyphicon-#{icon}") + " " + text
+    end
+  end
+
   def back_path
     if is_parent?
       h.collection_path(object.collection_id)
@@ -26,7 +40,7 @@ class ItemDecorator < Draper::Decorator
   end
 
   def show_image_box
-    h.react_component "ItemShowImageBox", image: image_json, itemID: object.id.to_s
+    h.react_component "ItemShowImageBox", image: image_json, thumbnailSrc: thumbnail_url, itemID: object.id.to_s
   end
 
   def item_meta_data_form
@@ -62,6 +76,18 @@ class ItemDecorator < Draper::Decorator
 
   def page_name
     h.render partial: "/items/item_name", locals: { item: self }
+  end
+
+  def thumbnail_url
+    if object.image.exists?(:thumb)
+      object.image.url(:thumb)
+    else
+      return nil
+    end
+  end
+
+  def thumbnail
+    h.react_component("Thumbnail", image: image_json, thumbnailSrc: thumbnail_url)
   end
 
   private

--- a/app/jobs/process_image_job.rb
+++ b/app/jobs/process_image_job.rb
@@ -1,0 +1,8 @@
+class ProcessImageJob < ActiveJob::Base
+  queue_as :uploaded_images
+
+  def perform(object:, upload_field: "uploaded_image", image_field: "image")
+    ProcessUploadedImage.call(object: object, upload_field: upload_field, image_field: image_field)
+    QueueJob.call(SaveHoneypotImageJob, object: object, image_field: image_field)
+  end
+end

--- a/app/jobs/save_honeypot_image_job.rb
+++ b/app/jobs/save_honeypot_image_job.rb
@@ -1,0 +1,7 @@
+class SaveHoneypotImageJob < ActiveJob::Base
+  queue_as :honeypot_images
+
+  def perform(object:, image_field: "image")
+    SaveHoneypotImage.call(object: object, image_field: image_field)
+  end
+end

--- a/app/models/exhibit.rb
+++ b/app/models/exhibit.rb
@@ -3,8 +3,13 @@ class Exhibit < ActiveRecord::Base
   belongs_to :collection
   has_one :honeypot_image
 
-  has_attached_file :image, restricted_characters: /[&$+,\/:;=?@<>\[\]{}\|\\^~%#]/
+  has_attached_file :image,
+                    restricted_characters: /[&$+,\/:;=?@<>\[\]{}\|\\^~%#]/
+  has_attached_file :uploaded_image,
+                    restricted_characters: /[&$+,\/:;=?@<>\[\]{}\|\\^~%#]/
+
   validates_attachment_content_type :image, content_type: /\Aimage\/.*\Z/
+  validates_attachment_content_type :uploaded_image, content_type: /\Aimage\/.*\Z/
 
   def items_json_url
     "/api/collections/#{collection_id}/items.json?include=image"

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -10,14 +10,23 @@ class Item < ActiveRecord::Base
   has_many :showcases, -> { distinct }, through: :sections
   has_one :honeypot_image
 
-  has_attached_file :image, restricted_characters: /[&$+,\/:;=?@<>\[\]{}\|\\^~%#]/
+  has_attached_file :image,
+                    restricted_characters: /[&$+,\/:;=?@<>\[\]{}\|\\^~%#]/,
+                    styles: {
+                      thumb: "300x300>",
+                      section: "x800>"
+                    }
+
+  has_attached_file :uploaded_image,
+                    restricted_characters: /[&$+,\/:;=?@<>\[\]{}\|\\^~%#]/
 
   validates :name, :collection, presence: true
-  validates :image, attachment_presence: true
+  # validates :image, attachment_presence: true
 
   validate :manuscript_url_is_valid_uri
 
   validates_attachment_content_type :image, content_type: /\Aimage\/.*\Z/
+  validates_attachment_content_type :uploaded_image, content_type: /\Aimage\/.*\Z/
 
   private
 

--- a/app/models/showcase.rb
+++ b/app/models/showcase.rb
@@ -5,11 +5,15 @@ class Showcase < ActiveRecord::Base
   has_many :items, through: :sections
   has_one :honeypot_image
 
-  has_attached_file :image, restricted_characters: /[&$+,\/:;=?@<>\[\]{}\|\\^~%#]/
+  has_attached_file :image,
+                    restricted_characters: /[&$+,\/:;=?@<>\[\]{}\|\\^~%#]/
+  has_attached_file :uploaded_image,
+                    restricted_characters: /[&$+,\/:;=?@<>\[\]{}\|\\^~%#]/
+
   validates_attachment_content_type :image, content_type: /\Aimage\/.*\Z/
+  validates_attachment_content_type :uploaded_image, content_type: /\Aimage\/.*\Z/
 
   validates :name_line_1, :exhibit, presence: true
-  validates :image, attachment_presence: true
 
   has_paper_trail
 

--- a/app/queries/item_query.rb
+++ b/app/queries/item_query.rb
@@ -10,7 +10,7 @@ class ItemQuery
   end
 
   def only_top_level
-    relation.where(parent_id: nil)
+    relation.where(parent_id: nil).includes(:honeypot_image)
   end
 
   delegate :find, to: :relation

--- a/app/services/preprocess_image.rb
+++ b/app/services/preprocess_image.rb
@@ -1,0 +1,79 @@
+class PreprocessImage
+  MAX_PIXELS = 16000000
+  attr_reader :paperclip_attachment
+
+  def self.call(paperclip_attachment)
+    new(paperclip_attachment).process
+  end
+
+  def initialize(paperclip_attachment)
+    @paperclip_attachment = paperclip_attachment
+  end
+
+  def process
+    if processing_needed?
+      preprocess_attachment
+    end
+    attachment_path
+  end
+
+  private
+
+  def preprocess_attachment
+    processor_attachment.reprocess!
+  end
+
+  def uploaded_image
+    paperclip_attachment
+  end
+
+  def processing_needed?
+    uploaded_image.exists? && (tiff? || exceeds_max_pixels?)
+  end
+
+  def tiff?
+    uploaded_image.content_type == "image/tiff"
+  end
+
+  def exceeds_max_pixels?
+    original_pixels > MAX_PIXELS
+  end
+
+  def original_dimensions
+    @original_dimensions ||= FastImage.size(uploaded_image.path)
+  end
+
+  def original_pixels
+    original_dimensions.inject(:*)
+  end
+
+  def processor_attachment
+    @processor_attachment ||= Paperclip::Attachment.new(:uploaded_image, uploaded_image.instance, processor_options)
+  end
+
+  def processor_options
+    new_options = uploaded_image.options.clone
+    new_options[:styles] = new_options[:styles].merge(processed: processor_style)
+    new_options
+  end
+
+  def processor_style
+    style = "#{MAX_PIXELS}@"
+    if tiff?
+      style = [style, :jpg]
+    end
+    style
+  end
+
+  def processed_path
+    @processed_path ||= processor_attachment.path(:processed)
+  end
+
+  def attachment_path
+    if processing_needed?
+      processed_path
+    else
+      uploaded_image.path
+    end
+  end
+end

--- a/app/services/process_uploaded_image.rb
+++ b/app/services/process_uploaded_image.rb
@@ -1,0 +1,62 @@
+class ProcessUploadedImage
+  attr_reader :object, :upload_field, :image_field
+
+  def self.call(*args)
+    new(*args).process
+  end
+
+  def initialize(object:, upload_field: "uploaded_image", image_field: "image")
+    @object = object
+    @upload_field = upload_field
+    @image_field = image_field
+  end
+
+  def process
+    if uploaded_image_exists?
+      process_uploaded_image
+    else
+      true
+    end
+  end
+
+  private
+
+  def process_uploaded_image
+    processed_path = PreprocessImage.call(uploaded_image)
+    copy_processed_image(processed_path)
+    begin
+      save_object
+    ensure
+      delete_processed_image(processed_path)
+    end
+  end
+
+  def save_object
+    if object.save
+      object
+    else
+      false
+    end
+  end
+
+  def uploaded_image_exists?
+    uploaded_image.exists?
+  end
+
+  def uploaded_image
+    object.send(upload_field)
+  end
+
+  def copy_processed_image(copy_path)
+    file = File.open(copy_path)
+    object.send("#{image_field}=", file)
+    file.close
+    object.send("#{upload_field}=", nil)
+  end
+
+  def delete_processed_image(processed_path)
+    if File.exists?(processed_path)
+      File.delete(processed_path)
+    end
+  end
+end

--- a/app/services/queue_job.rb
+++ b/app/services/queue_job.rb
@@ -1,0 +1,25 @@
+class QueueJob
+  attr_reader :job_class
+
+  def initialize(job_class)
+    @job_class = job_class
+  end
+
+  def queue(*args)
+    if process_in_background?
+      job_class.perform_later(*args)
+    else
+      job_class.perform_now(*args)
+    end
+  end
+
+  def self.call(job_class, *args)
+    new(job_class).queue(*args)
+  end
+
+  private
+
+  def process_in_background?
+    Rails.configuration.settings.background_processing
+  end
+end

--- a/app/services/save_exhibit.rb
+++ b/app/services/save_exhibit.rb
@@ -11,16 +11,22 @@ class SaveExhibit
   end
 
   def save
+    fix_image_param!
     exhibit.attributes = params
 
-    (exhibit.save && update_honeypot_image)
+    (exhibit.save && process_uploaded_image)
   end
 
   private
 
-  def update_honeypot_image
-    if params[:image]
-      SaveHoneypotImage.call(exhibit)
+  def fix_image_param!
+    # sometimes the form is sending an empty image value and this is causing paperclip to delete the image.
+    params.delete(:uploaded_image) if params[:uploaded_image].nil?
+  end
+
+  def process_uploaded_image
+    if params[:uploaded_image]
+      QueueJob.call(ProcessImageJob, object: exhibit)
     else
       true
     end

--- a/app/services/save_honeypot_image.rb
+++ b/app/services/save_honeypot_image.rb
@@ -1,12 +1,13 @@
 class SaveHoneypotImage
-  attr_reader :object
+  attr_reader :object, :image_field
 
-  def self.call(object)
-    new(object).save!
+  def self.call(*args)
+    new(*args).save!
   end
 
-  def initialize(object)
+  def initialize(object:, image_field: "image")
     @object = object
+    @image_field = image_field
   end
 
   def save!
@@ -29,7 +30,7 @@ class SaveHoneypotImage
     body = request.body.with_indifferent_access
     honeypot_image.json_response = body
 
-    honeypot_image.save
+    honeypot_image.save && object.save
   end
 
   def send_request
@@ -59,7 +60,7 @@ class SaveHoneypotImage
   end
 
   def object_image
-    object.image
+    object.send(image_field)
   end
 
   def upload_image

--- a/app/services/save_item.rb
+++ b/app/services/save_item.rb
@@ -16,7 +16,7 @@ class SaveItem
     item.attributes = params
     pre_process_name
 
-    if item.save && update_honeypot_image
+    if item.save && process_uploaded_image
       check_unique_id
 
       item
@@ -29,7 +29,7 @@ class SaveItem
 
   def pre_process_name
     if name_should_be_filename?
-      item.name = GenerateNameFromFilename.call(item.image_file_name)
+      item.name = GenerateNameFromFilename.call(item.uploaded_image_file_name)
     end
 
     item.sortable_name = SortableNameConverter.convert(item.name)
@@ -41,12 +41,12 @@ class SaveItem
 
   def fix_image_param!
     # sometimes the form is sending an empty image value and this is causing paperclip to delete the image.
-    params.delete(:image) if params[:image].nil?
+    params.delete(:uploaded_image) if params[:uploaded_image].nil?
   end
 
-  def update_honeypot_image
-    if params[:image]
-      SaveHoneypotImage.call(item)
+  def process_uploaded_image
+    if params[:uploaded_image]
+      QueueJob.call(ProcessImageJob, object: item)
     else
       true
     end

--- a/app/views/exhibits/_form.html.erb
+++ b/app/views/exhibits/_form.html.erb
@@ -2,4 +2,4 @@
 <%= f.input :short_description, input_html: { class: 'honeycomb_redactor'  } %>
 
 <%= HoneypotThumbnail.display(f.object.honeypot_image) %>
-<%= f.input :image, as: :file %>
+<%= f.input :uploaded_image, as: :file %>

--- a/app/views/items/_list.html.erb
+++ b/app/views/items/_list.html.erb
@@ -5,6 +5,7 @@
       <th><%= t('.title') %></th>
       <th></th>
       <th><%= t('.status') %></th>
+      <th><%= t('.publishing') %></th>
       <th><%= t('.updated_at') %></th>
       <th>Last Modified Timestamp</th>
       <th>Sortable Name</th>
@@ -17,14 +18,21 @@
         <td>
           <!--label><input type="checkbox" class="show-selected-menu" /></label-->
         </td>
-        <td class="image">
-          <%= link_to HoneypotThumbnail.display(item.honeypot_image), item.edit_path %>
+        <td class="image thing">
+          <% if item.image.exists? %>
+            <%= link_to item.thumbnail, item.edit_path %>
+          <% end %>
         </td>
         <td>
           <h4 class="media-heading"><%= h link_to item.name, item.edit_path %></h4>
-          <%= raw item.description %>
+          <div class="item-description">
+            <%= raw item.description %>
+          </div>
         </td>
-        <td>
+        <td class="item-status">
+          <%= item.status_text %>
+        </td>
+        <td class="item-publishing">
           <%= PublishedText.display(item) %>
         </td>
         <td>

--- a/app/views/showcases/_form.html.erb
+++ b/app/views/showcases/_form.html.erb
@@ -7,5 +7,5 @@
 
 <%= f.input :order %>
 
-<%= f.input :image, as: :file, required: true %>
+<%= f.input :uploaded_image, as: :file, required: true %>
 <%= HoneypotThumbnail.display(f.object.honeypot_image) %>

--- a/app/workers/honeypot_image_worker.rb
+++ b/app/workers/honeypot_image_worker.rb
@@ -1,0 +1,6 @@
+class HoneypotImageWorker < RetryWorker
+  from_queue "honeypot_images",
+             threads: 1,
+             timeout_job_after: 60,
+             prefetch: 1
+end

--- a/app/workers/retry_worker.rb
+++ b/app/workers/retry_worker.rb
@@ -1,0 +1,32 @@
+require "sneakers/handlers/maxretry"
+
+class RetryWorker < ActiveJob::QueueAdapters::SneakersAdapter::JobWrapper
+  WORKERS = 1
+
+  def self.from_queue(queue_name, options = {})
+    base_options = {
+      handler: Sneakers::Handlers::Maxretry,
+      arguments: {
+        :"x-dead-letter-exchange" => "#{queue_name}-retry",
+      },
+      routing_key: [queue_name],
+    }
+    options = options.merge(base_options)
+
+    super(queue_name, options)
+  end
+
+  def self.number_of_workers
+    self::WORKERS
+  end
+
+  def work(*args)
+    super(*args)
+  rescue StandardError => e
+    NotifyError.call(e, args: args)
+    logger.error e.message
+    logger.error args
+    logger.error e.backtrace.join("\n")
+    reject!
+  end
+end

--- a/app/workers/uploaded_image_worker.rb
+++ b/app/workers/uploaded_image_worker.rb
@@ -1,0 +1,8 @@
+class UploadedImageWorker < RetryWorker
+  WORKERS = 4
+
+  from_queue "uploaded_images",
+             threads: 1,
+             timeout_job_after: 60,
+             prefetch: 1
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,5 +38,7 @@ module ItemAdmin
     config.assets.precompile = [proc { |path| !File.extname(path).in?([".js", ".css", ".map", ".gzip", ""]) }, /(?:\/|\\|\A)application\.(css|js)$/]
 
     config.active_record.raise_in_transactional_callbacks = true
+
+    config.active_job.queue_adapter = :sneakers
   end
 end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -48,6 +48,20 @@ namespace :deploy do
   end
 end
 
+namespace :sneakers do
+  task :restart do
+    on roles(:all) do
+      within release_path do
+        with rails_env: fetch(:rack_env) do
+          execute :rake, "sneakers:restart"
+        end
+      end
+    end
+  end
+end
+
+after "deploy:restart", "sneakers:restart"
+
 before "npm:install", "npm:prune"
 
 after "deploy:finished", "airbrake:deploy"

--- a/config/initializers/development_overrides.rb
+++ b/config/initializers/development_overrides.rb
@@ -1,0 +1,7 @@
+if Rails.env.development?
+  Rails.application.configure do
+    if ENV["BACKGROUND_PROCESSING"]
+      config.settings.background_processing = true
+    end
+  end
+end

--- a/config/initializers/sneakers.rb
+++ b/config/initializers/sneakers.rb
@@ -1,0 +1,12 @@
+require "sneakers/handlers/maxretry"
+
+Sneakers.configure(
+  amqp: Rails.application.secrets.sneakers["amqp"],
+  vhost: Rails.application.secrets.sneakers["vhost"],
+  workers: 1,
+  heartbeat: 5,
+  exchange: "honeycomb",
+  exchange_type: "topic",
+  durable: true,
+  log: "log/sneakers.log",
+)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,6 +28,9 @@ en:
   published:
     published: 'Published'
     unpublished: 'Not published'
+  status:
+    complete: "OK"
+    processing: "Processing"
   buttons:
     save: 'Save'
     cancel: 'Cancel'
@@ -111,6 +114,8 @@ en:
       selected_items: "%{number} Item(s) Selected"
     list:
       title: 'Items'
+      status: Status
+      publishing: Publishing
       published: Published
       updated_at: 'Last Modified At'
     edit:

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -12,14 +12,25 @@
 
 development:
   secret_key_base: 02c9fddc8798f89f4ddd65c377d850b0ef9b420f576a577fc6157c96651cd81513584963a500c2779486cad19a571132f02c7c81f51e2cc1ea39c95d58f424bc
+  sneakers: &sneakers_local
+    amqp: 'amqp://guest:guest@localhost:5672'
+    vhost: '/'
 
 test:
   secret_key_base: 8d65b0aaf1ef46505ae365b1afa217794aeb80ffdec65d7f61b9b8d1d619b2e762955649dfb80f790e1c33689b2c3934b14fe1d57babbf2da7eb5e07d9682f78
+  sneakers:
+    <<: *sneakers_local
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.
 pre_production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+  sneakers:
+    amqp: <%= ENV["SNEAKERS_AMQP"] %>
+    vhost: <%= ENV["SNEAKERS_VHOST"] %>
 
 production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+  sneakers:
+    amqp: <%= ENV["SNEAKERS_AMQP"] %>
+    vhost: <%= ENV["SNEAKERS_VHOST"] %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,6 +1,7 @@
 # Store non-sensitive configuration settings here.  Acessible from Rails.configuration.settings
 defaults: &defaults
   cas_base: 'https://cas.library.nd.edu/cas'
+  background_processing: true
 
 local: &local
   <<: *defaults
@@ -12,9 +13,11 @@ vm: &vm
 
 development:
   <<: *local
+  background_processing: false
 
 test:
   <<: *local
+  background_processing: false
 
 pre_production:
   <<: *vm

--- a/db/migrate/20150425014820_add_uploaded_image_to_items.rb
+++ b/db/migrate/20150425014820_add_uploaded_image_to_items.rb
@@ -1,0 +1,5 @@
+class AddUploadedImageToItems < ActiveRecord::Migration
+  def change
+    add_attachment :items, :uploaded_image
+  end
+end

--- a/db/migrate/20150521170601_add_uploaded_image_to_exhibits_and_showcases.rb
+++ b/db/migrate/20150521170601_add_uploaded_image_to_exhibits_and_showcases.rb
@@ -1,0 +1,7 @@
+class AddUploadedImageToExhibitsAndShowcases < ActiveRecord::Migration
+  def change
+    add_attachment :exhibits, :uploaded_image
+
+    add_attachment :showcases, :uploaded_image
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -40,18 +40,22 @@ ActiveRecord::Schema.define(version: 20150616185505) do
   add_index "collections", ["unique_id"], name: "index_collections_on_unique_id", using: :btree
 
   create_table "exhibits", force: :cascade do |t|
-    t.text     "name",               limit: 65535
-    t.text     "description",        limit: 65535
-    t.integer  "collection_id",      limit: 4
-    t.string   "image_file_name",    limit: 255
-    t.string   "image_content_type", limit: 255
-    t.integer  "image_file_size",    limit: 4
+    t.text     "name",                        limit: 65535
+    t.text     "description",                 limit: 65535
+    t.integer  "collection_id",               limit: 4
+    t.string   "image_file_name",             limit: 255
+    t.string   "image_content_type",          limit: 255
+    t.integer  "image_file_size",             limit: 4
     t.datetime "image_updated_at"
-    t.text     "short_description",  limit: 65535
+    t.text     "short_description",           limit: 65535
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.text     "about",              limit: 65535
-    t.text     "copyright",          limit: 65535
+    t.text     "about",                       limit: 65535
+    t.text     "copyright",                   limit: 65535
+    t.string   "uploaded_image_file_name",    limit: 255
+    t.string   "uploaded_image_content_type", limit: 255
+    t.integer  "uploaded_image_file_size",    limit: 4
+    t.datetime "uploaded_image_updated_at"
   end
 
   create_table "honeypot_images", force: :cascade do |t|
@@ -67,22 +71,26 @@ ActiveRecord::Schema.define(version: 20150616185505) do
   add_index "honeypot_images", ["item_id"], name: "index_honeypot_images_on_item_id", using: :btree
 
   create_table "items", force: :cascade do |t|
-    t.text     "name",               limit: 65535
-    t.text     "description",        limit: 65535
+    t.text     "name",                        limit: 65535
+    t.text     "description",                 limit: 65535
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "collection_id",      limit: 4
-    t.string   "image_file_name",    limit: 255
-    t.string   "image_content_type", limit: 255
-    t.integer  "image_file_size",    limit: 4
+    t.integer  "collection_id",               limit: 4
+    t.string   "image_file_name",             limit: 255
+    t.string   "image_content_type",          limit: 255
+    t.integer  "image_file_size",             limit: 4
     t.datetime "image_updated_at"
-    t.text     "sortable_name",      limit: 65535
-    t.integer  "parent_id",          limit: 4
-    t.string   "manuscript_url",     limit: 255
-    t.boolean  "published",          limit: 1
-    t.string   "unique_id",          limit: 255
-    t.text     "transcription",      limit: 65535
-    t.text     "metadata",           limit: 4294967295
+    t.text     "sortable_name",               limit: 65535
+    t.integer  "parent_id",                   limit: 4
+    t.string   "manuscript_url",              limit: 255
+    t.boolean  "published",                   limit: 1
+    t.string   "unique_id",                   limit: 255
+    t.text     "transcription",               limit: 65535
+    t.text     "metadata",                    limit: 4294967295
+    t.string   "uploaded_image_file_name",    limit: 255
+    t.string   "uploaded_image_content_type", limit: 255
+    t.integer  "uploaded_image_file_size",    limit: 4
+    t.datetime "uploaded_image_updated_at"
   end
 
   add_index "items", ["collection_id"], name: "index_items_on_collection_id", using: :btree
@@ -106,19 +114,23 @@ ActiveRecord::Schema.define(version: 20150616185505) do
   add_index "sections", ["unique_id"], name: "index_sections_on_unique_id", using: :btree
 
   create_table "showcases", force: :cascade do |t|
-    t.text     "name_line_1",        limit: 65535
-    t.text     "description",        limit: 65535
-    t.integer  "exhibit_id",         limit: 4
-    t.string   "image_file_name",    limit: 255
-    t.string   "image_content_type", limit: 255
-    t.integer  "image_file_size",    limit: 4
+    t.text     "name_line_1",                 limit: 65535
+    t.text     "description",                 limit: 65535
+    t.integer  "exhibit_id",                  limit: 4
+    t.string   "image_file_name",             limit: 255
+    t.string   "image_content_type",          limit: 255
+    t.integer  "image_file_size",             limit: 4
     t.datetime "image_updated_at"
     t.datetime "updated_at"
     t.datetime "created_at"
-    t.boolean  "published",          limit: 1
-    t.string   "unique_id",          limit: 255
-    t.integer  "order",              limit: 4
-    t.string   "name_line_2",        limit: 255
+    t.boolean  "published",                   limit: 1
+    t.string   "unique_id",                   limit: 255
+    t.integer  "order",                       limit: 4
+    t.string   "name_line_2",                 limit: 255
+    t.string   "uploaded_image_file_name",    limit: 255
+    t.string   "uploaded_image_content_type", limit: 255
+    t.integer  "uploaded_image_file_size",    limit: 4
+    t.datetime "uploaded_image_updated_at"
   end
 
   add_index "showcases", ["order"], name: "index_showcases_on_order", using: :btree

--- a/lib/tasks/sneakers.rake
+++ b/lib/tasks/sneakers.rake
@@ -1,0 +1,107 @@
+require 'sneakers'
+require 'sneakers/runner'
+
+task :environment
+
+namespace :sneakers do
+  class SneakersAlreadyRunning < StandardError
+  end
+
+  def pid_file
+    Rails.root.join('tmp/pids/sneakers.pid')
+  end
+
+  def sneakers_running?
+    File.exists?(pid_file)
+  end
+
+  task :force_start do
+    if sneakers_running?
+      puts "Stopping existing sneakers process."
+      Rake::Task["sneakers:force_stop"].invoke
+    end
+    Rake::Task["sneakers:start"].invoke
+  end
+
+  task :start do |t, args|
+    puts "Starting sneakers in background"
+    Process.fork do
+      Rake::Task["sneakers:run"].invoke
+    end
+    puts "Started sneakers"
+  end
+
+  desc "Start work (set JOB_QUEUES=default,active_job_two,active_job_one)"
+  task :run  => :environment do
+    begin
+      if sneakers_running?
+        raise SneakersAlreadyRunning, "Sneakers already running: #{pid_file}"
+      end
+      File.open(pid_file, 'w'){|f| f.puts Process.pid}
+      begin
+        Rails.configuration.settings.background_processing = true
+        workers = []
+        worker_classes = [
+          HoneypotImageWorker,
+          UploadedImageWorker,
+        ]
+        worker_classes.each do |worker_class|
+          worker_class.number_of_workers.times do
+            workers << worker_class
+          end
+        end
+
+        runner = Sneakers::Runner.new(workers)
+
+        runner.run
+      ensure
+        File.delete pid_file
+      end
+    rescue SystemExit
+      # Ignore SystemExit errors
+    rescue Exception => e
+      NotifyError.call(exception: e)
+      raise e
+    end
+  end
+
+  task :stop do
+    if sneakers_running?
+      pid = File.read(pid_file).strip.to_i
+      puts "Stopping sneakers..."
+      Process.kill("INT", pid)
+      stopped = false
+      60.times do
+        begin
+          Process.kill(0, pid)
+        rescue Errno::ESRCH
+          stopped = true
+          break
+        end
+        sleep(1)
+      end
+      if stopped
+        puts "Stopped sneakers"
+      else
+        puts "INT sent to pid #{pid}, sneakers not stopped"
+      end
+    else
+      puts "Sneakers not running"
+    end
+  end
+
+  task :force_stop do
+    Rake::Task["sneakers:stop"].invoke
+    if sneakers_running?
+      timestamp = Time.now.strftime("%Y%m%d%H%M%S")
+      broken_name = "#{pid_file}.#{timestamp}"
+      puts "Moving broken PID file: #{broken_name}"
+      File.rename(pid_file, broken_name)
+    end
+  end
+
+  task :restart do
+    Rake::Task["sneakers:stop"].invoke
+    Rake::Task["sneakers:start"].invoke
+  end
+end

--- a/spec/decorators/item_decorator_spec.rb
+++ b/spec/decorators/item_decorator_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe ItemDecorator do
   end
   let(:item) { instance_double(Item, item_stubs) }
   let(:collection) { instance_double(Collection, id: 2, name_line_1: "name_line_1") }
+  let(:attachment) { double(Paperclip::Attachment, exists?: true, url: "image.jpg") }
 
   subject { described_class.new(item) }
 
@@ -96,6 +97,7 @@ RSpec.describe ItemDecorator do
 
     describe "#show_image_box" do
       it "renders a react component" do
+        allow(item).to receive(:image).and_return(attachment)
         expect(subject.show_image_box).to match("<div data-react-class=\"ItemShowImageBox\"")
       end
     end

--- a/spec/jobs/process_image_job_spec.rb
+++ b/spec/jobs/process_image_job_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe ProcessImageJob, type: :job do
+  let(:object) { instance_double(Item) }
+
+  subject { described_class }
+
+  describe "#perform" do
+    before do
+      allow(QueueJob).to receive(:call)
+    end
+
+    it "calls ProcessUploadedImage with default values" do
+      expect(ProcessUploadedImage).to receive(:call).with(
+        object: object,
+        upload_field: "uploaded_image",
+        image_field: "image"
+      )
+      subject.perform_now(object: object)
+    end
+
+    it "calls ProcessUploadedImage with set values" do
+      expect(ProcessUploadedImage).to receive(:call).with(
+        object: object,
+        upload_field: "other_uploaded_image",
+        image_field: "other_image"
+      )
+      subject.perform_now(object: object, upload_field: "other_uploaded_image", image_field: "other_image")
+    end
+
+    it "Queues SaveHoneypotImageJob after processing the uploaded image" do
+      expect(ProcessUploadedImage).to receive(:call)
+      expect(QueueJob).to receive(:call).with(SaveHoneypotImageJob, object: object, image_field: "image")
+      subject.perform_now(object: object)
+    end
+  end
+end

--- a/spec/jobs/save_honeypot_image_job_spec.rb
+++ b/spec/jobs/save_honeypot_image_job_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe SaveHoneypotImageJob, type: :job do
+  let(:object) { instance_double(Item) }
+
+  subject { described_class }
+
+  describe "#perform" do
+    it "calls SaveHoneypotImage with default values" do
+      expect(SaveHoneypotImage).to receive(:call).with(object: object, image_field: "image")
+      subject.perform_now(object: object)
+    end
+
+    it "calls SaveHoneypotImage with set values" do
+      expect(SaveHoneypotImage).to receive(:call).with(object: object, image_field: "other_image")
+      subject.perform_now(object: object, image_field: "other_image")
+    end
+  end
+end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -31,10 +31,6 @@ RSpec.describe Item do
     expect(subject).to have(1).error_on(:collection)
   end
 
-  it "requires that the item have an image" do
-    expect(subject).to have(1).error_on(:image)
-  end
-
   describe "#manuscript_url" do
     it "is not required" do
       expect(subject).to have(0).errors_on(:manuscript_url)

--- a/spec/queries/item_query_spec.rb
+++ b/spec/queries/item_query_spec.rb
@@ -29,7 +29,12 @@ describe ItemQuery do
 
   describe "#only_top_level" do
     it "returns only the items that are parents" do
-      expect(relation).to receive(:where).with(parent_id: nil)
+      expect(relation).to receive(:where).with(parent_id: nil).and_call_original
+      subject.only_top_level
+    end
+
+    it "includes the image" do
+      expect(relation).to receive(:includes).with(:honeypot_image).and_call_original
       subject.only_top_level
     end
   end

--- a/spec/services/preprocess_image_spec.rb
+++ b/spec/services/preprocess_image_spec.rb
@@ -1,0 +1,188 @@
+require "rails_helper"
+
+RSpec.describe PreprocessImage do
+  let(:object) { instance_double(Item) }
+  let(:uploaded_image) { double(Paperclip::Attachment, instance: object, content_type: "image/jpeg", path: "/tmp/test") }
+  let(:new_image) { instance_double(Paperclip::Attachment) }
+
+  subject { described_class.new(uploaded_image) }
+
+  before do
+    allow(subject).to receive(:processor_attachment).and_return(new_image)
+  end
+
+  describe "self" do
+    subject { described_class }
+
+    describe "#call" do
+      it "instantiates a new instance and calls #process" do
+        expect(subject).to receive(:new).with(uploaded_image).and_call_original
+        expect_any_instance_of(described_class).to receive(:process)
+        subject.call(uploaded_image)
+      end
+    end
+  end
+
+  describe "#process" do
+    let(:path) { "/tmp/test" }
+
+    before do
+      allow(subject).to receive(:attachment_path).and_return(path)
+    end
+
+    it "calls #preprocess_attachment and returns the path" do
+      expect(subject).to receive(:preprocess_attachment)
+      allow(subject).to receive(:processing_needed?).and_return(true)
+      expect(subject.process).to eq(path)
+    end
+
+    it "returns the path" do
+      expect(subject).to_not receive(:preprocess_attachment)
+      allow(subject).to receive(:processing_needed?).and_return(false)
+      expect(subject.process).to eq(path)
+    end
+  end
+
+  describe "#preprocess_attachment" do
+    it "calls reprocess on the new image" do
+      expect(new_image).to receive(:reprocess!)
+      subject.send(:preprocess_attachment)
+    end
+  end
+
+  describe "#uploaded_image" do
+    it "is the paperclip attachment" do
+      expect(subject.send(:uploaded_image)).to eq(uploaded_image)
+    end
+  end
+
+  describe "#processing_needed?" do
+    before do
+      allow(uploaded_image).to receive(:exists?).and_return(true)
+      allow(subject).to receive(:tiff?).and_return(false)
+      allow(subject).to receive(:exceeds_max_pixels?).and_return(false)
+    end
+
+    it "is false if the image doesn't exist" do
+      expect(uploaded_image).to receive(:exists?).and_return(false)
+      expect(subject.send(:processing_needed?)).to eq(false)
+    end
+
+    it "is false if the image exists and other processing isn't needed" do
+      expect(uploaded_image).to receive(:exists?).and_return(true)
+      expect(subject.send(:processing_needed?)).to eq(false)
+    end
+
+    it "is true if the image is a tiff" do
+      expect(subject).to receive(:tiff?).and_return(true)
+      expect(subject.send(:processing_needed?)).to eq(true)
+    end
+
+    it "is true if the image is exceeds the max pixels" do
+      expect(subject).to receive(:exceeds_max_pixels?).and_return(true)
+      expect(subject.send(:processing_needed?)).to eq(true)
+    end
+  end
+
+  describe "#tiff?" do
+    it "is true if the image is a tiff" do
+      expect(uploaded_image).to receive(:content_type).and_return("image/tiff")
+      expect(subject.send(:tiff?)).to eq(true)
+    end
+
+    it "is false otherwise" do
+      expect(uploaded_image).to receive(:content_type).and_return("image/jpeg")
+      expect(subject.send(:tiff?)).to eq(false)
+    end
+  end
+
+  describe "#exceeds_max_pixels?" do
+    it "is true if the image is too large" do
+      expect(subject).to receive(:original_pixels).and_return(described_class::MAX_PIXELS + 1)
+      expect(subject.send(:exceeds_max_pixels?)).to eq(true)
+    end
+
+    it "is false if the image is not too large" do
+      expect(subject).to receive(:original_pixels).and_return(described_class::MAX_PIXELS)
+      expect(subject.send(:exceeds_max_pixels?)).to eq(false)
+    end
+  end
+
+  describe "#original_dimensions" do
+    it "returns the width and height" do
+      dimensions = [100, 200]
+      expect(FastImage).to receive(:size).with(uploaded_image.path).and_return(dimensions)
+      expect(subject.send(:original_dimensions)).to eq(dimensions)
+    end
+  end
+
+  describe "#original_pixels" do
+    it "returns the product of the dimensions" do
+      dimensions = [100, 200]
+      expect(subject).to receive(:original_dimensions).and_return(dimensions)
+      expect(subject.send(:original_pixels)).to eq(dimensions[0] * dimensions[1])
+    end
+  end
+
+  describe "#processor_attachment" do
+    before do
+      allow(subject).to receive(:processor_options).and_return(test: "test")
+      allow(subject).to receive(:processor_attachment).and_call_original
+    end
+
+    it "returns a new instance of a paperclip attachment" do
+      expect(Paperclip::Attachment).to receive(:new).with(:uploaded_image, object, test: "test")
+      subject.send(:processor_attachment)
+    end
+  end
+
+  describe "#processor_options" do
+    let(:original_styles) { { test: "test" } }
+    let(:style) { "style" }
+
+    before do
+      allow(uploaded_image).to receive(:options).and_return(styles: original_styles)
+      allow(subject).to receive(:processor_style).and_return(style)
+    end
+
+    it "adds a new processed style to the original options" do
+      expect(subject.send(:processor_options)).to eq(styles: original_styles.merge(processed: style))
+    end
+  end
+
+  describe "#processor_style" do
+    before do
+      allow(subject).to receive(:tiff?).and_return(false)
+    end
+
+    it "limits the image to MAX_PIXELS" do
+      expect(subject.send(:processor_style)).to eq("#{described_class::MAX_PIXELS}@")
+    end
+
+    it "converts tiffs to jpgs" do
+      expect(subject).to receive(:tiff?).and_return(true)
+      expect(subject.send(:processor_style)).to eq(["#{described_class::MAX_PIXELS}@", :jpg])
+    end
+  end
+
+  describe "#processed_path" do
+    it "returns the new attachment path" do
+      expect(new_image).to receive(:path).with(:processed).and_return("newpath")
+      expect(subject.send(:processed_path)).to eq("newpath")
+    end
+  end
+
+  describe "#attachment_path" do
+    it "returns the #processed_path if processing was needed" do
+      expect(subject).to receive(:processing_needed?).and_return(true)
+      expect(subject).to receive(:processed_path).and_return("newpath")
+      expect(subject.send(:attachment_path)).to eq("newpath")
+    end
+
+    it "returns the original path if processing was not needed" do
+      expect(subject).to receive(:processing_needed?).and_return(false)
+      expect(uploaded_image).to receive(:path).and_return("originalpath")
+      expect(subject.send(:attachment_path)).to eq("originalpath")
+    end
+  end
+end

--- a/spec/services/process_uploaded_image_spec.rb
+++ b/spec/services/process_uploaded_image_spec.rb
@@ -1,0 +1,112 @@
+require "rails_helper"
+
+RSpec.describe ProcessUploadedImage do
+  let(:object) { instance_double(Item, uploaded_image: uploaded_image) }
+  let(:uploaded_image) { double(Paperclip::Attachment) }
+  let(:path) { "/tmp/test" }
+  let(:instance) { described_class.new(object: object) }
+
+  subject { instance }
+
+  describe "self" do
+    subject { described_class }
+
+    describe "#call" do
+      it "instantiates a new instance and calls #process" do
+        expect(subject).to receive(:new).with(object: object).and_call_original
+        expect_any_instance_of(described_class).to receive(:process)
+        subject.call(object: object)
+      end
+    end
+  end
+
+  describe "#process" do
+    it "calls #process_uploaded_image and returns the result" do
+      expect(subject).to receive(:process_uploaded_image).and_return(object)
+      allow(subject).to receive(:uploaded_image_exists?).and_return(true)
+      expect(subject.process).to eq(object)
+    end
+
+    it "returns true when there is no uploaded image" do
+      expect(subject).to_not receive(:process_uploaded_image)
+      allow(subject).to receive(:uploaded_image_exists?).and_return(false)
+      expect(subject.process).to eq(true)
+    end
+  end
+
+  describe "#process_uploaded_image" do
+    before do
+      allow(PreprocessImage).to receive(:call).and_return(path)
+      allow(subject).to receive(:copy_processed_image)
+      allow(subject).to receive(:save_object)
+      allow(subject).to receive(:delete_processed_image)
+    end
+
+    it "calls PreprocessImage" do
+      expect(PreprocessImage).to receive(:call).with(uploaded_image).and_return(path)
+      subject.send(:process_uploaded_image)
+    end
+
+    it "calls #copy_processed_image" do
+      expect(subject).to receive(:copy_processed_image).with(path)
+      subject.send(:process_uploaded_image)
+    end
+
+    it "returns the result of save_object" do
+      expect(subject).to receive(:save_object).and_return(object)
+      expect(subject.send(:process_uploaded_image)).to eq(object)
+    end
+
+    it "calls delete_processed_image" do
+      expect(subject).to receive(:delete_processed_image).with(path)
+      subject.send(:process_uploaded_image)
+    end
+  end
+
+  describe "#uploaded_image_exists?" do
+    it "returns the result of uploaded_image#exists?" do
+      expect(uploaded_image).to receive(:exists?).and_return(true)
+      expect(subject.send(:uploaded_image_exists?)).to eq(true)
+    end
+  end
+
+  describe "#save_object" do
+    it "returns the object if save is successful" do
+      expect(object).to receive(:save).and_return(true)
+      expect(subject.send(:save_object)).to eq(object)
+    end
+
+    it "returns false if save is not successful" do
+      expect(object).to receive(:save).and_return(false)
+      expect(subject.send(:save_object)).to eq(false)
+    end
+  end
+
+  describe "#copy_processed_image" do
+    let(:file) { instance_double(File, close: true) }
+
+    before do
+      allow(File).to receive(:open).with(path).and_return(file)
+    end
+
+    it "sets the image field and unsets the upload field" do
+      expect(object).to receive("#{subject.image_field}=").with(file)
+      expect(object).to receive("#{subject.upload_field}=").with(nil)
+      subject.send(:copy_processed_image, path)
+    end
+  end
+
+  describe "#delete_processed_image" do
+    it "deletes the file if it exists" do
+      expect(File).to receive(:exists?).with(path).and_return(true)
+      expect(File).to receive(:delete).with(path)
+      subject.send(:delete_processed_image, path)
+    end
+
+    it "does nothing if the file doesn't exist" do
+      expect(File).to receive(:exists?).with(path).and_return(false)
+      expect(File).to_not receive(:delete)
+      subject.send(:delete_processed_image, path)
+    end
+  end
+end

--- a/spec/services/queue_job_spec.rb
+++ b/spec/services/queue_job_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe QueueJob do
+  let(:job) { double(ProcessImageJob) }
+  let(:args) { { test: "test" } }
+
+  subject { described_class.new(job) }
+
+  describe "#queue" do
+    it "queues the job with #perform_later" do
+      expect(subject).to receive(:process_in_background?).and_return(true)
+      expect(job).to receive(:perform_later).with(args)
+      subject.queue(args)
+    end
+
+    it "runs the job immediately with #perform_now" do
+      expect(subject).to receive(:process_in_background?).and_return(false)
+      expect(job).to receive(:perform_now).with(args)
+      subject.queue(args)
+    end
+  end
+
+  describe "#process_in_background?" do
+    it "is true when configured" do
+      expect(Rails.configuration.settings).to receive(:background_processing).and_return(true)
+      expect(subject.send(:process_in_background?)).to be_truthy
+    end
+
+    it "is false when configured" do
+      expect(Rails.configuration.settings).to receive(:background_processing).and_return(false)
+      expect(subject.send(:process_in_background?)).to be_falsy
+    end
+
+    it "is false in test" do
+      expect(subject.send(:process_in_background?)).to be_falsy
+    end
+  end
+
+  describe "#self" do
+    subject { described_class }
+
+    it "instantiates a new instance and calls #queue" do
+      expect(subject).to receive(:new).with(job).and_call_original
+      expect_any_instance_of(described_class).to receive(:queue).with(args)
+      subject.call(job, args)
+    end
+  end
+end

--- a/spec/services/save_honeypot_image_spec.rb
+++ b/spec/services/save_honeypot_image_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe SaveHoneypotImage do
-  subject { described_class.new(item) }
+  subject { described_class.new(object: item) }
 
   let(:honeypot_json) { JSON.parse(File.read(File.join(Rails.root, "spec/fixtures/honeypot_response.json"))) }
 
@@ -23,7 +23,7 @@ RSpec.describe SaveHoneypotImage do
 
   let(:honeypot_image) { HoneypotImage.new(item_id: 1) }
   let(:collection) { double(Collection, id: 1) }
-  let(:item) { double(Item, id: 1, collection: collection, image: image, honeypot_image: honeypot_image) }
+  let(:item) { double(Item, id: 1, collection: collection, image: image, honeypot_image: honeypot_image, save: true) }
   let(:image) { double(path: Rails.root.join("spec/fixtures/test.jpg").to_s, content_type: "image/jpeg") }
   let(:faraday_response) { double(success?: true, body: honeypot_json) }
 
@@ -46,7 +46,7 @@ RSpec.describe SaveHoneypotImage do
     end
 
     describe "result of #save!" do
-      let(:service) { described_class.new(item) }
+      let(:service) { described_class.new(object: item) }
       subject { service.save! }
 
       it "creates a database records when the request is successful" do
@@ -81,9 +81,9 @@ RSpec.describe SaveHoneypotImage do
 
     describe "#call" do
       it "calls save! on a new instance" do
-        expect(subject).to receive(:new).with(item).and_call_original
+        expect(subject).to receive(:new).with(object: item).and_call_original
         expect_any_instance_of(described_class).to receive(:save!).and_return("saved!")
-        expect(subject.call(item)).to eq("saved!")
+        expect(subject.call(object: item)).to eq("saved!")
       end
     end
   end

--- a/spec/services/save_item_spec.rb
+++ b/spec/services/save_item_spec.rb
@@ -27,9 +27,9 @@ RSpec.describe SaveItem, type: :model do
     subject
   end
 
-  it "removes the image from the params if the image param is nil" do
-    params[:image] = nil
-    expect(params).to receive(:delete).with(:image)
+  it "removes the uploaded image from the params if the param is nil" do
+    params[:uploaded_image] = nil
+    expect(params).to receive(:delete).with(:uploaded_image)
 
     subject
   end
@@ -56,25 +56,18 @@ RSpec.describe SaveItem, type: :model do
     end
   end
 
-  describe "update honeypot image" do
-    it "calls SaveHoneypotImage if the image was updated" do
-      params[:image] = upload_image
+  describe "image processing" do
+    it "Queues image processing if the image was updated" do
+      params[:uploaded_image] = upload_image
       expect(item).to receive(:save).and_return(true)
-      expect(SaveHoneypotImage).to receive(:call).and_return(true)
+      expect(QueueJob).to receive(:call).with(ProcessImageJob, object: item).and_return(true)
       expect(subject).to eq(item)
     end
 
-    it "returns false if the honeypot update fails" do
-      params[:image] = upload_image
-      expect(item).to receive(:save).and_return(true)
-      expect(SaveHoneypotImage).to receive(:call).and_return(false)
-      expect(subject).to be_falsy
-    end
-
     it "is not called if the image is not changed" do
-      params[:image] = nil
+      params[:uploaded_image] = nil
       expect(item).to receive(:save).and_return(true)
-      expect(SaveHoneypotImage).to_not receive(:call)
+      expect(QueueJob).to_not receive(:call)
       expect(subject).to eq(item)
     end
   end

--- a/spec/workers/honeypot_image_worker_spec.rb
+++ b/spec/workers/honeypot_image_worker_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe HoneypotImageWorker, type: :worker do
+  subject { described_class.new }
+
+  let (:queue) { subject.queue }
+
+  let (:queue_options) { queue.opts.to_hash }
+
+  describe "self" do
+    subject { described_class }
+
+    describe "#number_of_workers" do
+      it "is 1" do
+        expect(subject.number_of_workers).to eq(1)
+      end
+    end
+  end
+
+  describe "queue" do
+    it "uses the correct queue name" do
+      expect(queue.name).to eq("honeypot_images")
+    end
+
+    it "sets the correct queue options" do
+      expect(queue_options[:arguments]).to eq(:"x-dead-letter-exchange" => "honeypot_images-retry")
+      expect(queue_options[:handler]).to eq(Sneakers::Handlers::Maxretry)
+      expect(queue_options[:routing_key]).to eq(["honeypot_images"])
+      expect(queue_options[:threads]).to eq(1)
+      expect(queue_options[:timeout_job_after]).to eq(60)
+      expect(queue_options[:prefetch]).to eq(1)
+    end
+  end
+end

--- a/spec/workers/retry_worker_spec.rb
+++ b/spec/workers/retry_worker_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+class DefaultsWorker < RetryWorker
+  from_queue "testdefaults"
+end
+
+RSpec.describe RetryWorker, type: :worker do
+  subject { described_class.new }
+
+  let (:queue) { subject.queue }
+
+  let (:queue_options) { queue.opts.to_hash }
+
+  describe "self" do
+    subject { described_class }
+
+    describe "#number_of_workers" do
+      it "defaults to 1" do
+        expect(subject.number_of_workers).to eq(1)
+      end
+    end
+  end
+
+  describe "defaults" do
+    subject { DefaultsWorker.new }
+
+    it "uses the correct queue name" do
+      expect(queue.name).to eq("testdefaults")
+    end
+
+    it "sets the correct queue options" do
+      expect(queue_options[:arguments]).to eq(:"x-dead-letter-exchange" => "testdefaults-retry")
+      expect(queue_options[:handler]).to eq(Sneakers::Handlers::Maxretry)
+      expect(queue_options[:routing_key]).to eq(["testdefaults"])
+    end
+  end
+end

--- a/spec/workers/uploaded_image_worker_spec.rb
+++ b/spec/workers/uploaded_image_worker_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe UploadedImageWorker, type: :worker do
+  subject { described_class.new }
+
+  let (:queue) { subject.queue }
+
+  let (:queue_options) { queue.opts.to_hash }
+
+  describe "self" do
+    subject { described_class }
+
+    describe "#number_of_workers" do
+      it "is 4" do
+        expect(subject.number_of_workers).to eq(4)
+      end
+    end
+  end
+
+  describe "queue" do
+    it "uses the correct queue name" do
+      expect(queue.name).to eq("uploaded_images")
+    end
+
+    it "sets the correct queue options" do
+      expect(queue_options[:arguments]).to eq(:"x-dead-letter-exchange" => "uploaded_images-retry")
+      expect(queue_options[:handler]).to eq(Sneakers::Handlers::Maxretry)
+      expect(queue_options[:routing_key]).to eq(["uploaded_images"])
+      expect(queue_options[:threads]).to eq(1)
+      expect(queue_options[:timeout_job_after]).to eq(60)
+      expect(queue_options[:prefetch]).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
### What
Added sneakers (RabbitMQ) as an ActiveJob adapter.  
Images are first uploaded to an uploaded_image paperclip field, then run through initial preprocessing (maximum pixel count, converting tiff to jpg) before being saved locally and then sent to the remote image tile server.
Images being sent to the remote server are limited to one request at a time.
Background processing is disabled by default in development and test.

### Why
Large images take a long time to process.  By uploading the images to a temporary location without doing any processing, the user receives quicker feedback that their action was successful.
The preprocess step in the background allows us to limit the maximum size of images (currently 16000000 pixels), as well as convert TIFFs to a friendlier format.
The remote tile server was having problems processing multiple images simultaneously.  The problem is mitigated by limiting that part of the process to a single worker.