### PR TITLE
Advanced seed data using external repo

### DIFF
--- a/app/services/brood/collection.rb
+++ b/app/services/brood/collection.rb
@@ -1,0 +1,98 @@
+module Brood
+  class Collection
+    attr_reader :base_path, :item_count
+
+    def initialize(base_path)
+      @base_path = base_path
+      @item_count = 0
+    end
+
+    def data
+      @data ||= JSON.parse(File.read(path("data.json")))
+    end
+
+    def collection_data
+      data["collection"]
+    end
+
+    def items_data
+      data["items"]
+    end
+
+    def total_item_count
+      items_data.count
+    end
+
+    def item_defaults
+      @item_defaults ||= {
+        "collection" => { "relationship" => "Collection/#{collection_data['unique_id']}" },
+      }
+    end
+
+    def grow!
+      set_progress
+      grow_collection!
+      set_progress
+      grow_items!
+      set_progress_complete
+    end
+
+    def grow_items!
+      items_data.each_with_index do |original_item_data|
+        item_data = item_defaults.merge(original_item_data)
+        grow_item!(item_data)
+        @item_count += 1
+        set_progress
+      end
+    end
+
+    def grow_brood_record(klass, data)
+      Brood::Record.grow(klass: klass, data: data, brood_collection: self)
+    end
+
+    def save_brood_record!(klass, data)
+      record = grow_brood_record(klass, data)
+      record.save!
+      record
+    end
+
+    def brood_collection
+      @brood_collection ||= grow_brood_record(::Collection, collection_data)
+    end
+
+    def grow_collection!
+      unless SaveCollection.call(brood_collection.record, brood_collection.data)
+        error_saving_record(brood_collection)
+      end
+    end
+
+    def grow_item!(data)
+      brood_record = grow_brood_record(::Item, data)
+      unless SaveItem.call(brood_record.record, brood_record.data)
+        error_saving_record(brood_record)
+      end
+    end
+
+    def error_saving_record(brood_record)
+      raise "#{brood_record.record.class} #{brood_record.record} not saved: #{brood_record.data}.\n#{brood_record.record.errors.full_messages}"
+    end
+
+    def path(path_segment)
+      File.join(base_path, path_segment)
+    end
+
+    def set_progress
+      $stdout.write "\r#{progress_message}"
+      $stdout.flush
+    end
+
+    def set_progress_complete
+      set_progress
+      $stdout.write("\n")
+    end
+
+    def progress_message
+      "Importing collection #{brood_collection.record.unique_id}: #{item_count}/#{total_item_count} items"
+    end
+  end
+end

--- a/app/services/brood/record.rb
+++ b/app/services/brood/record.rb
@@ -1,0 +1,86 @@
+module Brood
+  class Record
+    attr_reader :record, :original_data, :brood_collection
+
+    def initialize(record:, data:, brood_collection:)
+      @record = record
+      @original_data = data
+      @brood_collection = brood_collection
+    end
+
+    def grow
+      data.each do |key, value|
+        record.send("#{key}=", value)
+      end
+    end
+
+    def self.grow(klass:, data:, brood_collection:)
+      record = klass.find_or_initialize_by(unique_id: data["unique_id"])
+      brood_record = new(record: record, data: data, brood_collection: brood_collection)
+      brood_record.grow
+      brood_record
+    end
+
+    def data
+      @data ||= {}.with_indifferent_access.tap do |hash|
+        skipped = {}
+        original_data.each do |key, original_value|
+          value = brood_value(original_value)
+          if record.respond_to?("#{key}=")
+            hash[key] = value
+          else
+            skipped[key] = value
+          end
+        end
+        if skipped.present?
+          append_skipped_values(hash, skipped)
+        end
+      end
+    end
+
+    def append_skipped_values(data, values)
+      if record.respond_to?(:description)
+        debug "Appending values to #{record}#description: #{values}"
+        append_values_to_description(data, values)
+      else
+        debug "Discarding values on #{record}: #{values}"
+      end
+    end
+
+    def append_values_to_description(data, values)
+      if data[:description].present?
+        data[:description] += "\n\n"
+      else
+        data[:description] = ""
+      end
+      description_append = values.map { |key, value| "#{key.to_s.titleize}: #{value}" }
+      data[:description] += description_append.join("\n")
+    end
+
+    def brood_value(value)
+      if value.is_a?(Hash)
+        if value["relationship"]
+          find_record(value["relationship"])
+        elsif value["file"]
+          open_file(value["file"])
+        end
+      else
+        value
+      end
+    end
+
+    def find_record(value)
+      klass_string, unique_id = value.split("/")
+      klass = "::#{klass_string}".constantize
+      klass.where(unique_id: unique_id).take!
+    end
+
+    def open_file(file)
+      File.open(brood_collection.path("files/#{file}"))
+    end
+
+    def debug(message)
+      Rails.logger.debug "[Brood::Record] #{message}"
+    end
+  end
+end

--- a/app/services/brood/repo.rb
+++ b/app/services/brood/repo.rb
@@ -1,0 +1,54 @@
+module Brood
+  class Repo
+    attr_reader :url, :path, :branch
+
+    def self.default
+      new(github: "ndlib/honeycomb-brood")
+    end
+
+    def initialize(github:, branch: :master)
+      @branch = branch
+      set_github_url(github)
+    end
+
+    def grow!
+      clone_and_pull
+      set = Brood::Set.new(path)
+      set.grow!
+    end
+
+    def clone_and_pull
+      clone
+      pull
+    end
+
+    def clone
+      unless File.directory?(path) && File.directory?(File.join(path, ".git"))
+        FileUtils.mkdir_p(path)
+        `git clone #{Shellwords.escape(url)} #{Shellwords.escape(path)}`
+      end
+    end
+
+    def checkout_branch
+      git_command("checkout #{branch}")
+    end
+
+    def pull
+      checkout_branch
+      git_command("pull")
+    end
+
+    def git_command(command)
+      `cd #{Shellwords.escape(path)} && git #{command}`
+    end
+
+    def set_path(path_segment)
+      @path = Rails.root.join("tmp/brood", path_segment)
+    end
+
+    def set_github_url(repo_name)
+      @url = "https://github.com/#{repo_name}.git"
+      set_path(repo_name)
+    end
+  end
+end

--- a/app/services/brood/set.rb
+++ b/app/services/brood/set.rb
@@ -1,0 +1,32 @@
+module Brood
+  class Set
+    attr_reader :base_path
+
+    def initialize(base_path)
+      @base_path = base_path
+    end
+
+    def data
+      @data ||= JSON.parse(File.read(path("collections.json")))
+    end
+
+    def grow!
+      grow_collections!
+    end
+
+    def grow_collections!
+      data.each do |collection_name|
+        grow_collection!(collection_name)
+      end
+    end
+
+    def grow_collection!(collection_name)
+      collection = Brood::Collection.new(path(collection_name))
+      collection.grow!
+    end
+
+    def path(path_segment)
+      File.join(base_path, path_segment)
+    end
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -18,3 +18,6 @@
   u.admin = true
   u.save!
 end
+
+brood = Brood::Repo.new(github: "ndlib/honeycomb-brood")
+brood.grow!


### PR DESCRIPTION
This creates some seed data for development purposes.

I've tied the classes in to the `rake db:seed` task, but it could be made its own task if we wanted.

It pulls seed data from an external repo at https://github.com/ndlib/honeycomb-brood (so we don't have to store large files in this repo) and creates collections and items as defined in the repo.  It abuses the unique_id field to maintain its relationships, so urls on the front end wouldn't change after dropping/recreating the database.

It could also be updated *relatively* easily to add showcases/sections.