### PR TITLE
DEC-432: On destroy, cascade

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -106,6 +106,8 @@ group :development, :test do
   gem "web-console", "~> 2.0"
 
   gem "factory_girl_rails"
+
+  gem "rails-erd"
 end
 
 # Dalli Caching

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,7 @@ GEM
       xpath (~> 2.0)
     celluloid (0.16.0)
       timers (~> 4.0.0)
+    choice (0.2.0)
     climate_control (0.0.3)
       activesupport (>= 3.0)
     cocaine (0.5.4)
@@ -275,6 +276,11 @@ GEM
       activesupport (>= 4.2.0.beta, < 5.0)
       nokogiri (~> 1.6.0)
       rails-deprecated_sanitizer (>= 1.0.1)
+    rails-erd (1.4.0)
+      activerecord (>= 3.2)
+      activesupport (>= 3.2)
+      choice (~> 0.2.0)
+      ruby-graphviz (~> 1.2)
     rails-html-sanitizer (1.0.2)
       loofah (~> 2.0)
     railties (4.2.2)
@@ -326,6 +332,7 @@ GEM
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.4)
+    ruby-graphviz (1.2.2)
     ruby-progressbar (1.7.5)
     rubycas-client (2.3.9)
       activesupport
@@ -454,6 +461,7 @@ DEPENDENCIES
   pry-nav
   rack-cache
   rails (~> 4.2.0)
+  rails-erd
   rake
   rb-readline
   react-rails (~> 1.0.0.pre)!

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -56,7 +56,7 @@ class CollectionsController < ApplicationController
     check_admin_or_admin_masquerading_permission!
 
     @collection = CollectionQuery.new.find(params[:id])
-    @collection.destroy!
+    Destroy::Collection.new.cascade!(collection: @collection)
 
     flash[:notice] = t(".success")
     redirect_to collections_path

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -44,8 +44,8 @@ class ItemsController < ApplicationController
   def destroy
     @item = ItemQuery.new.find(params[:id])
     check_user_edits!(@item.collection)
+    Destroy::Item.new.destroy!(item: @item)
 
-    @item.destroy!
     flash[:notice] = t(".success")
 
     redirect_to collection_path(@item.collection)

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -52,8 +52,7 @@ class SectionsController < ApplicationController
   def destroy
     @section = SectionQuery.new.find(params[:id])
     check_user_edits!(@section.showcase.exhibit.collection)
-
-    @section.destroy!
+    Destroy::Section.new.cascade!(section: @section)
 
     flash[:notice] = t(".success")
     redirect_to edit_showcase_path(@section.showcase.id)

--- a/app/controllers/showcases_controller.rb
+++ b/app/controllers/showcases_controller.rb
@@ -72,8 +72,7 @@ class ShowcasesController < ApplicationController
   def destroy
     @showcase = ShowcaseQuery.new.find(params[:id])
     check_user_edits!(@showcase.collection)
-
-    @showcase.destroy!
+    Destroy::Showcase.new.cascade!(showcase: @showcase)
 
     flash[:notice] = t(".success")
     redirect_to exhibit_path(@showcase.exhibit)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -26,11 +26,8 @@ class UsersController < ApplicationController
   def destroy
     check_admin_or_admin_masquerading_permission!
     @user = User.find(params[:id])
-    if @user.destroy
-      flash[:notice] = t(".success")
-    else
-      flash[:error] = t(".failure")
-    end
+    Destroy::User.new.cascade!(user: @user)
+    flash[:notice] = t(".success")
 
     redirect_to users_path
   end

--- a/app/models/collection_user.rb
+++ b/app/models/collection_user.rb
@@ -1,4 +1,6 @@
 class CollectionUser < ActiveRecord::Base
   belongs_to :collection
   belongs_to :user
+
+  has_paper_trail
 end

--- a/app/models/exhibit.rb
+++ b/app/models/exhibit.rb
@@ -11,6 +11,10 @@ class Exhibit < ActiveRecord::Base
   validates_attachment_content_type :image, content_type: /\Aimage\/.*\Z/
   validates_attachment_content_type :uploaded_image, content_type: /\Aimage\/.*\Z/
 
+  validates :collection, presence: true
+
+  has_paper_trail
+
   def items_json_url
     "/api/collections/#{collection_id}/items.json?include=image"
   end

--- a/app/models/honeypot_image.rb
+++ b/app/models/honeypot_image.rb
@@ -9,6 +9,8 @@ class HoneypotImage < ActiveRecord::Base
 
   before_validation :set_values_from_json_response
 
+  has_paper_trail
+
   def json_response=(*args)
     super(*args)
     set_values_from_json_response

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -5,6 +5,8 @@ class Section < ActiveRecord::Base
 
   validates :showcase, presence: true
 
+  has_paper_trail
+
   def slug
     name
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,8 @@ class User < ActiveRecord::Base
 
   scope :username, ->(username) {  where(username: username) }
 
+  has_paper_trail
+
   def name
     "#{first_name} #{last_name}"
   end

--- a/app/queries/item_query.rb
+++ b/app/queries/item_query.rb
@@ -28,6 +28,6 @@ class ItemQuery
   end
 
   def can_delete?
-    relation.showcases.count == 0
+    !relation.showcases.any? && !relation.children.any?
   end
 end

--- a/app/services/destroy/collection.rb
+++ b/app/services/destroy/collection.rb
@@ -1,0 +1,33 @@
+module Destroy
+  class Collection
+    attr_reader :destroy_collection_user, :destroy_exhibit, :destroy_item
+
+    # Allow injecting destroy objects to use when cascading
+    def initialize(destroy_collection_user: nil, destroy_exhibit: nil, destroy_item: nil)
+      @destroy_collection_user = destroy_collection_user || Destroy::CollectionUser.new
+      @destroy_exhibit = destroy_exhibit || Destroy::Exhibit.new
+      @destroy_item = destroy_item || Destroy::Item.new
+    end
+
+    # Destroy the object only
+    def destroy!(collection:)
+      collection.destroy!
+    end
+
+    # Destroys this object and all associated objects.
+    def cascade!(collection: collection)
+      ActiveRecord::Base.transaction do
+        collection.collection_users.each do |child|
+          @destroy_collection_user.cascade!(collection_user: child)
+        end
+        if collection.exhibit
+          @destroy_exhibit.cascade!(exhibit: collection.exhibit)
+        end
+        collection.items.each do |child|
+          @destroy_item.cascade!(item: child)
+        end
+        collection.destroy!
+      end
+    end
+  end
+end

--- a/app/services/destroy/collection_user.rb
+++ b/app/services/destroy/collection_user.rb
@@ -1,0 +1,14 @@
+module Destroy
+  class CollectionUser
+    # Destroy the object only
+    def destroy!(collection_user:)
+      collection_user.destroy!
+    end
+
+    # There are no additional cascades for CollectionUser,
+    # so destroys the object only
+    def cascade!(collection_user:)
+      collection_user.destroy!
+    end
+  end
+end

--- a/app/services/destroy/exhibit.rb
+++ b/app/services/destroy/exhibit.rb
@@ -1,0 +1,25 @@
+module Destroy
+  class Exhibit
+    attr_reader :destroy_showcase
+
+    # Allow injecting destroy objects to use when cascading
+    def initialize(destroy_showcase: nil)
+      @destroy_showcase = destroy_showcase || Destroy::Showcase.new
+    end
+
+    # Destroy the object only
+    def destroy!(exhibit:)
+      exhibit.destroy!
+    end
+
+    # Destroys this object and all associated objects.
+    def cascade!(exhibit: exhibit)
+      ActiveRecord::Base.transaction do
+        exhibit.showcases.each do |child|
+          @destroy_showcase.cascade!(showcase: child)
+        end
+        exhibit.destroy!
+      end
+    end
+  end
+end

