### PR TITLE
Dec 407 collection preview

### DIFF
--- a/app/assets/javascripts/components/CollectionPreviewModeToggle.js.jsx
+++ b/app/assets/javascripts/components/CollectionPreviewModeToggle.js.jsx
@@ -3,7 +3,8 @@
 var CollectionPreviewModeToggle = React.createClass({
   propTypes: {
     collection: React.PropTypes.object.isRequired,
-    previewModePath: React.PropTypes.string.isRequired
+    previewModePath: React.PropTypes.string.isRequired,
+    onToggle: React.PropTypes.func
   },
   getInitialState: function() {
     return {
@@ -14,12 +15,16 @@ var CollectionPreviewModeToggle = React.createClass({
   handleClick: function () {
     this.togglePreviewMode();
   },
+  stateChanged: function() {
+    if(this.props.onToggle)
+      this.props.onToggle(this.state.preview_mode);
+  },
   previewLabel: function (preview_status) {
     var label;
     if (preview_status) {
-      label = 'Preview Enabled'
+      label = 'Enabled'
     } else {
-      label = 'Preview Not Enabled'
+      label = 'Disabled'
     }
     return label;
   },
@@ -41,7 +46,7 @@ var CollectionPreviewModeToggle = React.createClass({
         this.setState({
           preview_mode: preview_state,
           preview_mode_label: this.previewLabel(preview_state)
-        });
+        }, this.stateChanged);
       }).bind(this),
       error: (function(xhr, status, err) {
         console.error(actionUrl, status, err.toString());

--- a/app/assets/javascripts/components/CollectionPreviewModeToggle.js.jsx
+++ b/app/assets/javascripts/components/CollectionPreviewModeToggle.js.jsx
@@ -1,0 +1,59 @@
+/** @jsx React.DOM */
+
+var CollectionPreviewModeToggle = React.createClass({
+  propTypes: {
+    collection: React.PropTypes.object.isRequired,
+    previewModePath: React.PropTypes.string.isRequired
+  },
+  getInitialState: function() {
+    return {
+      preview_mode: this.props.collection.preview_mode,
+      preview_mode_label: this.previewLabel(this.props.collection.preview_mode)
+    };
+  },
+  handleClick: function () {
+    this.togglePreviewMode();
+  },
+  previewLabel: function (preview_status) {
+    var label;
+    if (preview_status) {
+      label = 'Preview Enabled'
+    } else {
+      label = 'Preview Not Enabled'
+    }
+    return label;
+  },
+  togglePreviewMode: function () {
+    var preview_state;
+    if (this.state.preview_mode) {
+      preview_state = false;
+    } else {
+      preview_state = true;
+    }
+    $.ajax({
+      url: this.props.previewModePath,
+      dataType: "json",
+      data: {
+        value: preview_state
+      },
+      method: "PUT",
+      success: (function(data) {
+        this.setState({
+          preview_mode: preview_state,
+          preview_mode_label: this.previewLabel(preview_state)
+        });
+      }).bind(this),
+      error: (function(xhr, status, err) {
+        console.error(actionUrl, status, err.toString());
+      }).bind(this)
+    });
+},
+render: function () {
+  return (
+    <label>
+    <input type="checkbox" checked={this.state.preview_mode} onChange={this.handleClick}/>
+    <span className="toggle"></span><span className="toggle-label">{this.state.preview_mode_label}</span>
+    </label>
+    )
+}
+});

--- a/app/assets/javascripts/components/CollectionPreviewModeToggle.js.jsx
+++ b/app/assets/javascripts/components/CollectionPreviewModeToggle.js.jsx
@@ -6,18 +6,22 @@ var CollectionPreviewModeToggle = React.createClass({
     previewModePath: React.PropTypes.string.isRequired,
     onToggle: React.PropTypes.func
   },
+
   getInitialState: function() {
     return {
       preview_mode: this.props.collection.preview_mode,
     };
   },
+
   handleClick: function () {
     this.togglePreviewMode();
   },
+
   stateChanged: function() {
     if(this.props.onToggle)
       this.props.onToggle(this.state.preview_mode);
   },
+
   previewLabel: function () {
     var label;
     if (this.state.preview_mode) {
@@ -27,6 +31,7 @@ var CollectionPreviewModeToggle = React.createClass({
     }
     return label;
   },
+
   togglePreviewMode: function () {
     var preview_state;
     if (this.state.preview_mode) {
@@ -50,13 +55,14 @@ var CollectionPreviewModeToggle = React.createClass({
         console.error(actionUrl, status, err.toString());
       }).bind(this)
     });
-},
-render: function () {
-  return (
-    <label>
-    <input type="checkbox" checked={this.state.preview_mode} onChange={this.handleClick}/>
-    <span className="toggle"></span><span className="toggle-label">{this.previewLabel()}</span>
-    </label>
-    )
-}
+  },
+
+  render: function () {
+    return (
+      <label>
+      <input type="checkbox" checked={this.state.preview_mode} onChange={this.handleClick}/>
+      <span className="toggle"></span><span className="toggle-label">{this.previewLabel()}</span>
+      </label>
+      )
+  }
 });

--- a/app/assets/javascripts/components/CollectionPreviewModeToggle.js.jsx
+++ b/app/assets/javascripts/components/CollectionPreviewModeToggle.js.jsx
@@ -9,7 +9,6 @@ var CollectionPreviewModeToggle = React.createClass({
   getInitialState: function() {
     return {
       preview_mode: this.props.collection.preview_mode,
-      preview_mode_label: this.previewLabel(this.props.collection.preview_mode)
     };
   },
   handleClick: function () {
@@ -19,9 +18,9 @@ var CollectionPreviewModeToggle = React.createClass({
     if(this.props.onToggle)
       this.props.onToggle(this.state.preview_mode);
   },
-  previewLabel: function (preview_status) {
+  previewLabel: function () {
     var label;
-    if (preview_status) {
+    if (this.state.preview_mode) {
       label = 'Enabled'
     } else {
       label = 'Disabled'
@@ -45,7 +44,6 @@ var CollectionPreviewModeToggle = React.createClass({
       success: (function(data) {
         this.setState({
           preview_mode: preview_state,
-          preview_mode_label: this.previewLabel(preview_state)
         }, this.stateChanged);
       }).bind(this),
       error: (function(xhr, status, err) {
@@ -57,7 +55,7 @@ render: function () {
   return (
     <label>
     <input type="checkbox" checked={this.state.preview_mode} onChange={this.handleClick}/>
-    <span className="toggle"></span><span className="toggle-label">{this.state.preview_mode_label}</span>
+    <span className="toggle"></span><span className="toggle-label">{this.previewLabel()}</span>
     </label>
     )
 }

--- a/app/assets/javascripts/components/CollectionPreviewPublish.js.jsx
+++ b/app/assets/javascripts/components/CollectionPreviewPublish.js.jsx
@@ -19,20 +19,22 @@ var CollectionPreviewPublish = React.createClass({
   },
 
   linkLabel: function () {
-    if (this.state.published)
+    if (this.state.published) {
       return this.props.liveLinkLabel;
+    }
     return this.props.previewLinkLabel;
   },
 
   siteLink: function() {
-    if(this.state.published || this.state.preview)
+    if(this.state.published || this.state.preview) {
       return (
         <a href={this.props.previewLinkURL} target="_blank">
           <i className="glyphicon mdi-av-web"></i>
           <span> {this.linkLabel()}</span>
         </a>)
-    else
+    } else {
       return "";
+    }
   },
 
   handlePreviewClick: function(newValue) {

--- a/app/assets/javascripts/components/CollectionPreviewPublish.js.jsx
+++ b/app/assets/javascripts/components/CollectionPreviewPublish.js.jsx
@@ -1,0 +1,61 @@
+/** @jsx React.DOM */
+
+var CollectionPreviewPublish = React.createClass({
+  propTypes: {
+    collection: React.PropTypes.object.isRequired,
+    previewModePath: React.PropTypes.string.isRequired,
+    previewLinkURL: React.PropTypes.string.isRequired,
+    previewLinkLabel: React.PropTypes.string.isRequired,
+    liveLinkLabel: React.PropTypes.string.isRequired,
+    publishPath: React.PropTypes.string.isRequired,
+    unpublishPath: React.PropTypes.string.isRequired
+  },
+
+  getInitialState: function() {
+    return {
+      published: this.props.collection.published,
+      preview: this.props.collection.preview_mode,
+    };
+  },
+
+  linkLabel: function () {
+    if (this.state.published)
+      return this.props.liveLinkLabel;
+    return this.props.previewLinkLabel;
+  },
+
+  siteLink: function() {
+    if(this.state.published || this.state.preview)
+      return (
+        <a href={this.props.previewLinkURL} target="_blank">
+          <i className="glyphicon mdi-av-web"></i>
+          <span> {this.linkLabel()}</span>
+        </a>)
+    else
+      return "";
+  },
+
+  handlePreviewClick: function(newValue) {
+    this.setState({ preview: newValue });
+  },
+
+  handlePublishClick: function(newValue) {
+    this.setState({ published: newValue });
+  },
+
+  render: function () {
+    return (
+        <div>
+          <li className="header" role="presentation">Publishing Status</li>
+          <li className="togglebutton">
+            <CollectionPublishToggle onToggle={this.handlePublishClick} ref="myPublishToggle" collection={this.props.collection} publishPath={this.props.publishPath} unpublishPath={this.props.unpublishPath} />
+          </li>
+          <li className="header" role="presentation">Preview Mode</li>
+          <li className="togglebutton">
+            <CollectionPreviewModeToggle onToggle={this.handlePreviewClick} ref="myPreviewToggle" collection={this.props.collection} previewModePath={this.props.previewModePath} previewLinkURL={this.props.previewLinkURL}/>
+          </li>
+          {this.siteLink()}
+        </div>
+      )
+  }
+});

--- a/app/assets/javascripts/components/publish/CollectionPublishToggle.js.jsx
+++ b/app/assets/javascripts/components/publish/CollectionPublishToggle.js.jsx
@@ -4,7 +4,8 @@ var CollectionPublishToggle = React.createClass({
   propTypes: {
     collection: React.PropTypes.object.isRequired,
     publishPath: React.PropTypes.string.isRequired,
-    unpublishPath: React.PropTypes.string.isRequired
+    unpublishPath: React.PropTypes.string.isRequired,
+    onToggle: React.PropTypes.func
   },
   getInitialState: function() {
     return {
@@ -14,6 +15,10 @@ var CollectionPublishToggle = React.createClass({
   },
   handleClick: function () {
     this.togglePublished();
+  },
+  stateChanged: function() {
+    if(this.props.onToggle)
+      this.props.onToggle(this.state.published);
   },
   publishedLabel: function (published_status) {
     var label;
@@ -42,7 +47,7 @@ var CollectionPublishToggle = React.createClass({
         this.setState({
           published: published_state,
           published_label: this.publishedLabel(published_state)
-        });
+        }, this.stateChanged);
       }).bind(this),
       error: (function(xhr, status, err) {
         console.error(searchUrl, status, err.toString());

--- a/app/controllers/v1/collections_controller.rb
+++ b/app/controllers/v1/collections_controller.rb
@@ -35,5 +35,14 @@ module V1
         format.json { render json: { status: @return_value }.to_json }
       end
     end
+
+    def preview_mode
+      @collection = CollectionQuery.new.any_find(params[:collection_id])
+      @return_value = SetCollectionPreviewMode.call(@collection, params[:value])
+
+      respond_to do |format|
+        format.json { render json: { status: @return_value }.to_json }
+      end
+    end
   end
 end

--- a/app/queries/collection_query.rb
+++ b/app/queries/collection_query.rb
@@ -22,7 +22,10 @@ class CollectionQuery
   end
 
   def public_find(id)
-    relation.find_by!(unique_id: id, published: true)
+    relation.where(
+      "unique_id = ? AND (published = ? OR preview_mode = ?)",
+      id, true, true
+    ).take!
   end
 
   def any_find(id)

--- a/app/services/set_collection_preview_mode.rb
+++ b/app/services/set_collection_preview_mode.rb
@@ -1,5 +1,4 @@
 class SetCollectionPreviewMode
-
   attr_reader :collection, :value
 
   def self.call(collection, value)
@@ -7,7 +6,7 @@ class SetCollectionPreviewMode
   end
 
   def initialize(collection, value)
-    @collection = collection 
+    @collection = collection
     @value = value
   end
 

--- a/app/services/set_collection_preview_mode.rb
+++ b/app/services/set_collection_preview_mode.rb
@@ -15,4 +15,3 @@ class SetCollectionPreviewMode
     collection.save
   end
 end
-

--- a/app/services/set_collection_preview_mode.rb
+++ b/app/services/set_collection_preview_mode.rb
@@ -15,3 +15,4 @@ class SetCollectionPreviewMode
     collection.save
   end
 end
+

--- a/app/services/set_collection_preview_mode.rb
+++ b/app/services/set_collection_preview_mode.rb
@@ -1,0 +1,18 @@
+class SetCollectionPreviewMode
+
+  attr_reader :collection, :value
+
+  def self.call(collection, value)
+    new(collection, value).set_preview_mode
+  end
+
+  def initialize(collection, value)
+    @collection = collection 
+    @value = value
+  end
+
+  def set_preview_mode
+    collection.preview_mode = value
+    collection.save
+  end
+end

--- a/app/views/shared/_collection_left_nav.html.erb
+++ b/app/views/shared/_collection_left_nav.html.erb
@@ -22,6 +22,17 @@
         %>
       </div>
     </li>
+    <li class="header" role="presentation">Preview Mode</li>
+    <li>
+      <div class="togglebutton">
+        <%= react_component 'CollectionPreviewModeToggle', {
+          collection: nav.collection,
+          previewModePath: v1_collection_preview_mode_url(nav.collection.unique_id)
+        },
+        {prerender: false }
+        %>
+      </div>
+    </li>
     <li class="<%= nav.active_section_css(:livesite) %>"><a href="<%= CreateBeehiveURL.call(nav.collection) %>" target="_blank"><i class="glyphicon mdi-av-web"></i> <%= t('collection_left_nav.live_site') %></a></li>
   </ul>
   &nbsp;

--- a/app/views/shared/_collection_left_nav.html.erb
+++ b/app/views/shared/_collection_left_nav.html.erb
@@ -10,30 +10,17 @@
     <li class="<%= nav.active_section_css(:editors) %>"><a href="<%= collection_editors_path(nav.collection) %>"><i class="glyphicon glyphicon-user"></i> <%= t('collection_left_nav.editors') %></a></li>
     <li class="<%= nav.active_section_css(:settings) %>"><a href="<%= edit_collection_path(nav.collection) %>"><i class="glyphicon glyphicon-list-alt"></i> <%= t('collection_left_nav.settings') %></a></li>
     <li role="presentation" class="divider"></li>
-    <li class="header" role="presentation">Publishing Status</li>
-    <li>
-      <div class="togglebutton">
-        <%= react_component 'CollectionPublishToggle', {
+
+    <%= react_component "CollectionPreviewPublish", {
           collection: nav.collection,
+          previewModePath: v1_collection_preview_mode_url(nav.collection.unique_id),
+          previewLinkURL: CreateBeehiveURL.call(nav.collection),
+          previewLinkLabel: t('collection_left_nav.preview_site'),
+          liveLinkLabel: t('collection_left_nav.live_site'),
           publishPath: v1_collection_publish_url(nav.collection.unique_id),
           unpublishPath: v1_collection_unpublish_url(nav.collection.unique_id)
-        },
-        {prerender: false }
-        %>
-      </div>
-    </li>
-    <li class="header" role="presentation">Preview Mode</li>
-    <li>
-      <div class="togglebutton">
-        <%= react_component 'CollectionPreviewModeToggle', {
-          collection: nav.collection,
-          previewModePath: v1_collection_preview_mode_url(nav.collection.unique_id)
-        },
-        {prerender: false }
-        %>
-      </div>
-    </li>
-    <li class="<%= nav.active_section_css(:livesite) %>"><a href="<%= CreateBeehiveURL.call(nav.collection) %>" target="_blank"><i class="glyphicon mdi-av-web"></i> <%= t('collection_left_nav.live_site') %></a></li>
+      }
+    %>
   </ul>
   &nbsp;
   <a href="#" id="trig"><span id="switch" class="glyphicon glyphicon-chevron-left"></span></a>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -66,6 +66,7 @@ en:
     website: 'Site Setup'
     editors: 'Editors'
     live_site: 'Live Site'
+    preview_site: 'Preview Site'
   collection_top_nav:
     recent_collections: 'Collections'
   collections:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,6 +64,7 @@ Rails.application.routes.draw do
               defaults: { format: :json } do
       put :publish, defaults: { format: :json }
       put :unpublish, defaults: { format: :json }
+      put :preview_mode, defaults: { format: :json }
       resources :items, only: [:index], defaults: { format: :json }
       resources :showcases, only: [:index], defaults: { format: :json }
     end

--- a/db/migrate/20150616185505_add_preview_mode_to_collections.rb
+++ b/db/migrate/20150616185505_add_preview_mode_to_collections.rb
@@ -1,0 +1,6 @@
+class AddPreviewModeToCollections < ActiveRecord::Migration
+  def change
+    add_column :collections, :preview_mode, :boolean
+    add_index :collections, :preview_mode
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -105,16 +105,6 @@ ActiveRecord::Schema.define(version: 20150616185505) do
 
   add_index "sections", ["unique_id"], name: "index_sections_on_unique_id", using: :btree
 
-  create_table "sessions", force: :cascade do |t|
-    t.string   "session_id", limit: 255,   null: false
-    t.text     "data",       limit: 65535
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
-  add_index "sessions", ["session_id"], name: "index_sessions_on_session_id", unique: true, using: :btree
-  add_index "sessions", ["updated_at"], name: "index_sessions_on_updated_at", using: :btree
-
   create_table "showcases", force: :cascade do |t|
     t.text     "name_line_1",        limit: 65535
     t.text     "description",        limit: 65535

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150604150434) do
+ActiveRecord::Schema.define(version: 20150616185505) do
 
   create_table "collection_users", force: :cascade do |t|
     t.integer  "user_id",       limit: 4, null: false
@@ -24,16 +24,18 @@ ActiveRecord::Schema.define(version: 20150604150434) do
   add_index "collection_users", ["user_id"], name: "index_collection_users_on_user_id", using: :btree
 
   create_table "collections", force: :cascade do |t|
-    t.string   "name_line_1", limit: 255
+    t.string   "name_line_1",  limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "deleted",     limit: 1,     default: false
-    t.text     "description", limit: 65535
-    t.string   "unique_id",   limit: 255
-    t.boolean  "published",   limit: 1
-    t.string   "name_line_2", limit: 255
+    t.boolean  "deleted",      limit: 1,     default: false
+    t.text     "description",  limit: 65535
+    t.string   "unique_id",    limit: 255
+    t.boolean  "published",    limit: 1
+    t.string   "name_line_2",  limit: 255
+    t.boolean  "preview_mode", limit: 1
   end
 
+  add_index "collections", ["preview_mode"], name: "index_collections_on_preview_mode", using: :btree
   add_index "collections", ["published"], name: "index_collections_on_published", using: :btree
   add_index "collections", ["unique_id"], name: "index_collections_on_unique_id", using: :btree
 
@@ -102,6 +104,16 @@ ActiveRecord::Schema.define(version: 20150604150434) do
   end
 
   add_index "sections", ["unique_id"], name: "index_sections_on_unique_id", using: :btree
+
+  create_table "sessions", force: :cascade do |t|
+    t.string   "session_id", limit: 255,   null: false
+    t.text     "data",       limit: 65535
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "sessions", ["session_id"], name: "index_sessions_on_session_id", unique: true, using: :btree
+  add_index "sessions", ["updated_at"], name: "index_sessions_on_updated_at", using: :btree
 
   create_table "showcases", force: :cascade do |t|
     t.text     "name_line_1",        limit: 65535

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -288,5 +288,4 @@ RSpec.describe CollectionsController, type: :controller do
       expect(response).to be_redirect
     end
   end
-
 end

--- a/spec/controllers/v1/collections_controller_spec.rb
+++ b/spec/controllers/v1/collections_controller_spec.rb
@@ -107,14 +107,8 @@ RSpec.describe V1::CollectionsController, type: :controller do
   describe "#preview_mode" do
     let(:collection_to_preview) { Collection.new(id: 1, preview_mode: false) }
     let(:collection_not_to_preview) { Collection.new(id: 2, preview_mode: true) }
-    let(:set_preview_mode_true) { put :preview_mode, 
-                  collection_id: collection_to_preview.id,
-                  value: true,
-                  format: :json }
-    let(:set_preview_mode_false) { put :preview_mode, 
-                  collection_id: collection_not_to_preview.id,
-                  value: false,
-                  format: :json }
+    let(:set_preview_mode_true) { put :preview_mode, collection_id: collection_to_preview.id, value: true, format: :json }
+    let(:set_preview_mode_false) { put :preview_mode, collection_id: collection_not_to_preview.id, value: false, format: :json }
 
     it "calls CollectionQuery" do
       expect_any_instance_of(CollectionQuery).to receive(:any_find).with("1").and_return(collection_to_preview)

--- a/spec/controllers/v1/collections_controller_spec.rb
+++ b/spec/controllers/v1/collections_controller_spec.rb
@@ -103,4 +103,36 @@ RSpec.describe V1::CollectionsController, type: :controller do
       end
     end
   end
+
+  describe "#preview_mode" do
+    let(:collection_to_preview) { Collection.new(id: 1, preview_mode: false) }
+    let(:collection_not_to_preview) { Collection.new(id: 2, preview_mode: true) }
+    let(:set_preview_mode_true) { put :preview_mode, 
+                  collection_id: collection_to_preview.id,
+                  value: true,
+                  format: :json }
+    let(:set_preview_mode_false) { put :preview_mode, 
+                  collection_id: collection_not_to_preview.id,
+                  value: false,
+                  format: :json }
+
+    it "calls CollectionQuery" do
+      expect_any_instance_of(CollectionQuery).to receive(:any_find).with("1").and_return(collection_to_preview)
+      set_preview_mode_true
+    end
+
+    it "sets preview mode for collection to true" do
+      expect_any_instance_of(CollectionQuery).to receive(:any_find).with("1").and_return(collection_to_preview)
+      expect_any_instance_of(SetCollectionPreviewMode).to receive(:set_preview_mode).and_return(true)
+      set_preview_mode_true
+      expect(response.body).to eq("{\"status\":true}")
+    end
+
+    it "sets preview mode for collection to false" do
+      expect_any_instance_of(CollectionQuery).to receive(:any_find).with("2").and_return(collection_not_to_preview)
+      expect_any_instance_of(SetCollectionPreviewMode).to receive(:set_preview_mode).and_return(true)
+      set_preview_mode_false
+      expect(response.body).to eq("{\"status\":true}")
+    end
+  end
 end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Collection do
-  [:name_line_1, :name_line_2, :items, :description, :unique_id, :showcases, :exhibit, :collection_users, :users, :updated_at, :created_at].each do |field|
+  [:name_line_1, :name_line_2, :items, :description, :unique_id, :showcases, :exhibit, :collection_users, :published, :preview_mode, :users, :updated_at, :created_at].each do |field|
     it "has field, #{field}" do
       expect(subject).to respond_to(field)
       expect(subject).to respond_to("#{field}=")

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -1,7 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Collection do
-  [:name_line_1, :name_line_2, :items, :description, :unique_id, :showcases, :exhibit, :collection_users, :published, :preview_mode, :users, :updated_at, :created_at].each do |field|
+  [:name_line_1, :name_line_2, :items, :description, :unique_id, :showcases, :exhibit,
+   :collection_users, :published, :preview_mode, :users, :updated_at, :created_at].each do |field|
     it "has field, #{field}" do
       expect(subject).to respond_to(field)
       expect(subject).to respond_to("#{field}=")

--- a/spec/queries/collection_query_spec.rb
+++ b/spec/queries/collection_query_spec.rb
@@ -37,8 +37,9 @@ describe CollectionQuery do
 
   describe "public_find" do
     it "calls public_find!" do
-      expect(relation).to receive(:where)
-        .with("unique_id = ? AND (published = ? OR preview_mode = ?)", "asdf", true, true).and_return(@collection_array = [collection])
+      expect(relation).to receive(:where).
+        with("unique_id = ? AND (published = ? OR preview_mode = ?)", "asdf", true, true).
+        and_return(@collection_array = [collection])
       expect(@collection_array).to receive(:take!).and_return(collection)
       subject.public_find("asdf")
     end

--- a/spec/queries/collection_query_spec.rb
+++ b/spec/queries/collection_query_spec.rb
@@ -37,7 +37,9 @@ describe CollectionQuery do
 
   describe "public_find" do
     it "calls public_find!" do
-      expect(relation).to receive(:find_by!).with(unique_id: "asdf", published: true)
+      expect(relation).to receive(:where).with("unique_id = ? AND (published = ? OR preview_mode = ?)", "asdf", true, true).and_return(@collection_array = [collection])
+      expect(@collection_array).to receive(:take!).and_return(collection)
+      # expect(relation).to receive(:find_by!).with(unique_id: "asdf", published: true)
       subject.public_find("asdf")
     end
 

--- a/spec/queries/collection_query_spec.rb
+++ b/spec/queries/collection_query_spec.rb
@@ -37,9 +37,9 @@ describe CollectionQuery do
 
   describe "public_find" do
     it "calls public_find!" do
-      expect(relation).to receive(:where).with("unique_id = ? AND (published = ? OR preview_mode = ?)", "asdf", true, true).and_return(@collection_array = [collection])
+      expect(relation).to receive(:where)
+        .with("unique_id = ? AND (published = ? OR preview_mode = ?)", "asdf", true, true).and_return(@collection_array = [collection])
       expect(@collection_array).to receive(:take!).and_return(collection)
-      # expect(relation).to receive(:find_by!).with(unique_id: "asdf", published: true)
       subject.public_find("asdf")
     end
 

--- a/spec/services/set_collection_preview_mode_spec.rb
+++ b/spec/services/set_collection_preview_mode_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+describe "SetCollectionPreviewMode" do
+  let(:collection) { double(Collection, "preview_mode=" => false, save: true) }
+  subject(:subject) { SetCollectionPreviewMode.new(collection, true) }
+
+  describe "#!enable_preview" do
+   it "should set the preview mode to true" do
+      expect(collection).to receive(:preview_mode=).with(true)
+      subject.set_preview_mode
+   end
+
+   it "should save the collection record" do
+     expect(collection).to receive(:save).and_return(true)
+     subject.set_preview_mode
+   end
+
+   it "should return false if the save fails" do
+     allow(collection).to receive("save").and_return(false)
+     expect(subject.set_preview_mode).to be_falsey
+   end
+  end
+
+  describe "#!call" do
+    it "uses the set_preview_mode method" do
+      expect_any_instance_of(SetCollectionPreviewMode).to receive(:set_preview_mode)
+      SetCollectionPreviewMode.call(collection, true)
+    end 
+  end
+end

--- a/spec/services/set_collection_preview_mode_spec.rb
+++ b/spec/services/set_collection_preview_mode_spec.rb
@@ -5,26 +5,26 @@ describe "SetCollectionPreviewMode" do
   subject(:subject) { SetCollectionPreviewMode.new(collection, true) }
 
   describe "#!enable_preview" do
-   it "should set the preview mode to true" do
+    it "should set the preview mode to true" do
       expect(collection).to receive(:preview_mode=).with(true)
       subject.set_preview_mode
-   end
+    end
 
-   it "should save the collection record" do
-     expect(collection).to receive(:save).and_return(true)
-     subject.set_preview_mode
-   end
+    it "should save the collection record" do
+      expect(collection).to receive(:save).and_return(true)
+      subject.set_preview_mode
+    end
 
-   it "should return false if the save fails" do
-     allow(collection).to receive("save").and_return(false)
-     expect(subject.set_preview_mode).to be_falsey
-   end
+    it "should return false if the save fails" do
+      allow(collection).to receive("save").and_return(false)
+      expect(subject.set_preview_mode).to be_falsey
+    end
   end
 
   describe "#!call" do
     it "uses the set_preview_mode method" do
       expect_any_instance_of(SetCollectionPreviewMode).to receive(:set_preview_mode)
       SetCollectionPreviewMode.call(collection, true)
-    end 
+    end
   end
 end

--- a/spec/services/set_collection_preview_mode_spec.rb
+++ b/spec/services/set_collection_preview_mode_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe "SetCollectionPreviewMode" do
-  let(:collection) { double(Collection, "preview_mode=" => false, save: true) }
+  let(:collection) { instance_double(Collection, "preview_mode=" => false, save: true) }
   subject(:subject) { SetCollectionPreviewMode.new(collection, true) }
 
   describe "#!enable_preview" do
@@ -16,7 +16,7 @@ describe "SetCollectionPreviewMode" do
     end
 
     it "should return false if the save fails" do
-      allow(collection).to receive("save").and_return(false)
+      allow(collection).to receive(:save).and_return(false)
       expect(subject.set_preview_mode).to be_falsey
     end
   end


### PR DESCRIPTION
**WHAT** Added functionality for managing a preview mode for collections. When preview mode is turned on, the collection remains hidden from the DEC home page but can be accessed via a direct URL.

**HOW** Added a service class to manage the preview mode attribute on collections, and added a new boolean field on collections. Added a react component for switching preview mode on and off. Modified the public_find() method for collection queries so that it accounts for the preview mode.

**WHY** We needed a way to enable preview mode so that the preview link on the admin interface would work, and to allow editors to share an accessible link with other individuals who are not editors so that they can view the work in progress prior to it being published.