### PR TITLE
DEC-515 - initial search api stub

### DIFF
--- a/app/controllers/v1/search_controller.rb
+++ b/app/controllers/v1/search_controller.rb
@@ -1,0 +1,23 @@
+module V1
+  class SearchController < APIController
+    def index
+      search_arguments = {
+        q: params[:q],
+        facets: params[:facets],
+        sort: params[:sort],
+        rows: params[:rows],
+        start: params[:start],
+        collection: collection
+      }
+      @search = Waggle::Search::Query.new(search_arguments).result
+    end
+
+    private
+
+    def collection
+      if params[:collection_id]
+        CollectionQuery.new.any_find(params[:collection_id])
+      end
+    end
+  end
+end

--- a/app/decorators/v1/metadata_json.rb
+++ b/app/decorators/v1/metadata_json.rb
@@ -42,17 +42,17 @@ module V1
 
     def date_created
       return nil if object.date_created.nil? || object.date_created.empty?
-      MetadataDate.new(object.date_created).human_readable
+      MetadataDate.new(**object.date_created).human_readable
     end
 
     def date_modified
       return nil if object.date_modified.nil? || object.date_modified.empty?
-      MetadataDate.new(object.date_modified).human_readable
+      MetadataDate.new(**object.date_modified).human_readable
     end
 
     def date_published
       return nil if object.date_published.nil? || object.date_published.empty?
-      MetadataDate.new(object.date_published).human_readable
+      MetadataDate.new(**object.date_published).human_readable
     end
 
     private

--- a/app/models/waggle/search/hit.rb
+++ b/app/models/waggle/search/hit.rb
@@ -26,8 +26,6 @@ module Waggle
       def thumbnail_url
         if object.honeypot_image
           object.honeypot_image.json_response["thumbnail/small"]["contentUrl"]
-        else
-          nil
         end
       end
 

--- a/app/models/waggle/search/hit.rb
+++ b/app/models/waggle/search/hit.rb
@@ -32,7 +32,7 @@ module Waggle
       end
 
       def updated
-        object.updated_at.to_json
+        object.updated_at.as_json
       end
     end
   end

--- a/app/models/waggle/search/hit.rb
+++ b/app/models/waggle/search/hit.rb
@@ -1,0 +1,39 @@
+module Waggle
+  module Search
+    class Hit < Draper::Decorator
+      delegate :name
+
+      def at_id
+        h.v1_item_url(object.unique_id)
+      end
+
+      def type
+        "Item"
+      end
+
+      def name
+        object.name
+      end
+
+      def short_description
+        "Short Description"
+      end
+
+      def description
+        object.description.to_s
+      end
+
+      def thumbnail_url
+        if object.honeypot_image
+          object.honeypot_image.json_response["thumbnail/small"]["contentUrl"]
+        else
+          nil
+        end
+      end
+
+      def updated
+        object.updated_at.to_json
+      end
+    end
+  end
+end

--- a/app/models/waggle/search/query.rb
+++ b/app/models/waggle/search/query.rb
@@ -1,0 +1,22 @@
+module Waggle
+  module Search
+    class Query
+      DEFAULT_ROWS = 10
+
+      attr_reader :q, :facets, :sort, :rows, :start, :collection
+
+      def initialize(q:, facets: [], sort: nil, rows: nil, start: nil, collection: nil)
+        @q = q
+        @facets = facets
+        @sort = sort
+        @rows = (rows || DEFAULT_ROWS).to_i
+        @start = (start || 0).to_i
+        @collection = collection
+      end
+
+      def result
+        @result ||= Waggle::Search::Result.new(query: self)
+      end
+    end
+  end
+end

--- a/app/models/waggle/search/result.rb
+++ b/app/models/waggle/search/result.rb
@@ -1,0 +1,41 @@
+module Waggle
+  module Search
+    class Result
+      attr_reader :query
+
+      def initialize(query: query)
+        @query = query
+      end
+
+      def hits
+        items.map { |item| Waggle::Search::Hit.new(item) }
+      end
+
+      def start
+        query.start
+      end
+
+      def rows
+        query.rows
+      end
+
+      def total
+        @total ||= item_relation.count
+      end
+
+      private
+
+      def collection
+        query.collection
+      end
+
+      def items
+        item_relation.limit(rows).offset(start)
+      end
+
+      def item_relation
+        collection ? collection.items : Item.all
+      end
+    end
+  end
+end

--- a/app/views/v1/search/_hit.json.jbuilder
+++ b/app/views/v1/search/_hit.json.jbuilder
@@ -1,0 +1,8 @@
+json.set! "@type", "SearchHit"
+json.set! "@id", hit.at_id
+json.type hit.type
+json.name hit.name
+json.shortDescription hit.short_description
+json.description hit.description
+json.thumbnailURL hit.thumbnail_url
+json.updated hit.updated

--- a/app/views/v1/search/index.json.jbuilder
+++ b/app/views/v1/search/index.json.jbuilder
@@ -1,0 +1,9 @@
+json.set! "@type", "SearchResponse"
+json.hits do
+  json.found @search.total
+  json.start @search.start
+  json.hit @search.hits do |hit|
+    json.partial! "v1/search/hit", hit: hit
+  end
+end
+json.facets []

--- a/app/views/v1/search/index.json.jbuilder
+++ b/app/views/v1/search/index.json.jbuilder
@@ -1,4 +1,4 @@
-json.set! "@type", "SearchResponse"
+json.set! "@type", "SearchResult"
 json.hits do
   json.found @search.total
   json.start @search.start

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,6 +65,7 @@ Rails.application.routes.draw do
       put :publish, defaults: { format: :json }
       put :unpublish, defaults: { format: :json }
       put :preview_mode, defaults: { format: :json }
+      resources :search, only: [:index], defaults: { format: :json }
       resources :items, only: [:index], defaults: { format: :json }
       resources :showcases, only: [:index], defaults: { format: :json }
     end

--- a/config/sunspot.yml
+++ b/config/sunspot.yml
@@ -18,5 +18,5 @@ test:
   solr:
     hostname: localhost
     port: 8981
-    log_level: WARNING
+    log_level: INFO
     path: /solr/test

--- a/spec/models/waggle/item_spec.rb
+++ b/spec/models/waggle/item_spec.rb
@@ -45,13 +45,21 @@ RSpec.describe Waggle::Item do
     Sunspot.index(other_instance)
     Sunspot.commit
 
+    q = "pig"
+    name_q = "pig-in-mud"
+
     search = Sunspot.search described_class do
       fulltext "pig" do
         boost_fields name: 3.0
         highlight :name
       end
 
-      facet :name_facet
+      if name_q.present?
+        name_filter = with(:name_facet, name_q)
+        facet :name_facet, exclude: [name_filter]
+      else
+        facet :name_facet
+      end
     end
 
     expect(search.facet(:name_facet).rows.first.value).to eq("pig-in-mud")

--- a/spec/models/waggle/item_spec.rb
+++ b/spec/models/waggle/item_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Waggle::Item do
     name_q = "pig-in-mud"
 
     search = Sunspot.search described_class do
-      fulltext "pig" do
+      fulltext q do
         boost_fields name: 3.0
         highlight :name
       end


### PR DESCRIPTION
This adds a search API that is hopefully similar to what the final version will include.

http://localhost:3017/v1/collections/<collection.unique_id>/search?q=asdf&rows=3&start=6

The returned data should match https://github.com/ndlib/honeycomb/wiki/Search-Api

This is a stub that's connecting directly to ActiveRecord, but I am actively working on the Solr integration.  Since  the core search code will be changed drastically over the next couple days I have not added any tests for the ActiveRecord integration.