--- a/app/services/destroy/item.rb
+++ b/app/services/destroy/item.rb
@@ -1,0 +1,28 @@
+module Destroy
+  class Item
+    attr_reader :destroy_section
+
+    # Allow injecting destroy objects to use when cascading
+    def initialize(destroy_section: nil)
+      @destroy_section = destroy_section || Destroy::Section.new
+    end
+
+    # Destroy the object only
+    def destroy!(item:)
+      item.destroy!
+    end
+
+    # Destroys this object and all associated objects.
+    def cascade!(item: item)
+      ActiveRecord::Base.transaction do
+        item.sections.each do |child|
+          @destroy_section.cascade!(section: child)
+        end
+        item.children.each do |child|
+          cascade!(item: child)
+        end
+        item.destroy!
+      end
+    end
+  end
+end

--- a/app/services/destroy/section.rb
+++ b/app/services/destroy/section.rb
@@ -1,0 +1,14 @@
+module Destroy
+  class Section
+    # Destroy the object only
+    def destroy!(section:)
+      section.destroy!
+    end
+
+    # There are no additional cascades for Sections,
+    # so destroys the object only
+    def cascade!(section:)
+      section.destroy!
+    end
+  end
+end

--- a/app/services/destroy/showcase.rb
+++ b/app/services/destroy/showcase.rb
@@ -1,0 +1,25 @@
+module Destroy
+  class Showcase
+    attr_reader :destroy_section
+
+    # Allow injecting destroy objects to use when cascading
+    def initialize(destroy_section: nil)
+      @destroy_section = destroy_section || Destroy::Section.new
+    end
+
+    # Destroy the object only
+    def destroy!(showcase:)
+      showcase.destroy!
+    end
+
+    # Destroys this object and all associated objects.
+    def cascade!(showcase: showcase)
+      ActiveRecord::Base.transaction do
+        showcase.sections.each do |child|
+          @destroy_section.cascade!(section: child)
+        end
+        showcase.destroy!
+      end
+    end
+  end
+end

--- a/app/services/destroy/user.rb
+++ b/app/services/destroy/user.rb
@@ -1,0 +1,25 @@
+module Destroy
+  class User
+    attr_reader :destroy_collection_user
+
+    # Allow injecting destroy objects to use when cascading
+    def initialize(destroy_collection_user: nil)
+      @destroy_collection_user = destroy_collection_user || Destroy::CollectionUser.new
+    end
+
+    # Destroy the object only
+    def destroy!(user:)
+      user.destroy!
+    end
+
+    # Destroys this object and all associated objects.
+    def cascade!(user: user)
+      ActiveRecord::Base.transaction do
+        user.collection_users.each do |child|
+          @destroy_collection_user.cascade!(collection_user: child)
+        end
+        user.destroy!
+      end
+    end
+  end
+end

--- a/app/services/remove_user_from_collection.rb
+++ b/app/services/remove_user_from_collection.rb
@@ -2,7 +2,7 @@ class RemoveUserFromCollection
   attr_reader :collection, :user
 
   def self.call(collection, user)
-    new(collection, user).delete!
+    new(collection, user).destroy
   end
 
   def initialize(collection, user)
@@ -10,8 +10,8 @@ class RemoveUserFromCollection
     @user = user
   end
 
-  def delete!
-    collection_user.destroy
+  def destroy!
+    Destroy::CollectionUser.new.destroy!(collection_user: collection_user)
   end
 
   private

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -155,7 +155,7 @@ en:
     delete_panel:
       heading: Delete this Item
       message: "Proceed with caution. This will also remove all the items information from the site."
-      cannot_delete_message: "Deleting this item is disabled due to its usage in one or more showcases. Please first remove the item from these showcases."
+      cannot_delete_message: "Deleting this item is disabled due to its additional resources or its usage in one or more showcases. Please first remove the additional resources from the item and ensure the item is not used in any showcases."
   item_children:
     new:
       title: "Upload Additional Resources"

--- a/db/migrate/20150623132325_add_foreign_key_constraints.rb
+++ b/db/migrate/20150623132325_add_foreign_key_constraints.rb
@@ -1,0 +1,12 @@
+class AddForeignKeyConstraints < ActiveRecord::Migration
+  def change
+    add_foreign_key :exhibits, :collections
+    add_foreign_key :collection_users, :collections
+    add_foreign_key :items, :collections
+    add_foreign_key :showcases, :exhibits
+    add_foreign_key :sections, :showcases
+    add_foreign_key :sections, :items
+    add_foreign_key :items, :items, column: :parent_id
+    add_foreign_key :collection_users, :users
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150616185505) do
+ActiveRecord::Schema.define(version: 20150623132325) do
 
   create_table "collection_users", force: :cascade do |t|
     t.integer  "user_id",       limit: 4, null: false
@@ -57,6 +57,8 @@ ActiveRecord::Schema.define(version: 20150616185505) do
     t.datetime "uploaded_image_updated_at"
     t.text     "copyright",                   limit: 65535
   end
+
+  add_index "exhibits", ["collection_id"], name: "fk_rails_b56f41d7b6", using: :btree
 
   create_table "honeypot_images", force: :cascade do |t|
     t.integer  "item_id",       limit: 4
@@ -111,6 +113,8 @@ ActiveRecord::Schema.define(version: 20150616185505) do
     t.datetime "created_at"
   end
 
+  add_index "sections", ["item_id"], name: "fk_rails_921f48e5e7", using: :btree
+  add_index "sections", ["showcase_id"], name: "fk_rails_9a3e59b41b", using: :btree
   add_index "sections", ["unique_id"], name: "index_sections_on_unique_id", using: :btree
 
   create_table "showcases", force: :cascade do |t|
@@ -133,6 +137,7 @@ ActiveRecord::Schema.define(version: 20150616185505) do
     t.datetime "uploaded_image_updated_at"
   end
 
+  add_index "showcases", ["exhibit_id"], name: "fk_rails_ee93a134d7", using: :btree
   add_index "showcases", ["order"], name: "index_showcases_on_order", using: :btree
   add_index "showcases", ["published"], name: "index_showcases_on_published", using: :btree
   add_index "showcases", ["unique_id"], name: "index_showcases_on_unique_id", using: :btree
@@ -167,4 +172,12 @@ ActiveRecord::Schema.define(version: 20150616185505) do
 
   add_index "versions", ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id", using: :btree
 
+  add_foreign_key "collection_users", "collections"
+  add_foreign_key "collection_users", "users"
+  add_foreign_key "exhibits", "collections"
+  add_foreign_key "items", "collections"
+  add_foreign_key "items", "items", column: "parent_id"
+  add_foreign_key "sections", "items"
+  add_foreign_key "sections", "showcases"
+  add_foreign_key "showcases", "exhibits"
 end

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 require "cache_spec_helper"
 
 RSpec.describe CollectionsController, type: :controller do
-  let(:collection) { instance_double(Collection, id: 1, name_line_1: "COLLECTION", destroy!: true) }
+  let(:collection) { instance_double(Collection, id: 1, name_line_1: "COLLECTION", destroy!: true, collection_users: [], exhibit: nil, items: []) }
 
   let(:create_params) { { collection: { name_line_1: "TITLE!!" } } }
   let(:update_params) { { id: "1", published: true, collection: { name_line_1: "TITLE!!" } } }
