### PR TITLE
Adding ES6 support

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -33,7 +33,7 @@ module ItemAdmin
 
     config.react.variant = :production
     config.react.addons = true
-    config.browserify_rails.commandline_options = "--transform reactify --extension=\".jsx\""
+    config.browserify_rails.commandline_options = "--transform  [ reactify --es6 ] --extension=\".jsx\""
 
     config.assets.precompile = [proc { |path| !File.extname(path).in?([".js", ".css", ".map", ".gzip", ""]) }, /(?:\/|\\|\A)application\.(css|js)$/]
 


### PR DESCRIPTION
Updating the browserify command so we can take adavantage of React 0.13+ ability to handle ES6 transformation.

https://facebook.github.io/react/blog/2015/01/27/react-v0.13.0-beta-1.html