### PR TITLE
Guard npm

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -102,6 +102,7 @@ group :development, :test do
   gem "guard-rails"
   gem "guard-rspec"
   gem "guard-spring"
+  gem "guard-npm"
   #  gem "growl"
   #  gem "ruby_gntp"
   #  gem "growl-rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ GIT
 
 GIT
   remote: git://github.com/ndlib/hesburgh_infrastructure.git
-  revision: 2b9af6f2d5f2a588703d03cd1dd91c09e883f183
+  revision: 0b1301f74047aed18e9b3b553fabc607b9694529
   specs:
     hesburgh_infrastructure (0.2.5)
       rails
@@ -186,6 +186,8 @@ GEM
     guard-coffeescript (1.4.0)
       coffee-script (>= 2.2.0)
       guard (>= 1.1.0)
+    guard-npm (1.1.0)
+      guard (>= 2.0)
     guard-rails (0.6.0)
       guard (~> 2.0)
     guard-rspec (4.3.1)
@@ -454,6 +456,7 @@ DEPENDENCIES
   guard
   guard-bundler
   guard-coffeescript
+  guard-npm
   guard-rails
   guard-rspec
   guard-spring
@@ -495,6 +498,3 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   underscore-rails
   web-console (~> 2.0)
-
-BUNDLED WITH
-   1.10.5

--- a/Guardfile
+++ b/Guardfile
@@ -22,3 +22,7 @@ end
 hesburgh_guard.rails do
   # Watch any custom paths
 end
+
+hesburgh_guard.npm do
+
+end


### PR DESCRIPTION
 * Adding `npm install` to guardfile with guard-npm.
 * Remember to run `bundle update hesburgh_infrastructure`