@@ -201,6 +201,11 @@ RSpec.describe CollectionsController, type: :controller do
     it "redirects on success " do
       delete :destroy, id: "1"
       expect(response).to be_redirect
+    end
+
+    it "uses the Destroy::Collection.cascade! method" do
+      expect_any_instance_of(Destroy::Collection).to receive(:cascade!)
+      delete :destroy, id: "1"
     end
 
     it_behaves_like "a private content-based etag cacher" do

--- a/spec/controllers/editors_controller_spec.rb
+++ b/spec/controllers/editors_controller_spec.rb
@@ -3,8 +3,8 @@ require "cache_spec_helper"
 
 RSpec.describe EditorsController, type: :controller do
   let(:collection) { instance_double(Collection, id: 1, collection_users: []) }
-  let(:user) { instance_double(User, id: 100, username: "username", name: "name") }
-  let(:collection_user) { double(CollectionUser, id: 1) }
+  let(:user) { instance_double(User, id: 100, username: "username", name: "name", display_name: "displayname") }
+  let(:collection_user) { instance_double(CollectionUser, id: 1, user_id: user.id, collection_id: collection.id, user: user) }
 
   before(:each) do
     sign_in_admin
@@ -38,6 +38,10 @@ RSpec.describe EditorsController, type: :controller do
   end
 
   describe "#create" do
+    before(:each) do
+      allow_any_instance_of(CollectionUser).to receive(:save).and_return(true)
+    end
+
     it "maps a user to a collection" do
       expect(FindOrCreateUser).to receive(:call).with(user.username).and_return(user)
       expect(AssignUserToCollection).to receive(:call).with(collection, user).and_return(collection_user)

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -188,7 +188,7 @@ RSpec.describe ItemsController, type: :controller do
 
   describe "DELETE #destroy" do
     let(:collection) { double(Collection, id: "1") }
-    let(:item) { double(Item, id: 1, collection: collection, destroy!: true) }
+    let(:item) { double(Item, id: 1, collection: collection, destroy!: true, sections: [], children: []) }
 
     subject { delete :destroy, id: item.id }
 
@@ -196,9 +196,7 @@ RSpec.describe ItemsController, type: :controller do
       allow_any_instance_of(ItemQuery).to receive(:find).and_return(item)
     end
 
-    it "calls destroy on the item on success, redirects, and flashes " do
-      expect(item).to receive(:destroy!).and_return(true)
-
+    it "on success, redirects, and flashes " do
       subject
       expect(response).to be_redirect
       expect(flash[:notice]).to_not be_nil
@@ -218,6 +216,15 @@ RSpec.describe ItemsController, type: :controller do
 
     it "uses item query " do
       expect_any_instance_of(ItemQuery).to receive(:find).with("1").and_return(item)
+      subject
+    end
+
+    # We should not cascade here since we've decided the user needs to correct
+    # the associations before deleting the item. If we later decide to just clean
+    # up all children and sections for the user when deleting the Item, then change
+    # this to use cascade
+    it "uses the Destroy::Item.destroy! method" do
+      expect_any_instance_of(Destroy::Item).to receive(:destroy!)
       subject
     end
 

--- a/spec/controllers/sections_controller_spec.rb
+++ b/spec/controllers/sections_controller_spec.rb
@@ -198,9 +198,7 @@ RSpec.describe SectionsController, type: :controller do
   describe "DELETE #destroy" do
     subject { delete :destroy, id: section.id }
 
-    it "calls destroy on the section on success, redirects, and flashes " do
-      expect(section).to receive(:destroy!).and_return(true)
-
+    it "on success, redirects, and flashes " do
       subject
       expect(response).to be_redirect
       expect(flash[:notice]).to_not be_nil
@@ -220,6 +218,11 @@ RSpec.describe SectionsController, type: :controller do
 
     it "uses section query " do
       expect_any_instance_of(SectionQuery).to receive(:find).with("1").and_return(section)
+      subject
+    end
+
+    it "uses the Destroy::Section.cascade method" do
+      expect_any_instance_of(Destroy::Section).to receive(:cascade!)
       subject
     end
 

--- a/spec/controllers/showcases_controller_spec.rb
+++ b/spec/controllers/showcases_controller_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 require "cache_spec_helper"
 
 RSpec.describe ShowcasesController, type: :controller do
-  let(:showcase) { instance_double(Showcase, id: 1, name_line_1: "name_line_1", exhibit: exhibit, destroy!: true, collection: collection) }
+  let(:showcase) { instance_double(Showcase, id: 1, name_line_1: "name_line_1", exhibit: exhibit, collection: collection, sections: [], destroy!: true) }
   let(:exhibit) { instance_double(Exhibit, id: 1, name: "name", showcases: relation, collection: collection) }
   let(:collection) { instance_double(Collection, id: 1, name_line_1: "name_line_1") }
 
@@ -262,9 +262,7 @@ RSpec.describe ShowcasesController, type: :controller do
   describe "DELETE #destroy" do
     subject { delete :destroy, id: showcase.id }
 
-    it "calls destroy on the item on success, redirects, and flashes " do
-      expect(showcase).to receive(:destroy!).and_return(true)
-
+    it "on success, redirects, and flashes " do
       subject
       expect(response).to be_redirect
       expect(flash[:notice]).to_not be_nil
@@ -284,6 +282,11 @@ RSpec.describe ShowcasesController, type: :controller do
 
     it "uses showcase query " do
       expect_any_instance_of(ShowcaseQuery).to receive(:find).with("1").and_return(showcase)
+      subject
+    end
+
+    it "uses the Destroy::Showcase.cascade method" do
+      expect_any_instance_of(Destroy::Showcase).to receive(:cascade!)
       subject
     end
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 require "cache_spec_helper"
 
 RSpec.describe UsersController, type: :controller do
-  let(:user) { instance_double(User, id: 100, username: "username") }
+  let(:user) { instance_double(User, id: 100, username: "username", collection_users: [], destroy!: true) }
   let(:admin_user) { double(User, id: 99, username: "dwolfe2", admin?: true) }
   let(:users) { [user] }
   let(:relation) { User.all }
@@ -55,20 +55,15 @@ RSpec.describe UsersController, type: :controller do
       expect(User).to receive(:find).and_return(user)
     end
 
-    it "calls destroy on the user on success, redirects, and flashes " do
-      expect(user).to receive(:destroy).and_return(true)
-
+    it "on success, redirects, and flashes " do
       delete :destroy, id: 100
       expect(response).to be_redirect
       expect(flash[:notice]).to_not be_nil
     end
 
-    it "calls destroy on the user on failure, redirects, and flashes " do
-      expect(user).to receive(:destroy).and_return(false)
-
-      delete :destroy, id: 100
-      expect(response).to be_redirect
-      expect(flash[:error]).to_not be_nil
+    it "uses the Destroy::User.cascade! method" do
+      expect_any_instance_of(Destroy::User).to receive(:cascade!)
+      delete :destroy, id: "1"
     end
 
     it_behaves_like "a private content-based etag cacher" do

--- a/spec/factories/collection_user.rb
+++ b/spec/factories/collection_user.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :collection_user do |u|
+    u.id { 1 }
+    u.user_id { 1 }
+    u.collection_id { 1 }
+  end
+end

