### PR TITLE
DEC-434 Fix for failed API call preventing logging in to the site

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,8 +6,8 @@ class User < ActiveRecord::Base
 
   before_validation :map_user
 
-  validates :username, :email, uniqueness: true
-  validates_presence_of :username
+  validates :username, presence: true, uniqueness: true
+  validates :email, uniqueness: true, allow_blank: true
 
   scope :username, ->(username) {  where(username: username) }
 

--- a/app/services/map_user_to_api.rb
+++ b/app/services/map_user_to_api.rb
@@ -15,6 +15,8 @@ class MapUserToApi
     user.email = api_attributes["contact_information"]["email"]
     user.display_name = api_attributes["full_name"]
     user
+  rescue StandardError => e
+    user
   end
 
   private

--- a/app/services/map_user_to_api.rb
+++ b/app/services/map_user_to_api.rb
@@ -15,7 +15,8 @@ class MapUserToApi
     user.email = api_attributes["contact_information"]["email"]
     user.display_name = api_attributes["full_name"]
     user
-  rescue StandardError => e
+  rescue StandardError => exception
+    NotifyError.call(exception: exception, args: {username: user.username})
     user
   end
 

--- a/app/services/map_user_to_api.rb
+++ b/app/services/map_user_to_api.rb
@@ -16,7 +16,7 @@ class MapUserToApi
     user.display_name = api_attributes["full_name"]
     user
   rescue StandardError => exception
-    NotifyError.call(exception: exception, args: {username: user.username})
+    NotifyError.call(exception: exception, args: { username: user.username })
     user
   end
 

--- a/app/services/notify_error.rb
+++ b/app/services/notify_error.rb
@@ -1,0 +1,16 @@
+class NotifyError
+  attr_reader :exception, :args
+
+  def self.call(exception:, args: {})
+    new(exception: exception, args: args).notify
+  end
+
+  def initialize(exception:, args: {})
+    @exception = exception
+    @args = args
+  end
+
+  def notify
+    Airbrake.notify(exception, parameters: { args: args })
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,10 +6,15 @@
 #   cities = City.create([{ name: "Chicago" }, { name: "Copenhagen" }])
 #   Mayor.create(name: "Emanuel", city: cities.first)
 
-User.new(username: "jhartzle", admin: true).save!
-User.new(username: "dwolfe2", admin: true).save!
-User.new(username: "rfox2", admin: true).save!
-User.new(username: "rmallot", admin: true).save!
-User.new(username: "jkennel", admin: true).save!
-User.new(username: "awetheri", admin: true).save!
-User.new(username: "jgondron", admin: true).save!
+[
+  "jhartzle",
+  "dwolfe2",
+  "rfox2",
+  "jkennel",
+  "awetheri",
+  "jgondron"
+].each do |username|
+  u = User.where(username: username).first || User.new(username: username)
+  u.admin = true
+  u.save!
+end

--- a/spec/services/map_user_to_api_spec.rb
+++ b/spec/services/map_user_to_api_spec.rb
@@ -16,6 +16,12 @@ describe MapUserToApi do
     subject
   end
 
+  it "does not raise an exception if one is encountered" do
+    expect(HesburghAPI::PersonSearch).to receive(:find).with(user.username).and_raise("error encountered")
+
+    subject
+  end
+
   [:first_name, :last_name, :display_name].each do |field|
     it "set the #{field} from the api data " do
       expect(user).to receive("#{field}=").with(api_data["#{field}"])

--- a/spec/services/notify_error_spec.rb
+++ b/spec/services/notify_error_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe NotifyError do
+  let(:exception) { instance_double(StandardError) }
+  let(:args) { { test: "test" } }
+
+  subject { described_class.new(exception: exception, args: args) }
+
+  describe "self" do
+    subject { described_class }
+
+    describe "#call" do
+      it "instantiates a new instance and calls #notify" do
+        expect(subject).to receive(:new).with(exception: exception, args: args).and_call_original
+        expect_any_instance_of(described_class).to receive(:notify)
+        subject.call(exception: exception, args: args)
+      end
+    end
+  end
+
+  describe "#notify" do
+    it "calls Airbrake#notify" do
+      expect(Airbrake).to receive(:notify).with(exception, parameters: { args: args })
+      subject.notify
+    end
+  end
+end


### PR DESCRIPTION
Fixes a bug where login could be blocked when an exception is encountered connecting to the API server. Also fixes #159