### PR TITLE
Immediate date fix

### DIFF
--- a/app/assets/javascripts/components.js
+++ b/app/assets/javascripts/components.js
@@ -45,6 +45,7 @@ ItemMetaDataForm = require("./components/forms/ItemMetaDataForm");
 StringField = require("./components/forms/StringField");
 SubmitButton = require("./components/forms/SubmitButton");
 TextField = require("./components/forms/TextField");
+DateField = require("./components/forms/DateField");
 
 // panel
 Panel = require("./components/panel/Panel");

--- a/app/assets/javascripts/components/forms/DateField.jsx
+++ b/app/assets/javascripts/components/forms/DateField.jsx
@@ -37,17 +37,16 @@ var DateField = React.createClass({
     if (!this.props.value) {
       return;
     }
-
-    var date = this.splitDate();
-
-    this.setState({
-      year: date[2],
-      month: date[3],
-      day: date[4],
-      bc: (date[1] === '-'),
-      displayText: this.props.value.display_text,
-      chooseDisplayText: (this.props.value.display_text ? true : false)
-    });
+    if (this.props.value) {
+      this.setState({
+        year: this.props.value.year,
+        month: this.props.value.month,
+        day: this.props.value.day,
+        bc: this.props.value.bc,
+        displayText: this.props.value.display_text,
+        chooseDisplayText: (this.props.value.display_text ? true : false)
+      });
+    }
   },
 
   requiredClass: function() {
@@ -80,13 +79,16 @@ var DateField = React.createClass({
       displayText: stateDisplayText,
     });
 
-    var date = ((bc) ? "-" : "") + year;
-    date += ((month) ? "-" + month : "");
-    date += ((month && day) ? "-" + day : "");
-
-    var newValue = {
-      value: date,
-      display_text: displayText,
+    if (year) {
+      var newValue = {
+        year: year,
+        month: month,
+        day: day,
+        bc: bc,
+        display_text: displayText,
+      };
+    } else {
+      var newValue = null;
     }
 
     this.props.handleFieldChange(this.props.name, newValue);
@@ -106,22 +108,11 @@ var DateField = React.createClass({
     if (this.state.chooseDisplayText) {
       return (
         <div className="row">
-          <input  onChange={this.handleChange} type="text" ref="displayText" className="form-control" name="specifieddate" placeholder="Example: &quot;1788&quot; or &quot;circa. 1950&quot;" value={this.state.displayText} />
+          <input onChange={this.handleChange} type="text" ref="displayText" className="form-control" name="specifieddate" placeholder="Example: &quot;1788&quot; or &quot;circa. 1950&quot;" value={this.state.displayText} />
         </div>
       );
     }
     return "";
-  },
-
-  splitDate: function () {
-    var re = /^([-]?)(\d{4})[-]?(\d{1,2})?[-]?(\d{1,2})?/;
-    var m;
-    if ((m = re.exec(this.props.value.value)) !== null) {
-      if (m.index === re.lastIndex) {
-        re.lastIndex++;
-      }
-      return m;
-    }
   },
 
   render: function () {
@@ -131,15 +122,15 @@ var DateField = React.createClass({
           <div className="row form-inline">
             <div className="form-group">
               <label className="sr-only" htmlFor={"year" + this.props.name}>Year</label>
-              <input id={"year" + this.props.name} type="number" max="2100" min="0" step="1" onChange={this.handleChange} placeholder="YYYY" className="form-control" ref="year" style={{display: 'inline', width: '6em' }} value={this.state.year} />
+              <input id={"year" + this.props.name} type="text" max="2100" min="0" step="1" onChange={this.handleChange} placeholder="YYYY" className="form-control" ref="year" style={{display: 'inline', width: '6em' }} value={this.state.year} />
             </div>
             <div className="form-group">
               <label className="sr-only" htmlFor={"month" + this.props.name}>Month</label>
-              <input id={"month" + this.props.name} onChange={this.handleChange} type="number" max="12" min="1" step="1" placeholder="MM" className="form-control" style={{display: 'inline', width: '6em' }} ref="month" value={this.state.month} />
+              <input id={"month" + this.props.name} onChange={this.handleChange} type="text" max="12" min="1" step="1" placeholder="MM" className="form-control" style={{display: 'inline', width: '6em' }} ref="month" value={this.state.month} />
             </div>
             <div className="form-group">
               <label className="sr-only" htmlFor={"day" + this.props.name}>Day</label>
-              <input id={"day" + this.props.name} onChange={this.handleChange} type="number" max="31" min="1" step="1" placeholder="DD" className="form-control" ref="day" style={{display: 'inline', width: '6em' }} value={this.state.day} />
+              <input id={"day" + this.props.name} onChange={this.handleChange} type="text" max="31" min="1" step="1" placeholder="DD" className="form-control" ref="day" style={{display: 'inline', width: '6em' }} value={this.state.day} />
             </div>
             <div className="form-group">
               <label className="control-label">

--- a/app/controllers/v1/items_controller.rb
+++ b/app/controllers/v1/items_controller.rb
@@ -57,9 +57,9 @@ module V1
         :alternate_name,
         :rights,
         :original_language,
-        date_created: [:value, :display_text],
-        date_modified: [:value, :display_text],
-        date_published: [:value, :display_text],
+        date_created: [:value, :year, :month, :day, :bc, :display_text],
+        date_modified: [:value, :year, :month, :day, :bc, :display_text],
+        date_published: [:value, :year, :month, :day, :bc, :display_text],
       )
     end
   end

--- a/app/decorators/v1/metadata_json.rb
+++ b/app/decorators/v1/metadata_json.rb
@@ -41,17 +41,17 @@ module V1
     end
 
     def date_created
-      return nil if !object.date_created
+      return nil if object.date_created.nil? || object.date_created.empty?
       MetadataDate.new(object.date_created).human_readable
     end
 
     def date_modified
-      return nil if !object.date_modified
+      return nil if object.date_modified.nil? || object.date_modified.empty?
       MetadataDate.new(object.date_modified).human_readable
     end
 
     def date_published
-      return nil if !object.date_published
+      return nil if object.date_published.nil? || object.date_published.empty?
       MetadataDate.new(object.date_published).human_readable
     end
 

--- a/app/validators/date_validator.rb
+++ b/app/validators/date_validator.rb
@@ -8,7 +8,8 @@ class DateValidator < ActiveModel::EachValidator
   private
 
   def date_valid?(value)
-    date_data = { display_text: nil, value: value }
+    date_data = value
+    puts date_data.inspect
     return true if value.nil?
     begin
       MetadataDate.new(date_data)

--- a/app/validators/date_validator.rb
+++ b/app/validators/date_validator.rb
@@ -9,5 +9,10 @@ class DateValidator < ActiveModel::EachValidator
         record.errors[attribute] << msg
       end
     end
+    # this is to catch an additional errors from date formatting such as but not limited to
+    # invalid days for a month.
+    if record.errors[attribute].empty? && !date.to_date
+      record.errors[attribute] << "Invalid Date"
+    end
   end
 end

--- a/app/validators/date_validator.rb
+++ b/app/validators/date_validator.rb
@@ -1,23 +1,13 @@
 # Validator to make sure submitted date is correctly formatted
 class DateValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    @error_message = nil
-    record.errors[attribute] << (@error_message || "Invalid date") unless date_valid?(value)
-  end
+    return if !value
 
-  private
-
-  def date_valid?(value)
-    date_data = value
-    puts date_data.inspect
-    return true if value.nil?
-    begin
-      MetadataDate.new(date_data)
-    rescue MetadataDate::ParseError => e
-      @error_message = e.message
-      false
-    rescue ArgumentError
-      false
+    date = MetadataDate.new(value)
+    if !date.valid?
+      date.errors.full_messages.each do | msg |
+        record.errors[attribute] << msg
+      end
     end
   end
 end

--- a/app/validators/date_validator.rb
+++ b/app/validators/date_validator.rb
@@ -5,7 +5,7 @@ class DateValidator < ActiveModel::EachValidator
 
     date = MetadataDate.new(value)
     if !date.valid?
-      date.errors.full_messages.each do | msg |
+      date.errors.full_messages.each do |msg|
         record.errors[attribute] << msg
       end
     end

--- a/app/values/metadata_date.rb
+++ b/app/values/metadata_date.rb
@@ -7,7 +7,6 @@ class MetadataDate
   validates :month, numericality: { only_integer: true, allow_nil: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 12 }
   validates :day, numericality: { only_integer: true, allow_nil: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 31  }
 
-
   class ParseError < Exception
   end
 
@@ -46,8 +45,6 @@ class MetadataDate
   def to_date
     @date ||= ConvertToRubyDate.new(self).convert
   end
-
-  private
 
   class FormatDisplayText
     attr_reader :metadata_date
@@ -121,11 +118,9 @@ class MetadataDate
     end
 
     def convert
-      begin
-        convert!
-      rescue ArgumentError
-        false
-      end
+      convert!
+    rescue ArgumentError
+      false
     end
   end
 
@@ -137,9 +132,8 @@ class MetadataDate
     end
 
     def convert
-      return false if !metadata_date.valid?
-      return false if !metadata_date.to_date
-      
+      return false if !metadata_date.valid? || !metadata_date.to_date
+
       date = format_date
       format_bc(date)
     end
@@ -156,7 +150,6 @@ class MetadataDate
       else
         raise "Invalid metadata date. I expect this state to be unreachable so there is an error somewhere."
       end
-
     end
 
     def format_bc(date)

--- a/app/values/metadata_date.rb
+++ b/app/values/metadata_date.rb
@@ -3,9 +3,9 @@ class MetadataDate
 
   attr_reader :date_data, :display_text, :year, :month, :day, :bc
 
-  validates :year, numericality: { only_integer: true, allow_nil: false, greater_than_or_equal_to: 0, less_than_or_equal_to: 9999  }
-  validates :month, numericality: { only_integer: true, allow_nil: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 12 }
-  validates :day, numericality: { only_integer: true, allow_nil: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 31  }
+  validates :year, numericality:{ only_integer: true, allow_nil: false, greater_than_or_equal_to: 0, less_than_or_equal_to: 9999  }
+  validates :month, numericality:{ only_integer: true, allow_nil: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 12 }
+  validates :day, numericality:{ only_integer: true, allow_nil: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 31  }
 
   class ParseError < Exception
   end

--- a/app/values/metadata_date.rb
+++ b/app/values/metadata_date.rb
@@ -3,9 +3,9 @@ class MetadataDate
 
   attr_reader :date_data, :display_text, :year, :month, :day, :bc
 
-  validates :year, numericality:{ only_integer: true, allow_nil: false, greater_than_or_equal_to: 0, less_than_or_equal_to: 9999  }
-  validates :month, numericality:{ only_integer: true, allow_nil: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 12 }
-  validates :day, numericality:{ only_integer: true, allow_nil: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 31  }
+  validates :year, numericality: { only_integer: true, allow_nil: false, greater_than_or_equal_to: 0, less_than_or_equal_to: 9999 }
+  validates :month, numericality: { only_integer: true, allow_nil: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 12 }
+  validates :day, numericality: { only_integer: true, allow_nil: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 31 }
 
   class ParseError < Exception
   end

--- a/app/values/metadata_date.rb
+++ b/app/values/metadata_date.rb
@@ -39,8 +39,12 @@ class MetadataDate
     @day ||= date_data[:day] ? date_data[:day].strip : nil
   end
 
+  def iso8601
+    @iso ||= ConvertToIsoDate.new(self).convert
+  end
+
   def to_date
-    ConvertToRubyDate.new(self).convert
+    @date ||= ConvertToRubyDate.new(self).convert
   end
 
   private
@@ -122,6 +126,44 @@ class MetadataDate
       rescue ArgumentError
         false
       end
+    end
+  end
+
+  class ConvertToIsoDate
+    attr_reader :metadata_date
+
+    def initialize(metadata_date)
+      @metadata_date = metadata_date
+    end
+
+    def convert
+      return false if !metadata_date.valid?
+      return false if !metadata_date.to_date
+      
+      date = format_date
+      format_bc(date)
+    end
+
+    private
+
+    def format_date
+      if metadata_date.day
+        "#{metadata_date.year}-#{metadata_date.month}-#{metadata_date.day}"
+      elsif metadata_date.month
+        "#{metadata_date.year}-#{metadata_date.month}"
+      elsif metadata_date.year
+        "#{metadata_date.year}"
+      else
+        raise "Invalid metadata date. I expect this state to be unreachable so there is an error somewhere."
+      end
+
+    end
+
+    def format_bc(date)
+      if metadata_date.bc?
+        date = "-#{date}"
+      end
+      date
     end
   end
 end

--- a/spec/decorators/v1/metadata_json_spec.rb
+++ b/spec/decorators/v1/metadata_json_spec.rb
@@ -54,6 +54,11 @@ RSpec.describe V1::MetadataJSON do
         expect(subject.send(field)).to eq(nil)
       end
 
+      it "returns nil if the field value is \"\"" do
+        item.stub(field).and_return("")
+        expect(subject.send(field)).to eq(nil)
+      end
+
       it "uses the MetadataDate#display_text field" do
         item.stub(field).and_return(value: "2010-12-12")
         expect_any_instance_of(MetadataDate).to receive(:human_readable).and_return("date")

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -52,17 +52,17 @@ RSpec.describe Item do
 
   describe "date metadata" do
     it "validates date created" do
-      subject.date_created = "+-01-13"
+      subject.date_created = { value: "+-01-13", display_text: nil }
       expect(subject).to have(1).error_on(:date_created)
     end
 
     it "validates date modified" do
-      subject.date_modified = "+-01-13"
+      subject.date_modified = { value: "+-01-13", display_text: nil }
       expect(subject).to have(1).error_on(:date_modified)
     end
 
     it "validates date published" do
-      subject.date_published = "+-01-13"
+      subject.date_published = { value: "+-01-13", display_text: nil }
       expect(subject).to have(1).error_on(:date_published)
     end
   end

--- a/spec/validators/date_validator_spec.rb
+++ b/spec/validators/date_validator_spec.rb
@@ -5,15 +5,15 @@ describe DateValidator do
 
   it "passes the errors from metadata date to determine validity" do
     expect_any_instance_of(MetadataDate).to receive(:valid?).twice.and_return(true)
-    i = Item.new(date_created: { year: '2010' })
+    i = Item.new(date_created: { year: "2010" })
     i.save
   end
 
   it "passes errors from metadata date to item errors" do
     allow_any_instance_of(MetadataDate).to receive(:valid?).and_return(false)
-    expect_any_instance_of(MetadataDate).to receive(:errors).and_return(double(full_messages: [ "error message"]))
+    expect_any_instance_of(MetadataDate).to receive(:errors).and_return(double(full_messages: ["error message"]))
 
-    i = Item.new(date_created: { year: '2010' })
+    i = Item.new(date_created: { year: "2010" })
     i.save
   end
 

--- a/spec/validators/date_validator_spec.rb
+++ b/spec/validators/date_validator_spec.rb
@@ -3,84 +3,22 @@ require "rails_helper"
 describe DateValidator do
   let(:item) { Item.new }
 
-  context "with valid date" do
-    it "does not require a date string to be submitted" do
-      item.date_created =  nil
-      expect(item).to have(0).errors_on(:date_created)
-    end
-
-    it "allows 1-4 digit years" do
-      item.date_created = { value: "1", display_text: nil }
-      expect(item).to have(0).errors_on(:date_created)
-    end
-
-    it "allows 1-2 digit months" do
-      item.date_created = { value: "1-06", display_text: nil }
-      expect(item).to have(0).errors_on(:date_created)
-    end
-
-    it "allows 1-2 digit days" do
-      item.date_created = { value: "1-06-30", display_text: nil }
-      expect(item).to have(0).errors_on(:date_created)
-    end
-
-    it "allows BC dates" do
-      item.date_created = { value: "-01-06", display_text: nil }
-      expect(item).to have(0).errors_on(:date_created)
-    end
-
-    it "allows dates with only a year" do
-      item.date_created = { value: "-01", display_text: nil }
-      expect(item).to have(0).errors_on(:date_created)
-    end
-
-    it "allows dates with only a month and a year" do
-      item.date_created = { value: "1-06", display_text: nil }
-      expect(item).to have(0).errors_on(:date_created)
-    end
+  it "passes the errors from metadata date to determine validity" do
+    expect_any_instance_of(MetadataDate).to receive(:valid?).and_return(true)
+    i = Item.new(date_created: { year: '2010' })
+    i.save
   end
 
-  context "with invalid date" do
-    it "does not allow alpha characters" do
-      item.date_created = { value: "e01-13", display_text: nil }   
-      expect(item).to have(1).errors_on(:date_created)
-      expect(item.errors.messages[:date_created][0]).to eq "Unable to parse date"
-    end
+  it "passes errors from metadata date to item errors" do
+    allow_any_instance_of(MetadataDate).to receive(:valid?).and_return(false)
+    expect_any_instance_of(MetadataDate).to receive(:errors).and_return(double(full_messages: [ "error message"]))
 
-    it "does not allow extra characters" do
-      item.date_created = { value: "+-01-13", display_text: nil }
-      expect(item).to have(1).errors_on(:date_created)
-      expect(item.errors.messages[:date_created][0]).to eq "Unable to parse date"
-    end
+    i = Item.new(date_created: { year: '2010' })
+    i.save
+  end
 
-    it "does not allow more than 4 year digits" do
-      item.date_created = { value: "10000-12", display_text: nil }
-      expect(item).to have(1).errors_on(:date_created)
-      expect(item.errors.messages[:date_created][0]).to eq "Invalid date"
-    end
-
-    it "does not allow more than 2 month digits" do
-      item.date_created = { value: "1000-120", display_text: nil }
-      expect(item).to have(1).errors_on(:date_created)
-      expect(item.errors.messages[:date_created][0]).to eq "Invalid date"
-    end
-
-    it "verifies that the month is a valid month" do
-      item.date_created = { value: "1000-13", display_text: nil }
-      expect(item).to have(1).errors_on(:date_created)
-      expect(item.errors.messages[:date_created][0]).to eq "Invalid date"
-    end
-
-    it "does not allow more than 2 day digits" do
-      item.date_created = { value: "1000-12-100", display_text: nil }
-      expect(item).to have(1).errors_on(:date_created)
-      expect(item.errors.messages[:date_created][0]).to eq "Unable to parse date"
-    end
-
-    it "verifies that the day is a valid day" do
-      item.date_created = { value: "1000-12-32", display_text: nil }
-      expect(item).to have(1).errors_on(:date_created)
-      expect(item.errors.messages[:date_created][0]).to eq "Invalid date"
-    end
+  it "does no validation if the field is empty" do
+    expect_any_instance_of(MetadataDate).to_not receive(:valid?)
+    Item.new.save
   end
 end

--- a/spec/validators/date_validator_spec.rb
+++ b/spec/validators/date_validator_spec.rb
@@ -4,7 +4,7 @@ describe DateValidator do
   let(:item) { Item.new }
 
   it "passes the errors from metadata date to determine validity" do
-    expect_any_instance_of(MetadataDate).to receive(:valid?).and_return(true)
+    expect_any_instance_of(MetadataDate).to receive(:valid?).twice.and_return(true)
     i = Item.new(date_created: { year: '2010' })
     i.save
   end

--- a/spec/validators/date_validator_spec.rb
+++ b/spec/validators/date_validator_spec.rb
@@ -5,80 +5,80 @@ describe DateValidator do
 
   context "with valid date" do
     it "does not require a date string to be submitted" do
-      item.date_created = nil
+      item.date_created =  nil
       expect(item).to have(0).errors_on(:date_created)
     end
 
     it "allows 1-4 digit years" do
-      item.date_created = "1"
+      item.date_created = { value: "1", display_text: nil }
       expect(item).to have(0).errors_on(:date_created)
     end
 
     it "allows 1-2 digit months" do
-      item.date_created = "1-06"
+      item.date_created = { value: "1-06", display_text: nil }
       expect(item).to have(0).errors_on(:date_created)
     end
 
     it "allows 1-2 digit days" do
-      item.date_created = "1-06-30"
+      item.date_created = { value: "1-06-30", display_text: nil }
       expect(item).to have(0).errors_on(:date_created)
     end
 
     it "allows BC dates" do
-      item.date_created = "-01-06"
+      item.date_created = { value: "-01-06", display_text: nil }
       expect(item).to have(0).errors_on(:date_created)
     end
 
     it "allows dates with only a year" do
-      item.date_created = "-01"
+      item.date_created = { value: "-01", display_text: nil }
       expect(item).to have(0).errors_on(:date_created)
     end
 
     it "allows dates with only a month and a year" do
-      item.date_created = "1-06"
+      item.date_created = { value: "1-06", display_text: nil }
       expect(item).to have(0).errors_on(:date_created)
     end
   end
 
   context "with invalid date" do
     it "does not allow alpha characters" do
-      item.date_created = "e01-13"
+      item.date_created = { value: "e01-13", display_text: nil }   
       expect(item).to have(1).errors_on(:date_created)
       expect(item.errors.messages[:date_created][0]).to eq "Unable to parse date"
     end
 
     it "does not allow extra characters" do
-      item.date_created = "+-01-13"
+      item.date_created = { value: "+-01-13", display_text: nil }
       expect(item).to have(1).errors_on(:date_created)
       expect(item.errors.messages[:date_created][0]).to eq "Unable to parse date"
     end
 
     it "does not allow more than 4 year digits" do
-      item.date_created = "10000-12"
+      item.date_created = { value: "10000-12", display_text: nil }
       expect(item).to have(1).errors_on(:date_created)
       expect(item.errors.messages[:date_created][0]).to eq "Invalid date"
     end
 
     it "does not allow more than 2 month digits" do
-      item.date_created = "1000-120"
+      item.date_created = { value: "1000-120", display_text: nil }
       expect(item).to have(1).errors_on(:date_created)
       expect(item.errors.messages[:date_created][0]).to eq "Invalid date"
     end
 
     it "verifies that the month is a valid month" do
-      item.date_created = "1000-13"
+      item.date_created = { value: "1000-13", display_text: nil }
       expect(item).to have(1).errors_on(:date_created)
       expect(item.errors.messages[:date_created][0]).to eq "Invalid date"
     end
 
     it "does not allow more than 2 day digits" do
-      item.date_created = "1000-12-100"
+      item.date_created = { value: "1000-12-100", display_text: nil }
       expect(item).to have(1).errors_on(:date_created)
       expect(item.errors.messages[:date_created][0]).to eq "Unable to parse date"
     end
 
     it "verifies that the day is a valid day" do
-      item.date_created = "1000-12-32"
+      item.date_created = { value: "1000-12-32", display_text: nil }
       expect(item).to have(1).errors_on(:date_created)
       expect(item.errors.messages[:date_created][0]).to eq "Invalid date"
     end

--- a/spec/values/metadata_date/convert_to_iso_date_spec.rb
+++ b/spec/values/metadata_date/convert_to_iso_date_spec.rb
@@ -1,7 +1,6 @@
 require "rails_helper"
 
 RSpec.describe MetadataDate::ConvertToIsoDate do
-
   describe "#convert!" do
     it "converts a date with year, month, day" do
       date = MetadataDate.new(year: "2010", month: "10", day: "10", bc: false)
@@ -9,17 +8,17 @@ RSpec.describe MetadataDate::ConvertToIsoDate do
     end
 
     it "converts a date with year, month" do
-      date = MetadataDate.new( year: "2010", month: "10", day: nil, bc: false)
+      date = MetadataDate.new(year: "2010", month: "10", day: nil, bc: false)
       expect(described_class.new(date).convert).to eq("2010-10")
     end
 
     it "converts a date with year" do
-      date = MetadataDate.new( year: "2010", day: nil, month: nil, bc: false)
+      date = MetadataDate.new(year: "2010", day: nil, month: nil, bc: false)
       expect(described_class.new(date).convert).to eq("2010")
     end
 
     it "adds the - for bc dates" do
-      date = MetadataDate.new( year: "2010", month: "10", day: "10", bc: true)
+      date = MetadataDate.new(year: "2010", month: "10", day: "10", bc: true)
       expect(described_class.new(date).convert).to eq("-2010-10-10")
     end
 
@@ -29,7 +28,7 @@ RSpec.describe MetadataDate::ConvertToIsoDate do
     end
 
     it "returns false if the metadata_date is not a valid day" do
-      date = MetadataDate.new( year: "2010", month: "02", day: "30", bc: false)
+      date = MetadataDate.new(year: "2010", month: "02", day: "30", bc: false)
       expect(described_class.new(date).convert).to eq(false)
     end
   end

--- a/spec/values/metadata_date/convert_to_iso_date_spec.rb
+++ b/spec/values/metadata_date/convert_to_iso_date_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe MetadataDate::ConvertToIsoDate do
+
+  describe "#convert!" do
+    it "converts a date with year, month, day" do
+      date = MetadataDate.new(year: "2010", month: "10", day: "10", bc: false)
+      expect(described_class.new(date).convert).to eq("2010-10-10")
+    end
+
+    it "converts a date with year, month" do
+      date = MetadataDate.new( year: "2010", month: "10", day: nil, bc: false)
+      expect(described_class.new(date).convert).to eq("2010-10")
+    end
+
+    it "converts a date with year" do
+      date = MetadataDate.new( year: "2010", day: nil, month: nil, bc: false)
+      expect(described_class.new(date).convert).to eq("2010")
+    end
+
+    it "adds the - for bc dates" do
+      date = MetadataDate.new( year: "2010", month: "10", day: "10", bc: true)
+      expect(described_class.new(date).convert).to eq("-2010-10-10")
+    end
+
+    it "returns false if the metadata_date is invalid" do
+      date = MetadataDate.new({})
+      expect(described_class.new(date).convert).to eq(false)
+    end
+
+    it "returns false if the metadata_date is not a valid day" do
+      date = MetadataDate.new( year: "2010", month: "02", day: "30", bc: false)
+      expect(described_class.new(date).convert).to eq(false)
+    end
+  end
+end

--- a/spec/values/metadata_date/convert_to_ruby_date_spec.rb
+++ b/spec/values/metadata_date/convert_to_ruby_date_spec.rb
@@ -1,7 +1,6 @@
 require "rails_helper"
 
 RSpec.describe MetadataDate::ConvertToRubyDate do
-
   describe "#convert!" do
     it "converts a date with year, month, day" do
       date = double(MetadataDate, year: "2010", month: "10", day: "10", valid?: true)
@@ -56,6 +55,5 @@ RSpec.describe MetadataDate::ConvertToRubyDate do
       expect(object).to receive(:convert!).and_raise(ArgumentError.new(""))
       expect(object.convert).to eq(false)
     end
-
   end
 end

--- a/spec/values/metadata_date/convert_to_ruby_date_spec.rb
+++ b/spec/values/metadata_date/convert_to_ruby_date_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.describe MetadataDate::ConvertToRubyDate do
+
+  describe "#convert!" do
+    it "converts a date with year, month, day" do
+      date = double(MetadataDate, year: "2010", month: "10", day: "10", valid?: true)
+      expect(described_class.new(date).convert!).to eq(Date.new(2010, 10, 10))
+    end
+
+    it "converts a date with year, month" do
+      date = double(MetadataDate, year: "2010", month: "10", day: nil, valid?: true)
+      expect(described_class.new(date).convert!).to eq(Date.new(2010, 10))
+    end
+
+    it "converts a date with year" do
+      date = double(MetadataDate, year: "2010", day: nil, month: nil, valid?: true)
+      expect(described_class.new(date).convert!).to eq(Date.new(2010))
+    end
+
+    it "raises errors when there is an invalid date" do
+      date = double(MetadataDate, year: "2010", month: "2", day: "30", valid?: true)
+      expect { described_class.new(date).convert! }.to raise_error(ArgumentError)
+    end
+
+    it "raises an error when the year is a string" do
+      date = double(MetadataDate, year: "e2010", month: "2", day: "30", valid?: true)
+      expect { described_class.new(date).convert! }.to raise_error(ArgumentError)
+    end
+
+    it "raises an error when the month is a string" do
+      date = double(MetadataDate, year: "2010", month: "wer", day: "30", valid?: true)
+      expect { described_class.new(date).convert! }.to raise_error(ArgumentError)
+    end
+
+    it "raises an error when the day is a string" do
+      date = double(MetadataDate, year: "2010", month: "2", day: "sdfg", valid?: true)
+      expect { described_class.new(date).convert! }.to raise_error(ArgumentError)
+    end
+
+    it "returns false if the metadata_date is invalid?" do
+      date = double(MetadataDate, valid?: false)
+      expect(described_class.new(date).convert!).to eq(false)
+    end
+  end
+
+  describe "#convert" do
+    it "calls convert!" do
+      object = described_class.new("")
+      expect(object).to receive(:convert!).and_return("conveted")
+      object.convert
+    end
+
+    it "catches the argument error" do
+      object = described_class.new("")
+      expect(object).to receive(:convert!).and_raise(ArgumentError.new(""))
+      expect(object.convert).to eq(false)
+    end
+
+  end
+end

--- a/spec/values/metadata_date/format_display_text_spec.rb
+++ b/spec/values/metadata_date/format_display_text_spec.rb
@@ -2,37 +2,37 @@ require "rails_helper"
 
 RSpec.describe MetadataDate::FormatDisplayText do
   it "returns the display text field when there is a display text" do
-    date = double(MetadataDate, display_text: "Text to display")
+    date = MetadataDate.new(display_text: "Text to display", year: "2010")
     expect(MetadataDate::FormatDisplayText.format(date)).to eq("Text to display")
   end
 
   it "returns the year month day format when all are present" do
-    date = double(MetadataDate, valid?: true, display_text: nil, bc?: false, day: "5", month: "10", year: "1000")
+    date = MetadataDate.new(display_text: nil, bc: false, day: "5", month: "10", year: "1000")
     expect(MetadataDate::FormatDisplayText.format(date)).to eq("October 05, 1000")
   end
 
   it "returns the year month format when all are present" do
-    date = double(MetadataDate, valid?: true, display_text: nil, bc?: false, day: nil, month: "10", year: "1000")
+    date = MetadataDate.new(display_text: nil, bc: false, day: nil, month: "10", year: "1000")
     expect(MetadataDate::FormatDisplayText.format(date)).to eq("October, 1000")
   end
 
   it "returns the year format when all are present" do
-    date = double(MetadataDate, valid?: true, display_text: nil, bc?: false, day: nil, month: nil, year: "1000")
+    date = MetadataDate.new(display_text: nil, bc: false, day: nil, month: nil, year: "1000")
     expect(MetadataDate::FormatDisplayText.format(date)).to eq("1000")
   end
 
   it "adds BC when the year is BC" do
-    date = double(MetadataDate, valid?: true, display_text: nil, bc?: true, day: "5", month: "10", year: "1000")
+    date = MetadataDate.new(display_text: nil, bc: true, day: "5", month: "10", year: "1000")
     expect(MetadataDate::FormatDisplayText.format(date)).to match(/ BC$/)
   end
 
   it "when the date is BC year is displayed in the possitive" do
-    date = double(MetadataDate, valid?: true, display_text: nil, bc?: true, day: "5", month: "10", year: "1000")
+    date = MetadataDate.new(display_text: nil, bc: true, day: "5", month: "10", year: "1000")
     expect(MetadataDate::FormatDisplayText.format(date)).to_not include("-1000")
   end
 
   it "returns empty string when the metadata date is not valid?" do
-    date = double(MetadataDate, valid?: false, display_text: nil)
+    date = MetadataDate.new(display_text: nil)
     expect(MetadataDate::FormatDisplayText.format(date)).to include("")
   end
 end

--- a/spec/values/metadata_date/format_display_text_spec.rb
+++ b/spec/values/metadata_date/format_display_text_spec.rb
@@ -7,27 +7,32 @@ RSpec.describe MetadataDate::FormatDisplayText do
   end
 
   it "returns the year month day format when all are present" do
-    date = double(MetadataDate, display_text: nil, date: Date.new(1000, 10, 5), bc?: false, day: 5, month: 10, year: 1000)
+    date = double(MetadataDate, valid?: true, display_text: nil, bc?: false, day: "5", month: "10", year: "1000")
     expect(MetadataDate::FormatDisplayText.format(date)).to eq("October 05, 1000")
   end
 
   it "returns the year month format when all are present" do
-    date = double(MetadataDate, display_text: nil, date: Date.new(1000, 10, 10), bc?: false, day: nil, month: 10, year: 1000)
+    date = double(MetadataDate, valid?: true, display_text: nil, bc?: false, day: nil, month: "10", year: "1000")
     expect(MetadataDate::FormatDisplayText.format(date)).to eq("October, 1000")
   end
 
   it "returns the year format when all are present" do
-    date = double(MetadataDate, display_text: nil, date: Date.new(1000, 10, 10), bc?: false, day: nil, month: nil, year: 1000)
+    date = double(MetadataDate, valid?: true, display_text: nil, bc?: false, day: nil, month: nil, year: "1000")
     expect(MetadataDate::FormatDisplayText.format(date)).to eq("1000")
   end
 
   it "adds BC when the year is BC" do
-    date = double(MetadataDate, display_text: nil, date: Date.new(-1000, 10, 10), bc?: true, day: 10, month: 10, year: -1000)
+    date = double(MetadataDate, valid?: true, display_text: nil, bc?: true, day: "5", month: "10", year: "1000")
     expect(MetadataDate::FormatDisplayText.format(date)).to match(/ BC$/)
   end
 
   it "when the date is BC year is displayed in the possitive" do
-    date = double(MetadataDate, display_text: nil, date: Date.new(-1000, 10, 10), bc?: true, day: 10, month: 10, year: -1000)
+    date = double(MetadataDate, valid?: true, display_text: nil, bc?: true, day: "5", month: "10", year: "1000")
     expect(MetadataDate::FormatDisplayText.format(date)).to_not include("-1000")
+  end
+
+  it "returns empty string when the metadata date is not valid?" do
+    date = double(MetadataDate, valid?: false, display_text: nil)
+    expect(MetadataDate::FormatDisplayText.format(date)).to include("")
   end
 end

--- a/spec/values/metadata_date_spec.rb
+++ b/spec/values/metadata_date_spec.rb
@@ -1,68 +1,58 @@
 require "rails_helper"
 
 RSpec.describe MetadataDate do
-  describe :date_parsing do
-    {
-      "2012-12-12" => [2012, 12, 12],
-      "0010-1-2" => [10, 1, 2],
-      "190-03-22" => [190, 3, 22],
-      "19-12-05" => [19, 12, 5],
-      "1-12-22" => [1, 12, 22],
-      "-1190-12-22" => [-1190, 12, 22],
-      "-110-12" => [-110, 12, nil],
-      "1000-03" => [1000, 3, nil],
-      "0010-11" => [10, 11, nil],
-      "10-11" => [10, 11, nil],
-      "5-3" => [5, 3, nil],
-      "-2125-03" => [-2125, 3, nil],
-      "-2125" => [-2125, nil, nil],
-      "2121" => [2121, nil, nil],
-      "121" => [121, nil, nil],
-      "0121" => [121, nil, nil],
-      "0021" => [21, nil, nil],
-      "21" => [21, nil, nil],
-      "0002" => [2, nil, nil],
-      "2" => [2, nil, nil],
-    }.each do |date, expected|
-      it "parses #{date}" do
-        date = MetadataDate.new(value: date)
-        expect(date.year).to eq(expected[0])
-        expect(date.month).to eq(expected[1])
-        expect(date.day).to eq(expected[2])
-      end
+
+  describe :year do
+    it "passes the value of the year field " do
+      date = MetadataDate.new(year: 'year')
+      expect(date.year).to eq('year')
     end
 
-    [
-      "asdf-da-as",
-      "sd23-10-21",
-      "2012-15-21",
-      "2012-10-41",
-    ].each do |date|
-      it "fails on the invalid format of #{date}" do
-        expect { MetadataDate.new(value: date) }.to raise_error
-      end
+    it "returns nil if there is nothing passed in for year" do
+      date = MetadataDate.new({})
+      expect(date.year).to eq(nil)
+    end
+  end
+
+  describe :month do
+    it "passes the value of the month field " do
+      date = MetadataDate.new(month: 'month')
+      expect(date.month).to eq('month')
     end
 
-    it "raises an error if there is no date" do
-      expect { MetadataDate.new(value: nil) }.to raise_error(MetadataDate::ParseError)
+    it "returns nil if there is nothing passed in for month" do
+      date = MetadataDate.new({})
+      expect(date.month).to eq(nil)
+    end
+  end
+
+  describe :day do
+    it "passes the value of the day field " do
+      date = MetadataDate.new(year: 'day')
+      expect(date.year).to eq('day')
+    end
+
+    it "returns nil if there is nothing passed in for day" do
+      date = MetadataDate.new({})
+      expect(date.day).to eq(nil)
     end
   end
 
   describe :bc? do
     it "is true when the date is BC" do
-      date = MetadataDate.new(value: "-2322")
+      date = MetadataDate.new(bc: true)
       expect(date.bc?).to be_truthy
     end
 
     it "is false when the date is AD" do
-      date = MetadataDate.new(value: "2322")
+      date = MetadataDate.new(bc: false)
       expect(date.bc?).to be_falsey
     end
   end
 
   describe :human_readable do
     it "uses FormatDisplayText to determine how to format display text" do
-      date = MetadataDate.new(value: "2322", display_text: "display-text")
+      date = MetadataDate.new(display_text: "display-text")
       expect(MetadataDate::FormatDisplayText).to receive(:format).with(date)
       date.human_readable
     end
@@ -70,13 +60,99 @@ RSpec.describe MetadataDate do
 
   describe :display_text do
     it "returns the passed in display_text" do
-      date = MetadataDate.new(value: "2122", display_text: "display-text")
+      date = MetadataDate.new(display_text: "display-text")
       expect(date.display_text).to eq("display-text")
     end
 
     it "returns nil if there is nothing passed in for display-text" do
-      date = MetadataDate.new(value: "2122")
+      date = MetadataDate.new({})
       expect(date.display_text).to eq(nil)
     end
+  end
+
+
+  context :validations do
+
+    describe :year do
+      it "does not allow nil" do
+        date = MetadataDate.new(year: nil)
+        expect(date).to have(1).errors_on(:year)
+      end
+
+      it "requires it to be an integer " do
+        date = MetadataDate.new(year: "a")
+        expect(date).to have(1).errors_on(:year)
+      end
+
+      it "does allow year 0" do
+        date = MetadataDate.new(year: "0")
+        expect(date).to have(0).errors_on(:year)
+      end
+
+      it "does not allow negative numbers" do
+        date = MetadataDate.new(year: "-100")
+        expect(date).to have(1).errors_on(:year)
+      end
+
+      it "does not allow numbers greater than 9999" do
+        date = MetadataDate.new(year: "10000")
+        expect(date).to have(1).errors_on(:year)
+      end
+    end
+
+    describe :month do
+      it "allows nil" do
+        date = MetadataDate.new(month: nil)
+        expect(date).to have(0).errors_on(:month)
+      end
+
+      it "requires it to be an integer " do
+        date = MetadataDate.new(month: "a")
+        expect(date).to have(1).errors_on(:month)
+      end
+
+      it "does not allow year 0" do
+        date = MetadataDate.new(month: "0")
+        expect(date).to have(1).errors_on(:month)
+      end
+
+      it "does not allow negative numbers" do
+        date = MetadataDate.new(month: "-100")
+        expect(date).to have(1).errors_on(:month)
+      end
+
+      it "does not allow numbers greater than 12" do
+        date = MetadataDate.new(month: "13")
+        expect(date).to have(1).errors_on(:month)
+      end
+    end
+
+    describe :day do
+      it "allows nil" do
+        date = MetadataDate.new(day: nil)
+        expect(date).to have(0).errors_on(:day)
+      end
+
+      it "requires it to be an integer " do
+        date = MetadataDate.new(day: "a")
+        expect(date).to have(1).errors_on(:day)
+      end
+
+      it "does not allow year 0" do
+        date = MetadataDate.new(day: "0")
+        expect(date).to have(1).errors_on(:day)
+      end
+
+      it "does not allow negative numbers" do
+        date = MetadataDate.new(day: "-100")
+        expect(date).to have(1).errors_on(:day)
+      end
+
+      it "does not allow numbers greater than 31" do
+        date = MetadataDate.new(month: "32")
+        expect(date).to have(1).errors_on(:month)
+      end
+    end
+
   end
 end

--- a/spec/values/metadata_date_spec.rb
+++ b/spec/values/metadata_date_spec.rb
@@ -1,11 +1,10 @@
 require "rails_helper"
 
 RSpec.describe MetadataDate do
-
   describe :year do
     it "passes the value of the year field " do
-      date = MetadataDate.new(year: 'year')
-      expect(date.year).to eq('year')
+      date = MetadataDate.new(year: "year")
+      expect(date.year).to eq("year")
     end
 
     it "returns nil if there is nothing passed in for year" do
@@ -16,8 +15,8 @@ RSpec.describe MetadataDate do
 
   describe :month do
     it "passes the value of the month field " do
-      date = MetadataDate.new(month: 'month')
-      expect(date.month).to eq('month')
+      date = MetadataDate.new(month: "month")
+      expect(date.month).to eq("month")
     end
 
     it "returns nil if there is nothing passed in for month" do
@@ -28,8 +27,8 @@ RSpec.describe MetadataDate do
 
   describe :day do
     it "passes the value of the day field " do
-      date = MetadataDate.new(year: 'day')
-      expect(date.year).to eq('day')
+      date = MetadataDate.new(year: "day")
+      expect(date.year).to eq("day")
     end
 
     it "returns nil if there is nothing passed in for day" do
@@ -70,9 +69,7 @@ RSpec.describe MetadataDate do
     end
   end
 
-
   context :validations do
-
     describe :year do
       it "does not allow nil" do
         date = MetadataDate.new(year: nil)
@@ -153,6 +150,5 @@ RSpec.describe MetadataDate do
         expect(date).to have(1).errors_on(:month)
       end
     end
-
   end
 end


### PR DESCRIPTION
Why:  The code for validating dates and sending api response was both using the metadata_date model.  That model was incompatible with both operations in the case when data in the form was invalid.  This was because the we were relying on the failure of the metadata date to convert itself to a ruby date to raise exceptions.  This set of changes refactors that.  I also determined that the old storage format for dates caused a lot of extra code to be written so I refactored that as.

What:  I updated the way that date data is stored see: https://github.com/ndlib/honeycomb/wiki/Meta-Data-Storage  and how the date object will be sent in the api see: https://github.com/ndlib/honeycomb/wiki/Meta-Data-Api.   I also adjusted where the validations are happening and to stop relying on the metadata date conversion.  In addition I refactored the code so that the conversion algorithms got their own classes.  