--- a/spec/factories/item.rb
+++ b/spec/factories/item.rb
@@ -1,0 +1,10 @@
+FactoryGirl.define do
+  factory :item do |i|
+    i.id { 1 }
+    i.name { "one" }
+    i.collection_id { 1 }
+    image_file_name "one.jpg"
+    image_content_type "image/jpeg"
+    image_file_size 1.megabyte
+  end
+end

--- a/spec/factories/section.rb
+++ b/spec/factories/section.rb
@@ -1,0 +1,12 @@
+FactoryGirl.define do
+  factory :section do |s|
+    s.id { 1 }
+    s.showcase_id { 1 }
+
+    factory :section_with_showcase do
+      after(:build, :create) do |ss|
+        ss.showcase = build(:showcase_with_exhibit)
+      end
+    end
+  end
+end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,0 +1,12 @@
+FactoryGirl.define do
+  factory :user do |u|
+    u.id { 1 }
+    u.first_name { "One" }
+    u.last_name { "User" }
+    u.display_name { "User One" }
+    u.email { "noone@nowhere.com" }
+    u.sign_in_count { 1 }
+    u.username { "user1" }
+    u.admin { true }
+  end
+end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -13,8 +13,9 @@ RSpec.describe Collection do
     expect(subject).to have(1).error_on(:name_line_1)
   end
 
-  it "has paper trail" do
-    expect(subject).to respond_to(:versions)
+  it "has a papertrail" do
+    expect(subject).to respond_to(:paper_trail_enabled_for_model?)
+    expect(subject.paper_trail_enabled_for_model?).to be(true)
   end
 
   describe "#name" do
@@ -30,6 +31,29 @@ RSpec.describe Collection do
       expect(subject).to receive(:name_line_2).and_return(nil)
 
       expect(subject.name).to eq("name line 1")
+    end
+  end
+
+  context "foreign key constraints" do
+    describe "#destroy" do
+      it "fails if a CollectionUser references it" do
+        FactoryGirl.create(:user)
+        subject = FactoryGirl.create(:collection)
+        FactoryGirl.create(:collection_user)
+        expect { subject.destroy }.to raise_error
+      end
+
+      it "fails if a Exhibit references it" do
+        subject = FactoryGirl.create(:collection)
+        FactoryGirl.create(:exhibit)
+        expect { subject.destroy }.to raise_error
+      end
+
+      it "fails if an Item references it" do
+        subject = FactoryGirl.create(:collection)
+        FactoryGirl.create(:item)
+        expect { subject.destroy }.to raise_error
+      end
     end
   end
 end

--- a/spec/models/collection_user_spec.rb
+++ b/spec/models/collection_user_spec.rb
@@ -1,0 +1,8 @@
+require "rails_helper"
+
+RSpec.describe CollectionUser do
+  it "has a papertrail" do
+    expect(subject).to respond_to(:paper_trail_enabled_for_model?)
+    expect(subject.paper_trail_enabled_for_model?).to be(true)
+  end
+end

--- a/spec/models/exhibit_spec.rb
+++ b/spec/models/exhibit_spec.rb
@@ -35,4 +35,20 @@ RSpec.describe Exhibit do
       expect(subject).to respond_to(:collection)
     end
   end
+
+  it "has a papertrail" do
+    expect(subject).to respond_to(:paper_trail_enabled_for_model?)
+    expect(subject.paper_trail_enabled_for_model?).to be(true)
+  end
+
+  context "foreign key constraints" do
+    describe "#destroy" do
+      it "fails if a Showcase references it" do
+        FactoryGirl.create(:collection)
+        subject = FactoryGirl.create(:exhibit)
+        FactoryGirl.create(:showcase)
+        expect { subject.destroy }.to raise_error
+      end
+    end
+  end
 end

--- a/spec/models/honeypot_image_spec.rb
+++ b/spec/models/honeypot_image_spec.rb
@@ -33,4 +33,9 @@ RSpec.describe HoneypotImage, type: :model do
       expect(subject.name).to eq("1920x1200.jpeg")
     end
   end
+
+  it "has a papertrail" do
+    expect(subject).to respond_to(:paper_trail_enabled_for_model?)
+    expect(subject.paper_trail_enabled_for_model?).to be(true)
+  end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -67,8 +67,9 @@ RSpec.describe Item do
     end
   end
 
-  it "has versioning " do
-    expect(subject).to respond_to(:versions)
+  it "has a papertrail" do
+    expect(subject).to respond_to(:paper_trail_enabled_for_model?)
+    expect(subject.paper_trail_enabled_for_model?).to be(true)
   end
 
   it "keeps spaces in the original filename" do
@@ -107,6 +108,28 @@ RSpec.describe Item do
 
     it "responds to collection" do
       expect(subject).to respond_to(:collection)
+    end
+  end
+
+  context "foreign key constraints" do
+    describe "#destroy" do
+      it "fails if a section references it" do
+        FactoryGirl.create(:collection)
+        FactoryGirl.create(:exhibit)
+        FactoryGirl.create(:showcase)
+        subject = FactoryGirl.create(:item)
+        FactoryGirl.create(:section, id: 1, item_id: 1)
+        expect { subject.destroy }.to raise_error
+      end
+
+      it "fails if a child item references it" do
+        FactoryGirl.create(:collection)
+        FactoryGirl.create(:exhibit)
+        FactoryGirl.create(:showcase)
+        subject = FactoryGirl.create(:item)
+        FactoryGirl.create(:item, id: 2, parent_id: 1)
+        expect { subject.destroy }.to raise_error
+      end
     end
   end
 end

--- a/spec/models/section_spec.rb
+++ b/spec/models/section_spec.rb
@@ -13,4 +13,9 @@ RSpec.describe Section do
       expect(subject).to have(1).error_on(field)
     end
   end
+
+  it "has a papertrail" do
+    expect(subject).to respond_to(:paper_trail_enabled_for_model?)
+    expect(subject.paper_trail_enabled_for_model?).to be(true)
+  end
 end

--- a/spec/models/showcase_spec.rb
+++ b/spec/models/showcase_spec.rb
@@ -14,8 +14,9 @@ RSpec.describe Showcase do
     end
   end
 
-  it "has paper trail" do
-    expect(subject).to respond_to(:versions)
+  it "has a papertrail" do
+    expect(subject).to respond_to(:paper_trail_enabled_for_model?)
+    expect(subject.paper_trail_enabled_for_model?).to be(true)
   end
 
   describe "#has honeypot image interface" do
@@ -57,6 +58,18 @@ RSpec.describe Showcase do
     it "uses name_line_1 for the slug" do
       subject.name_line_1 = "Slug"
       expect(subject.slug).to eq(subject.name_line_1)
+    end
+  end
+
+  context "foreign key constraints" do
+    describe "#destroy" do
+      it "fails if a Section references it" do
+        FactoryGirl.create(:collection)
+        FactoryGirl.create(:exhibit)
+        subject = FactoryGirl.create(:showcase)
+        FactoryGirl.create(:section)
+        expect { subject.destroy }.to raise_error
+      end
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -22,4 +22,20 @@ RSpec.describe User do
     expect(MapUserToApi).to receive(:call)
     User.new.save
   end
+
+  it "has a papertrail" do
+    expect(subject).to respond_to(:paper_trail_enabled_for_model?)
+    expect(subject.paper_trail_enabled_for_model?).to be(true)
+  end
+
+  context "foreign key constraints" do
+    describe "#destroy" do
+      it "fails if a collection_user references it" do
+        subject = FactoryGirl.create(:user)
+        FactoryGirl.create(:collection)
+        FactoryGirl.create(:collection_user, user_id: 1)
+        expect { subject.destroy }.to raise_error
+      end
+    end
+  end
 end

