### PR TITLE
DEC-327: Auth check v1 items update

### DIFF
--- a/app/assets/javascripts/components/forms/FormErrorMsg.js.jsx
+++ b/app/assets/javascripts/components/forms/FormErrorMsg.js.jsx
@@ -1,11 +1,15 @@
 //app/assets/javascripts/components/forms/FormErrorMsg.jsx
 
 var FormErrorMsg = React.createClass({
+  propTypes: {
+    message: React.PropTypes.string,
+  },
 
   render: function () {
+    var message = this.props.message || "An unspecified error has occurred.";
     return (
       <div className="alert alert-warning" role="alert">
-        Please complete the highlighted fields in order to continue.
+        {message}
       </div>
     );
   }

--- a/app/assets/javascripts/components/forms/FormServerErrorMsg.js.jsx
+++ b/app/assets/javascripts/components/forms/FormServerErrorMsg.js.jsx
@@ -1,11 +1,15 @@
 //app/assets/javascripts/components/forms/FormServerErrorMsg.jsx
 
 var FormServerErrorMsg = React.createClass({
+  propTypes: {
+    message: React.PropTypes.string,
+  },
 
   render: function () {
+    var message = this.props.message || "The server has encountered an error.  The form has not been saved.";
     return (
       <div className="alert alert-danger" role="alert">
-        The server has encountered an error.  The form has not been saved.
+        {message}
       </div>
     );
   }

--- a/app/assets/javascripts/components/forms/ItemMetaDataForm.js.jsx
+++ b/app/assets/javascripts/components/forms/ItemMetaDataForm.js.jsx
@@ -30,6 +30,7 @@ var ItemMetaDataForm = React.createClass({
       formState: "new",
       dataState: "clean",
       formErrors: false,
+      responseCode: 0,
       displayedFields: _.mapObject(this.props.data, function(val, key) {
         if (val) {
           return true;
@@ -66,7 +67,7 @@ var ItemMetaDataForm = React.createClass({
         if (xhr.status == "422") {
           this.setSavedFailure(xhr.responseJSON.errors);
         } else {
-          this.setServerError();
+          this.setServerError(xhr.status, xhr.responseJSON);
         }
       }).bind(this),
     });
@@ -116,9 +117,12 @@ var ItemMetaDataForm = React.createClass({
     });
   },
 
-  setServerError: function () {
+  setServerError: function (code, responseJSON) {
+    errors = responseJSON || {}
     this.setState({
       formState: "error",
+      formErrors: errors,
+      responseCode: code,
     });
   },
 
@@ -138,11 +142,11 @@ var ItemMetaDataForm = React.createClass({
 
   formMsg: function () {
     if (this.state.formState == "invalid") {
-      return (<FormErrorMsg />);
+      return (<FormErrorMsg message="Please complete the highlighted fields in order to continue."/>);
     } else if (this.state.formState == "saved") {
       return (<FormSavedMsg />);
     } else if (this.state.formState == "error") {
-      return (<FormServerErrorMsg />);
+      return (<FormServerErrorMsg message={this.state.formErrors[this.state.responseCode]}/>);
     }
     return "";
   },

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -4,6 +4,22 @@ class APIController < ApplicationController
 
   before_action :set_access
 
+  protected
+
+  # Checks if a user can edit the given collection. If they cannot
+  # then it will handle rendering a forbidden response.
+  # Returns true if the response was rendered
+  def rendered_forbidden?(collection)
+    can_edit = user_can_edit?(collection)
+    can_edit = false
+    unless can_edit
+      @errors = { 403 => "User does not have permission to edit this collection." }
+      render json: @errors, status: :forbidden
+      #render nothing: true, status: :forbidden
+    end
+    !can_edit
+  end
+
   private
 
   def set_access

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -11,11 +11,9 @@ class APIController < ApplicationController
   # Returns true if the response was rendered
   def rendered_forbidden?(collection)
     can_edit = user_can_edit?(collection)
-    can_edit = false
     unless can_edit
       @errors = { 403 => "User does not have permission to edit this collection." }
       render json: @errors, status: :forbidden
-      #render nothing: true, status: :forbidden
     end
     !can_edit
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -56,8 +56,12 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def user_can_edit?(collection)
+    permission.user_is_admin_in_masquerade? || permission.user_is_administrator? || permission.user_is_editor?(collection)
+  end
+
   def check_user_edits!(collection)
-    unless permission.user_is_admin_in_masquerade? || permission.user_is_administrator? || permission.user_is_editor?(collection)
+    unless user_can_edit?(collection)
       raise_404("User does not edit this collection")
     end
   end

--- a/app/controllers/v1/items_controller.rb
+++ b/app/controllers/v1/items_controller.rb
@@ -23,7 +23,8 @@ module V1
 
     def update
       @item = ItemQuery.new.public_find(params[:id])
-      # check_user_edits!(@item.collection)
+
+      return if rendered_forbidden?(@item.collection)
 
       if SaveItem.call(@item, save_params)
         render :update

--- a/spec/controllers/v1/items_controller_spec.rb
+++ b/spec/controllers/v1/items_controller_spec.rb
@@ -65,15 +65,15 @@ RSpec.describe V1::ItemsController, type: :controller do
     subject { put :update, update_params }
 
     before(:each) do
-      # sign_in_admin
+      sign_in_admin
       allow(SaveItem).to receive(:call).and_return(true)
       allow_any_instance_of(ItemQuery).to receive(:find).and_return(item)
     end
 
-    # it "checks the editor permissions" do
-    #   expect_any_instance_of(described_class).to receive(:check_user_edits!).with(collection)
-    #   subject
-    # end
+    it "checks the editor permissions" do
+      expect_any_instance_of(described_class).to receive(:user_can_edit?).with(collection)
+      subject
+    end
 
     it "uses item query " do
       expect_any_instance_of(ItemQuery).to receive(:public_find).with("1").and_return(item)


### PR DESCRIPTION
**Why:** Permissions check for editing the item was temporarily disabled, needed to be restored.
**How:** For the most part this was the same as any other permissions check, but we determined that there needed to be additional info in the response so that the front end could better report why the user received the response that it did. The ItemMetaDataForm already had mechanisms for rendering errors encountered with item validation. I expanded this to also handle generic server error messages and changed APIController to provide a permission error message when the user is forbidden to make the change.