### PR TITLE
DEC-521: FK constraint checks

### DIFF
--- a/db/migrate/20150623132325_add_foreign_key_constraints.rb
+++ b/db/migrate/20150623132325_add_foreign_key_constraints.rb
@@ -1,5 +1,36 @@
 class AddForeignKeyConstraints < ActiveRecord::Migration
+  # Asserts that the given relation is empty
+  def empty!(relation:, error_message:)
+    if relation.count > 0
+      raise "Unable to add foreign keys. #{error_message}"
+    end
+  end
+
   def change
+    empty!(relation: Section.where("sections.item_id NOT IN (SELECT id FROM items)"),
+           error_message: "A section was found that had no associated item.")
+
+    empty!(relation: Section.where("sections.showcase_id NOT IN (SELECT id FROM showcases)"),
+           error_message: "A section was found that had no associated showcase.")
+
+    empty!(relation: Item.where("items.collection_id NOT IN (SELECT id FROM collections)"),
+           error_message: "An item was found that had no associated collection.")
+
+    empty!(relation: Item.where("items.parent_id IS NOT NULL AND items.parent_id NOT IN (SELECT id FROM items)"),
+           error_message: "An item was found that had no associated parent item.")
+
+    empty!(relation: Showcase.where("showcases.exhibit_id NOT IN (SELECT id FROM exhibits)"),
+           error_message: "A showcase was found that had no associated exhibit.")
+
+    empty!(relation: Exhibit.where("exhibits.collection_id NOT IN (SELECT id FROM collections)"),
+           error_message: "An exhibit was found that had no associated collection.")
+
+    empty!(relation: CollectionUser.where("collection_users.collection_id NOT IN (SELECT id FROM collections)"),
+           error_message: "A collection user was found that had no associated collection.")
+
+    empty!(relation: CollectionUser.where("collection_users.user_id NOT IN (SELECT id FROM users)"),
+           error_message: "A collection user was found that had no associated user.")
+
     add_foreign_key :exhibits, :collections
     add_foreign_key :collection_users, :collections
     add_foreign_key :items, :collections


### PR DESCRIPTION
Why: Current migration allowed for adding some foreign keys before breaking on others. This lead to a partially migrated state that was difficult to recover from.
How: Expanded the migration to first do checks for any records that would break the migration. If any fail, it will print the broken association and bail out of this and all future migrations. This should help us to isolate which tables we need to check whenever we deploy.