--- a/spec/queries/item_query_spec.rb
+++ b/spec/queries/item_query_spec.rb
@@ -75,4 +75,22 @@ describe ItemQuery do
       expect { subject.public_find("asdf") }.to raise_error ActiveRecord::RecordNotFound
     end
   end
+
+  describe "can_delete?" do
+    let(:relation) { instance_double(Item, showcases: [], children: []) }
+    let(:child) { instance_double(Item) }
+    let(:showcase) { instance_double(Showcase) }
+
+    it "returns false if the item has children" do
+      allow(relation).to receive(:showcases).and_return([])
+      allow(relation).to receive(:children).and_return([child])
+      expect(subject.can_delete?).to eq(false)
+    end
+
+    it "returns false if its used in a showcase" do
+      allow(relation).to receive(:showcases).and_return([showcase])
+      allow(relation).to receive(:children).and_return([])
+      expect(subject.can_delete?).to eq(false)
+    end
+  end
 end

--- a/spec/queries/showcase_query_spec.rb
+++ b/spec/queries/showcase_query_spec.rb
@@ -62,9 +62,14 @@ describe ShowcaseQuery do
   end
 
   describe "next" do
+    before(:each) do
+      FactoryGirl.create(:collection)
+      FactoryGirl.create(:exhibit)
+    end
+
     it "finds the correct showcase when there is one" do
-      showcase1 = FactoryGirl.build(:showcase_with_exhibit, id: 1, order: 1)
-      showcase2 = FactoryGirl.create(:showcase_with_exhibit, id: 2, order: 2)
+      showcase1 = FactoryGirl.build(:showcase, id: 1, order: 1)
+      showcase2 = FactoryGirl.create(:showcase, id: 2, order: 2)
       expect(subject.next(showcase1)).to eq(showcase2)
     end
 
@@ -79,42 +84,47 @@ describe ShowcaseQuery do
     end
 
     it "doesn't find one if the orders are the same" do
-      showcase1 = FactoryGirl.build(:showcase_with_exhibit, id: 1, order: 1)
-      FactoryGirl.create(:showcase_with_exhibit, id: 2, order: 1)
+      showcase1 = FactoryGirl.build(:showcase, id: 1, order: 1)
+      FactoryGirl.create(:showcase, id: 2, order: 1)
       expect(subject.next(showcase1)).to eq(nil)
     end
 
     it "doesn't find one if the next showcase's order is nil" do
-      showcase1 = FactoryGirl.build(:showcase_with_exhibit, id: 1, order: 1)
-      FactoryGirl.create(:showcase_with_exhibit, id: 2, order: nil)
+      showcase1 = FactoryGirl.build(:showcase, id: 1, order: 1)
+      FactoryGirl.create(:showcase, id: 2, order: nil)
       expect(subject.next(showcase1)).to eq(nil)
     end
 
     it "doesn't find one if the current showcase's order is nil" do
-      showcase1 = FactoryGirl.build(:showcase_with_exhibit, id: 1, order: nil)
-      FactoryGirl.create(:showcase_with_exhibit, id: 2, order: 1)
+      showcase1 = FactoryGirl.build(:showcase, id: 1, order: nil)
+      FactoryGirl.create(:showcase, id: 2, order: 1)
       expect(subject.next(showcase1)).to eq(nil)
     end
 
     context "searches based on order, not id" do
       it "and does not find one when there is no showcase with a higher order, even though there is one with a higher id" do
-        showcase1 = FactoryGirl.build(:showcase_with_exhibit, id: 1, order: 2)
-        FactoryGirl.create(:showcase_with_exhibit, id: 2, order: 1)
+        showcase1 = FactoryGirl.build(:showcase, id: 1, order: 2)
+        FactoryGirl.create(:showcase, id: 2, order: 1)
         expect(subject.next(showcase1)).to eq(nil)
       end
 
       it "and finds one when there is a showcase with a higher order, even though it has a lower id" do
-        showcase1 = FactoryGirl.create(:showcase_with_exhibit, id: 1, order: 2)
-        showcase2 = FactoryGirl.build(:showcase_with_exhibit, id: 2, order: 1)
+        showcase1 = FactoryGirl.create(:showcase, id: 1, order: 2)
+        showcase2 = FactoryGirl.build(:showcase, id: 2, order: 1)
         expect(subject.next(showcase2)).to eq(showcase1)
       end
     end
   end
 
   describe "previous" do
+    before(:each) do
+      FactoryGirl.create(:collection)
+      FactoryGirl.create(:exhibit)
+    end
+
     it "finds the correct showcase when there is one" do
-      showcase1 = FactoryGirl.create(:showcase_with_exhibit, id: 1, order: 1)
-      showcase2 = FactoryGirl.build(:showcase_with_exhibit, id: 2, order: 2)
+      showcase1 = FactoryGirl.create(:showcase, id: 1, order: 1)
+      showcase2 = FactoryGirl.build(:showcase, id: 2, order: 2)
       expect(subject.previous(showcase2)).to eq(showcase1)
     end
 
@@ -129,33 +139,33 @@ describe ShowcaseQuery do
     end
 
     it "doesn't find one if the orders are the same" do
-      FactoryGirl.create(:showcase_with_exhibit, id: 1, order: 1)
-      showcase2 = FactoryGirl.build(:showcase_with_exhibit, id: 2, order: 1)
+      FactoryGirl.create(:showcase, id: 1, order: 1)
+      showcase2 = FactoryGirl.build(:showcase, id: 2, order: 1)
       expect(subject.previous(showcase2)).to eq(nil)
     end
 
     it "doesn't find one if the previous showcase's order is nil" do
-      FactoryGirl.create(:showcase_with_exhibit, id: 1, order: nil)
-      showcase2 = FactoryGirl.build(:showcase_with_exhibit, id: 2, order: 1)
+      FactoryGirl.create(:showcase, id: 1, order: nil)
+      showcase2 = FactoryGirl.build(:showcase, id: 2, order: 1)
       expect(subject.previous(showcase2)).to eq(nil)
     end
 
     it "doesn't find one if the current showcase's order is nil" do
-      FactoryGirl.create(:showcase_with_exhibit, id: 1, order: 1)
-      showcase2 = FactoryGirl.build(:showcase_with_exhibit, id: 2, order: nil)
+      FactoryGirl.create(:showcase, id: 1, order: 1)
+      showcase2 = FactoryGirl.build(:showcase, id: 2, order: nil)
       expect(subject.previous(showcase2)).to eq(nil)
     end
 
     context "searches based on order, not id" do
       it "and does not find one when there is no showcase with a lower order, even though there is one with a lower id" do
-        FactoryGirl.create(:showcase_with_exhibit, id: 1, order: 2)
-        showcase2 = FactoryGirl.build(:showcase_with_exhibit, id: 2, order: 1)
+        FactoryGirl.create(:showcase, id: 1, order: 2)
+        showcase2 = FactoryGirl.build(:showcase, id: 2, order: 1)
         expect(subject.previous(showcase2)).to eq(nil)
       end
 
       it "and finds one when there is a showcase with a lower order, even though it has a higher id" do
-        showcase1 = FactoryGirl.build(:showcase_with_exhibit, id: 1, order: 2)
-        showcase2 = FactoryGirl.create(:showcase_with_exhibit, id: 2, order: 1)
+        showcase1 = FactoryGirl.build(:showcase, id: 1, order: 2)
+        showcase2 = FactoryGirl.create(:showcase, id: 2, order: 1)
         expect(subject.previous(showcase1)).to eq(showcase2)
       end
     end

