### PR TITLE
DEC 398

### DIFF
--- a/app/assets/javascripts/components/CollectionPreviewModeToggle.jsx
+++ b/app/assets/javascripts/components/CollectionPreviewModeToggle.jsx
@@ -1,6 +1,9 @@
 /** @jsx React.DOM */
 var React = require("react");
+var mui = require("material-ui");
+var Toggle = mui.Toggle;
 var CollectionPreviewModeToggle = React.createClass({
+  mixins: [MuiThemeMixin],
   propTypes: {
     collection: React.PropTypes.object.isRequired,
     previewModePath: React.PropTypes.string.isRequired,
@@ -59,11 +62,12 @@ var CollectionPreviewModeToggle = React.createClass({
 
   render: function () {
     return (
-      <label>
-      <input type="checkbox" checked={this.state.preview_mode} onChange={this.handleClick}/>
-      <span className="toggle"></span><span className="toggle-label">{this.previewLabel()}</span>
-      </label>
-      )
+      <Toggle
+        label={this.previewLabel()}
+        defaultToggled={this.state.preview_mode}
+        onToggle={this.handleClick}
+      />
+    )
   }
 });
 module.exports = CollectionPreviewModeToggle;

--- a/app/assets/javascripts/components/CollectionPreviewPublish.jsx
+++ b/app/assets/javascripts/components/CollectionPreviewPublish.jsx
@@ -47,18 +47,18 @@ var CollectionPreviewPublish = React.createClass({
 
   render: function () {
     return (
-        <div>
-          <li className="header" role="presentation">Publishing Status</li>
-          <li className="togglebutton">
-            <CollectionPublishToggle onToggle={this.handlePublishClick} ref="myPublishToggle" collection={this.props.collection} publishPath={this.props.publishPath} unpublishPath={this.props.unpublishPath} />
-          </li>
-          <li className="header" role="presentation">Preview Mode</li>
-          <li className="togglebutton">
-            <CollectionPreviewModeToggle onToggle={this.handlePreviewClick} ref="myPreviewToggle" collection={this.props.collection} previewModePath={this.props.previewModePath} previewLinkURL={this.props.previewLinkURL}/>
-          </li>
-          {this.siteLink()}
-        </div>
-      )
+      <div>
+        <li className="header" role="presentation">Publishing Status</li>
+        <li className="togglebutton">
+          <CollectionPublishToggle onToggle={this.handlePublishClick} ref="myPublishToggle" collection={this.props.collection} publishPath={this.props.publishPath} unpublishPath={this.props.unpublishPath} />
+        </li>
+        <li className="header" role="presentation">Preview Mode</li>
+        <li className="togglebutton">
+          <CollectionPreviewModeToggle onToggle={this.handlePreviewClick} ref="myPreviewToggle" collection={this.props.collection} previewModePath={this.props.previewModePath} previewLinkURL={this.props.previewLinkURL}/>
+        </li>
+        {this.siteLink()}
+      </div>
+    )
   }
 });
 module.exports = CollectionPreviewPublish;

--- a/app/assets/javascripts/components/publish/CollectionPublishToggle.jsx
+++ b/app/assets/javascripts/components/publish/CollectionPublishToggle.jsx
@@ -1,8 +1,10 @@
 /** @jsx React.DOM */
 var React = require("react");
+var mui = require("material-ui");
+var Toggle = mui.Toggle;
 var mediator = require("../../mediator");
 var CollectionPublishToggle = React.createClass({
-  mixins: [APIResponseMixin],
+  mixins: [APIResponseMixin, MuiThemeMixin],
   propTypes: {
     collection: React.PropTypes.object.isRequired,
     publishPath: React.PropTypes.string.isRequired,
@@ -64,10 +66,11 @@ var CollectionPublishToggle = React.createClass({
   },
   render: function () {
     return (
-      <label>
-      <input type="checkbox" checked={this.state.published} onChange={this.handleClick}/>
-      <span className="toggle"></span><span className="toggle-label">{this.state.published_label}</span>
-      </label>
+      <Toggle
+        label={this.state.published_label}
+        defaultToggled={this.state.published}
+        onToggle={this.handleClick}
+      />
       )
   }
 });

--- a/app/assets/javascripts/components/publish/CollectionPublishToggle.jsx
+++ b/app/assets/javascripts/components/publish/CollectionPublishToggle.jsx
@@ -71,7 +71,7 @@ var CollectionPublishToggle = React.createClass({
         defaultToggled={this.state.published}
         onToggle={this.handleClick}
       />
-      )
+    )
   }
 });
 module.exports = CollectionPublishToggle;

--- a/app/assets/javascripts/components/publish/PublishToggle.jsx
+++ b/app/assets/javascripts/components/publish/PublishToggle.jsx
@@ -1,19 +1,35 @@
 /** @jsx React.DOM */
 var React = require('react');
+var mui = require("material-ui");
+var Toggle = mui.Toggle;
 var PublishToggle = React.createClass({
+  mixins: [MuiThemeMixin],
   propTypes: {
     publishPanelFieldName: React.PropTypes.string.isRequired,
     published: React.PropTypes.bool.isRequired,
     togglePublished: React.PropTypes.func.isRequired,
   },
+
+  publishLabel: function () {
+    var label;
+    if (this.props.published) {
+      label = 'Publishedxxx'
+    } else {
+      label = 'Not Published'
+    }
+    return label;
+  },
+
   handleClick: function () {
     this.props.togglePublished();
   },
   render: function () {
     return (
-      <label>
-        <input type="checkbox" checked={this.props.published} onChange={this.handleClick} /> {this.props.publishPanelFieldName}
-      </label>
+      <Toggle
+        label={this.publishLabel()}
+        defaultToggled={this.props.published}
+        onToggle={this.handleClick}
+      />
     )
   }
 });

--- a/app/assets/javascripts/components/publish/PublishToggle.jsx
+++ b/app/assets/javascripts/components/publish/PublishToggle.jsx
@@ -13,7 +13,7 @@ var PublishToggle = React.createClass({
   publishLabel: function () {
     var label;
     if (this.props.published) {
-      label = 'Publishedxxx'
+      label = 'Published'
     } else {
       label = 'Not Published'
     }


### PR DESCRIPTION
What: Replace checkboxes with material-ui toggles.
Why: Using standard components simplifies the code vs. continuously recreating them.