--- a/spec/services/assign_user_to_collection_spec.rb
+++ b/spec/services/assign_user_to_collection_spec.rb
@@ -17,11 +17,13 @@ describe AssignUserToCollection do
     end
 
     it "to set the collection id" do
+      allow_any_instance_of(CollectionUser).to receive(:save).and_return(true)
       result = subject.assign!
       expect(result.collection_id).to eq collection.id
     end
 
     it "to set the user id" do
+      allow_any_instance_of(CollectionUser).to receive(:save).and_return(true)
       result = subject.assign!
       expect(result.user_id).to eq user.id
     end

--- a/spec/services/destroy/collection_spec.rb
+++ b/spec/services/destroy/collection_spec.rb
@@ -1,0 +1,113 @@
+require "rails_helper"
+
+describe Destroy::Collection do
+  describe "#cascade" do
+    let(:destroy_item) { instance_double(Destroy::Item, cascade!: nil) }
+    let(:destroy_exhibit) { instance_double(Destroy::Exhibit, cascade!: nil) }
+    let(:destroy_collection_user) { instance_double(Destroy::CollectionUser, cascade!: nil) }
+    let(:subject) { Destroy::Collection.new(destroy_collection_user: destroy_collection_user, destroy_item: destroy_item, destroy_exhibit: destroy_exhibit) }
+    let(:exhibit) { instance_double(Exhibit, destroy!: true, showcases: []) }
+    let(:item) { instance_double(Item, destroy!: true, sections: [], children: []) }
+    let(:collection) do
+      instance_double(Collection,
+                      collection_users: [collection_user, collection_user],
+                      exhibit: exhibit,
+                      items: [item, item],
+                      destroy!: true)
+    end
+    let(:collection_user) { instance_double(CollectionUser) }
+
+    it "calls DestroyItem.cascade on all associated items" do
+      expect(destroy_item).to receive(:cascade!).with(item: item).twice
+      subject.cascade!(collection: collection)
+    end
+
+    it "calls DestroyExhibit.cascade on all associated exhibits" do
+      expect(destroy_exhibit).to receive(:cascade!).with(exhibit: exhibit).once
+      subject.cascade!(collection: collection)
+    end
+
+    it "calls DestroyExhibit then DestroyItem to prevent FK constraints on Item->Section" do
+      expect(destroy_exhibit).to receive(:cascade!).with(exhibit: exhibit).at_least(:once).ordered
+      expect(destroy_item).to receive(:cascade!).with(item: item).at_least(:once).ordered
+      subject.cascade!(collection: collection)
+    end
+
+    it "calls DestroyCollectionUser.cascade on all associated collection_users" do
+      expect(destroy_collection_user).to receive(:cascade!).with(collection_user: collection_user).twice
+      subject.cascade!(collection: collection)
+    end
+
+    it "destroys the Collection" do
+      expect(collection).to receive(:destroy!)
+      subject.cascade!(collection: collection)
+    end
+  end
+
+  context "cascade transaction" do
+    let(:destroy_item) { Destroy::Item.new }
+    let(:destroy_exhibit) { Destroy::Exhibit.new }
+    let(:destroy_collection_user) { Destroy::CollectionUser.new }
+    let(:subject) { Destroy::Collection.new(destroy_collection_user: destroy_collection_user, destroy_item: destroy_item, destroy_exhibit: destroy_exhibit) }
+    let(:collection) { FactoryGirl.create(:collection) }
+    let(:exhibit) { FactoryGirl.create(:exhibit, collection_id: collection.id) }
+    let(:user) { FactoryGirl.create(:user) }
+    let(:collection_users) do
+      [FactoryGirl.create(:collection_user, id: 1, collection_id: collection.id),
+       FactoryGirl.create(:collection_user, id: 2, collection_id: collection.id)]
+    end
+    let(:items) do
+      [FactoryGirl.create(:item, id: 1, collection_id: collection.id),
+       FactoryGirl.create(:item, id: 2, collection_id: collection.id)]
+    end
+
+    before(:each) do
+      user
+      collection
+      exhibit
+      items
+      collection_users
+    end
+
+    # Ensures all data that was created still exists
+    # in the database
+    def data_still_exists!
+      items.each do |item|
+        expect { item.reload }.not_to raise_error
+      end
+      collection_users.each do |collection_user|
+        expect { collection_user.reload }.not_to raise_error
+      end
+      expect { exhibit.reload }.not_to raise_error
+      expect { collection.reload }.not_to raise_error
+    end
+
+    it "rolls back if an error occurs with Destroy::CollectionUser" do
+      # Throw error on second object to allow first one to get deleted
+      allow(collection).to receive(:collection_users).and_return(collection_users)
+      allow(collection_users[1]).to receive(:destroy!).and_raise("error")
+      expect { subject.cascade!(collection: collection) }.to raise_error("error")
+      data_still_exists!
+    end
+
+    it "rolls back if an error occurs with Destroy::Item" do
+      # Throw error on second object to allow first one to get deleted
+      allow(collection).to receive(:items).and_return(items)
+      allow(items[1]).to receive(:destroy!).and_raise("error")
+      expect { subject.cascade!(collection: collection) }.to raise_error("error")
+      data_still_exists!
+    end
+
+    it "rolls back if an error occurs with Destroy::Exhibit" do
+      allow(destroy_exhibit).to receive(:cascade!).with(exhibit: exhibit).and_raise("error")
+      expect { subject.cascade!(collection: collection) }.to raise_error("error")
+      data_still_exists!
+    end
+
+    it "rolls back if an error occurs with Collection.destroy!" do
+      allow(collection).to receive(:destroy!).and_raise("error")
+      expect { subject.cascade!(collection: collection) }.to raise_error("error")
+      data_still_exists!
+    end
+  end
+end

--- a/spec/services/destroy/collection_user_spec.rb
+++ b/spec/services/destroy/collection_user_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+describe Destroy::CollectionUser do
+  let(:collection_user) { instance_double(CollectionUser) }
+
+  describe "#destroy" do
+    it "destroys the CollectionUser" do
+      expect(collection_user).to receive(:destroy!)
+      subject.destroy!(collection_user: collection_user)
+    end
+  end
+
+  describe "#cascade" do
+    it "destroys the CollectionUser" do
+      expect(collection_user).to receive(:destroy!)
+      subject.cascade!(collection_user: collection_user)
+    end
+  end
+
+  context "cascade transaction" do
+    let(:user) { FactoryGirl.create(:user) }
+    let(:collection) { FactoryGirl.create(:collection) }
+    let(:collection_user) { FactoryGirl.create(:collection_user) }
+
+    # Ensures all data that was created still exists
+    # in the database
+    def data_still_exists!
+      expect { collection_user.reload }.not_to raise_error
+    end
+
+    it "rolls back if an error occurs with CollectionUser.destroy!" do
+      collection
+      user
+      allow(collection_user).to receive(:destroy!).and_raise("error")
+      expect { subject.cascade!(collection_user: collection_user) }.to raise_error("error")
+      data_still_exists!
+    end
+  end
+end

--- a/spec/services/destroy/exhibit_spec.rb
+++ b/spec/services/destroy/exhibit_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+describe Module::Exhibit do
+  let(:showcase) { instance_double(Showcase, destroy!: true) }
+  let(:exhibit) { instance_double(Exhibit, showcases: [showcase, showcase], destroy!: true) }
+  let(:destroy_showcase) { instance_double(Destroy::Showcase, cascade!: nil) }
+  let(:subject) { Destroy::Exhibit.new(destroy_showcase: destroy_showcase) }
+
+  describe "#destroy" do
+    it "destroys the Exhibit" do
+      expect(exhibit).to receive(:destroy!)
+      subject.cascade!(exhibit: exhibit)
+    end
+  end
+
+  describe "#cascade" do
+    it "calls DestroyShowcase on all associated showcases" do
+      expect(destroy_showcase).to receive(:cascade!).with(showcase: showcase).twice
+      subject.cascade!(exhibit: exhibit)
+    end
+
+    it "destroys the Exhibit" do
+      expect(exhibit).to receive(:destroy!)
+      subject.cascade!(exhibit: exhibit)
+    end
+  end
+
+  context "cascade transaction" do
+    let(:destroy_showcase) { Destroy::Showcase.new }
+    let(:subject) { Destroy::Exhibit.new(destroy_showcase: destroy_showcase) }
+    let(:exhibit) { FactoryGirl.create(:exhibit) }
+    let(:collection) { FactoryGirl.create(:collection) }
+    let(:showcases) { [FactoryGirl.create(:showcase, id: 1, exhibit_id: exhibit.id), FactoryGirl.create(:showcase, id: 2, exhibit_id: exhibit.id)] }
+
+    before(:each) do
+      collection
+      showcases
+    end
+
+    # Ensures all data that was created still exists
+    # in the database
+    def data_still_exists!
+      showcases.each do |showcase|
+        expect { showcase.reload }.not_to raise_error
+      end
+      expect { exhibit.reload }.not_to raise_error
+    end
+
+    it "rolls back if an error occurs with Destroy::Showcase" do
+      # Throw error on second object to allow first one to get deleted
+      allow(exhibit).to receive(:showcases).and_return(showcases)
+      allow(showcases[1]).to receive(:destroy!).and_raise("error")
+      expect { subject.cascade!(exhibit: exhibit) }.to raise_error("error")
+      data_still_exists!
+    end
+
+    it "rolls back if an error occurs with Exhibit.destroy!" do
+      allow(exhibit).to receive(:destroy!).and_raise("error")
+      expect { subject.cascade!(exhibit: exhibit) }.to raise_error("error")
+      data_still_exists!
+    end
+  end
+end

--- a/spec/services/destroy/item_spec.rb
+++ b/spec/services/destroy/item_spec.rb
@@ -1,0 +1,98 @@
+require "rails_helper"
+
+describe Destroy::Item do
+  let(:section) { instance_double(Section, destroy!: true) }
+  let(:child) { instance_double(Item, sections: [], children: [child2], destroy!: true) }
+  let(:child2) { instance_double(Item, sections: [], children: [], destroy!: true) }
+  let(:item) { instance_double(Item, sections: [section, section], children: [child, child], destroy!: true) }
+  let(:destroy_section) { instance_double(Destroy::Section, cascade!: nil) }
+  let(:subject) { Destroy::Item.new(destroy_section: destroy_section) }
+
+  describe "#destroy" do
+    it "destroys the Item" do
+      expect(item).to receive(:destroy!)
+      subject.cascade!(item: item)
+    end
+  end
+
+  describe "#cascade" do
+    it "calls DestroySection on all associated sections" do
+      expect(destroy_section).to receive(:cascade!).with(section: section).twice
+      subject.cascade!(item: item)
+    end
+
+    it "calls DestroyItem on all associated child items" do
+      # Can't test for cascade call here since it's a recursive call and stubbing
+      # it out will cause it to never call cascade on the child objects. Instead,
+      # it tests to see that it calls destroy on the item's children, and it's
+      # childrens' children, implying that cascade was properly called.
+      expect(child).to receive(:destroy!).twice
+      expect(child2).to receive(:destroy!).twice
+      subject.cascade!(item: item)
+    end
+
+    it "destroys sections before children to prevent FK constraints on Item->Section" do
+      expect(destroy_section).to receive(:cascade!).with(section: section).at_least(:once).ordered
+      expect(child).to receive(:destroy!).at_least(:once).ordered
+      subject.cascade!(item: item)
+    end
+
+    it "destroys the Exhibit" do
+      expect(item).to receive(:destroy!)
+      subject.cascade!(item: item)
+    end
+  end
+
+  context "cascade transaction" do
+    let(:destroy_section) { Destroy::Section.new }
+    let(:subject) { Destroy::Item.new(destroy_section: destroy_section) }
+    let(:collection) { FactoryGirl.create(:collection) }
+    let(:item) { FactoryGirl.create(:item) }
+    let(:showcase) { FactoryGirl.create(:showcase) }
+    let(:exhibit) { FactoryGirl.create(:exhibit) }
+    let(:sections) { [FactoryGirl.create(:section, id: 1, item_id: item.id), FactoryGirl.create(:section, id: 2, item_id: item.id)] }
+    let(:children) { [FactoryGirl.create(:item, id: 3, parent_id: item.id), FactoryGirl.create(:item, id: 4, parent_id: item.id)] }
+
+    before(:each) do
+      collection
+      exhibit
+      showcase
+      children
+      sections
+    end
+
+    # Ensures all data that was created still exists
+    # in the database
+    def data_still_exists!
+      children.each do |child|
+        expect { child.reload }.not_to raise_error
+      end
+      sections.each do |section|
+        expect { section.reload }.not_to raise_error
+      end
+      expect { item.reload }.not_to raise_error
+    end
+
+    it "rolls back if an error occurs with Destroy::Item on child items" do
+      # Throw error on second object to allow first one to get deleted
+      allow(item).to receive(:children).and_return(children)
+      allow(children[1]).to receive(:destroy!).and_raise("error")
+      expect { subject.cascade!(item: item) }.to raise_error("error")
+      data_still_exists!
+    end
+
+    it "rolls back if an error occurs with Destroy::Section" do
+      # Throw error on second object to allow first one to get deleted
+      allow(item).to receive(:sections).and_return(sections)
+      allow(sections[1]).to receive(:destroy!).and_raise("error")
+      expect { subject.cascade!(item: item) }.to raise_error("error")
+      data_still_exists!
+    end
+
+    it "rolls back if an error occurs with Item.destroy!" do
+      allow(item).to receive(:destroy!).and_raise("error")
+      expect { subject.cascade!(item: item) }.to raise_error("error")
+      data_still_exists!
+    end
+  end
+end

--- a/spec/services/destroy/section_spec.rb
+++ b/spec/services/destroy/section_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+describe Destroy::Section do
+  let(:section) { instance_double(Section) }
+
+  describe "#destroy" do
+    it "destroys the Section" do
+      expect(section).to receive(:destroy!)
+      subject.destroy!(section: section)
+    end
+  end
+
+  describe "#cascade" do
+    it "destroys the Section" do
+      expect(section).to receive(:destroy!)
+      subject.cascade!(section: section)
+    end
+  end
+
+  context "cascade transaction" do
+    let(:collection) { FactoryGirl.create(:collection) }
+    let(:exhibit) { FactoryGirl.create(:exhibit) }
+    let(:showcase) { FactoryGirl.create(:showcase) }
+    let(:section) { FactoryGirl.create(:section) }
+
+    # Ensures all data that was created still exists
+    # in the database
+    def data_still_exists!
+      expect { section.reload }.not_to raise_error
+    end
+
+    it "rolls back if an error occurs with Section.destroy!" do
+      collection
+      exhibit
+      showcase
+      allow(section).to receive(:destroy!).and_raise("error")
+      expect { subject.cascade!(section: section) }.to raise_error("error")
+      data_still_exists!
+    end
+  end
+end

--- a/spec/services/destroy/showcase_spec.rb
+++ b/spec/services/destroy/showcase_spec.rb
@@ -1,0 +1,65 @@
+require "rails_helper"
+
+describe Destroy::Showcase do
+  let(:section) { instance_double(Section, destroy!: true) }
+  let(:showcase) { instance_double(Showcase, sections: [section, section], destroy!: true) }
+  let(:destroy_section) { instance_double(Destroy::Section, cascade!: nil) }
+  let(:subject) { Destroy::Showcase.new(destroy_section: destroy_section) }
+
+  describe "#destroy" do
+    it "destroys the Showcase" do
+      expect(showcase).to receive(:destroy!)
+      subject.destroy!(showcase: showcase)
+    end
+  end
+
+  describe "#cascade" do
+    it "calls DestroySection on all associated sections" do
+      expect(destroy_section).to receive(:cascade!).with(section: section).twice
+      subject.cascade!(showcase: showcase)
+    end
+
+    it "destroys the Section" do
+      expect(showcase).to receive(:destroy!)
+      subject.cascade!(showcase: showcase)
+    end
+  end
+
+  context "cascade transaction" do
+    let(:destroy_section) { Destroy::Section.new }
+    let(:subject) { Destroy::Showcase.new(destroy_section: destroy_section) }
+    let(:showcase) { FactoryGirl.create(:showcase) }
+    let(:exhibit) { FactoryGirl.create(:exhibit) }
+    let(:collection) { FactoryGirl.create(:collection) }
+    let(:sections) { [FactoryGirl.create(:section, id: 1, showcase_id: showcase.id), FactoryGirl.create(:section, id: 2, showcase_id: showcase.id)] }
+
+    before(:each) do
+      collection
+      exhibit
+      sections
+    end
+
+    # Ensures all data that was created still exists
+    # in the database
+    def data_still_exists!
+      sections.each do |section|
+        expect { section.reload }.not_to raise_error
+      end
+      expect { showcase.reload }.not_to raise_error
+    end
+
+    it "rolls back if an error occurs with Destroy::Section" do
+      # Throw error on second object to allow first one to get deleted
+      allow(showcase).to receive(:sections).and_return(sections)
+      allow(sections[1]).to receive(:destroy!).and_raise("error")
+      expect { subject.cascade!(showcase: showcase) }.to raise_error("error")
+      data_still_exists!
+    end
+
+    it "rolls back if an error occurs with Showcase.destroy!" do
+      allow(showcase).to receive(:destroy!).and_raise("error")
+      expect { subject.cascade!(showcase: showcase) }.to raise_error("error")
+      data_still_exists!
+    end
+  end
+end

--- a/spec/services/destroy/user_spec.rb
+++ b/spec/services/destroy/user_spec.rb
@@ -1,0 +1,67 @@
+require "rails_helper"
+
+describe Destroy::User do
+  let(:user) { instance_double(User, collection_users: [collection_user, collection_user], destroy!: true) }
+  let(:collection) { instance_double(Collection) }
+  let(:collection_user) { instance_double(CollectionUser) }
+  let(:destroy_collection_user) { instance_double(Destroy::CollectionUser, cascade!: nil) }
+  let(:subject) { Destroy::User.new(destroy_collection_user: destroy_collection_user) }
+
+  describe "#destroy" do
+    it "destroys the User" do
+      expect(user).to receive(:destroy!)
+      subject.destroy!(user: user)
+    end
+  end
+
+  describe "#cascade" do
+    it "calls DestroyCollectionUser on all associated collection_users" do
+      expect(destroy_collection_user).to receive(:cascade!).with(collection_user: collection_user).twice
+      subject.cascade!(user: user)
+    end
+
+    it "destroys the User" do
+      expect(user).to receive(:destroy!)
+      subject.cascade!(user: user)
+    end
+  end
+
+  context "cascade transaction" do
+    let(:destroy_collection_user) { Destroy::CollectionUser.new }
+    let(:subject) { Destroy::User.new(destroy_collection_user: destroy_collection_user) }
+    let(:collection) { FactoryGirl.create(:collection) }
+    let(:user) { FactoryGirl.create(:user) }
+    let(:collection_users) do
+      [FactoryGirl.create(:collection_user, id: 1, collection_id: collection.id),
+       FactoryGirl.create(:collection_user, id: 2, collection_id: collection.id)]
+    end
+
+    before(:each) do
+      user
+      collection_users
+    end
+
+    # Ensures all data that was created still exists
+    # in the database
+    def data_still_exists!
+      collection_users.each do |collection_user|
+        expect { collection_user.reload }.not_to raise_error
+      end
+      expect { user.reload }.not_to raise_error
+    end
+
+    it "rolls back if an error occurs with Destroy::CollectionUser" do
+      # Throw error on second object to allow first one to get deleted
+      allow(user).to receive(:collection_users).and_return(collection_users)
+      allow(collection_users[1]).to receive(:destroy!).and_raise("error")
+      expect { subject.cascade!(user: user) }.to raise_error("error")
+      data_still_exists!
+    end
+
+    it "rolls back if an error occurs with User.destroy!" do
+      allow(user).to receive(:destroy!).and_raise("error")
+      expect { subject.cascade!(user: user) }.to raise_error("error")
+      data_still_exists!
+    end
+  end
+end

--- a/spec/services/remove_user_from_collection_spec.rb
+++ b/spec/services/remove_user_from_collection_spec.rb
@@ -2,15 +2,23 @@ require "rails_helper"
 
 describe RemoveUserFromCollection do
   subject { described_class.new(collection, user) }
+  let(:collection_user) { instance_double(CollectionUser, user_id: 1, collection_id: 1)}
   let(:collection) { double(Collection, id: 1) }
   let(:user) { double(User, id: 1) }
 
   before(:each) do
+    allow_any_instance_of(CollectionUser).to receive(:save).and_return(true)
+    allow(CollectionUser).to receive(:find_by!).and_return(collection_user)
     AssignUserToCollection.call(collection, user)
   end
 
   it "deletes the collection_user" do
-    expect_any_instance_of(CollectionUser).to receive(:destroy)
-    subject.delete!
+    expect(collection_user).to receive(:destroy!)
+    subject.destroy!
+  end
+
+  it "uses the Destroy::CollectionUser.destroy! method" do
+    expect_any_instance_of(Destroy::CollectionUser).to receive(:destroy!)
+    subject.destroy!
   end
 end

--- a/spec/services/remove_user_from_collection_spec.rb
+++ b/spec/services/remove_user_from_collection_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe RemoveUserFromCollection do
   subject { described_class.new(collection, user) }
-  let(:collection_user) { instance_double(CollectionUser, user_id: 1, collection_id: 1)}
+  let(:collection_user) { instance_double(CollectionUser, user_id: 1, collection_id: 1) }
   let(:collection) { double(Collection, id: 1) }
   let(:user) { double(User, id: 1) }
 


### PR DESCRIPTION
Why: Need to ensure referential integrity when deleting data. We decided we should cascade destroy most objects. The only exception is when a user directly deletes an item, it should constrain on section and child items.
How: Modified the item forms to only allow the user to delete an item if it has no associated sections or child items. Created Destroy service objects that handle cascading the destroy down through all associated objects and changed the controllers over to use these new services. Added papertrail to all models. As a final safeguard created foreign key constraints at the database layer to prevent any mishaps with application logic.