### PR TITLE
DEC-507 Index items

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,8 @@ gem "paper_trail", "~> 4.0.0.beta2"
 gem "faraday"
 gem "faraday_middleware"
 
+gem "sanitize"
+
 gem "sunspot"
 # Include the sunspot_rails gem but don't require it because we only want the configuration
 gem "sunspot_rails", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,6 +131,7 @@ GEM
       simplecov (>= 0.7)
       term-ansicolor
       thor
+    crass (1.0.2)
     curly-templates (2.4.1)
       actionpack (>= 3.1, < 5.0)
     dalli (2.7.4)
@@ -238,6 +239,8 @@ GEM
     newrelic_rpm (3.9.6.257)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
+    nokogumbo (1.4.1)
+      nokogiri
     orm_adapter (0.5.0)
     paper_trail (4.0.0.beta2)
       activerecord (>= 3.0, < 6.0)
@@ -341,6 +344,10 @@ GEM
     ruby-progressbar (1.7.5)
     rubycas-client (2.3.9)
       activesupport
+    sanitize (4.0.0)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.4.4)
+      nokogumbo (= 1.4.1)
     sass (3.2.19)
     sass-rails (4.0.5)
       railties (>= 4.0.0, < 5.0)
@@ -483,6 +490,7 @@ DEPENDENCIES
   rspec-collection_matchers
   rspec-rails
   rubocop
+  sanitize
   sass-rails (~> 4.0.3)
   sdoc (~> 0.4.0)
   showdown-rails
@@ -498,3 +506,6 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   underscore-rails
   web-console (~> 2.0)
+
+BUNDLED WITH
+   1.10.6

--- a/Guardfile
+++ b/Guardfile
@@ -17,6 +17,7 @@ end
 # https://github.com/guard/guard-spring
 hesburgh_guard.spring do
   # Watch any custom paths
+  watch(%r{^config/metadata/(.+)\.yml$}) { "spec/models/metadata/configuration/config_yml_spec.rb" }
 end
 
 hesburgh_guard.rails do
@@ -24,5 +25,4 @@ hesburgh_guard.rails do
 end
 
 hesburgh_guard.npm do
-
 end

--- a/app/models/metadata/configuration.rb
+++ b/app/models/metadata/configuration.rb
@@ -1,0 +1,42 @@
+module Metadata
+  class Configuration
+    attr_reader :fields, :field_map
+    private :field_map
+
+    def self.build_fields(data)
+      data.map { |field_data| self::Field.new(**field_data) }
+    end
+
+    def self.item_configuration
+      @item_configuration ||= new(load_yml(:item))
+    end
+
+    def initialize(data)
+      @fields = self.class.build_fields(data)
+      @field_map = build_field_map
+    end
+
+    def field(name)
+      field_map[name]
+    end
+
+    def field?(name)
+      field(name).present?
+    end
+
+    def self.load_yml(name)
+      YAML.load_file(Rails.root.join("config/metadata/", "#{name}.yml"))
+    end
+    private_class_method :load_yml
+
+    private
+
+    def build_field_map
+      {}.tap do |hash|
+        fields.each do |field|
+          hash[field.name] = field
+        end
+      end
+    end
+  end
+end

--- a/app/models/metadata/configuration/field.rb
+++ b/app/models/metadata/configuration/field.rb
@@ -1,0 +1,18 @@
+module Metadata
+  class Configuration
+    class Field
+      TYPES = [:string, :html, :date]
+
+      attr_reader :name, :type, :label
+
+      def initialize(name:, type:, label:)
+        unless TYPES.include?(type.to_sym)
+          raise ArgumentError, "Invalid type: #{type}.  Must be one of #{TYPES.join(', ')}"
+        end
+        @name = name.to_sym
+        @type = type.to_sym
+        @label = label
+      end
+    end
+  end
+end

--- a/app/models/waggle/index/item.rb
+++ b/app/models/waggle/index/item.rb
@@ -1,0 +1,26 @@
+module Waggle
+  module Index
+    module Item
+      def self.setup(configuration = default_configuration)
+        reset!
+        ::Sunspot.setup(Waggle::Item) do
+          configuration.fields.each do |field|
+            text field.name
+          end
+          string :type, stored: true
+          string :thumbnail_url, stored: true
+          time :last_updated, stored: true
+          text :name, stored: true
+        end
+      end
+
+      def self.reset!
+        ::Sunspot::Setup.send(:setups)[Waggle::Item.name.to_sym] = nil
+      end
+
+      def self.default_configuration
+        ::Metadata::Configuration.item_configuration
+      end
+    end
+  end
+end

--- a/app/models/waggle/index/item.rb
+++ b/app/models/waggle/index/item.rb
@@ -5,7 +5,13 @@ module Waggle
         reset!
         ::Sunspot.setup(Waggle::Item) do
           configuration.fields.each do |field|
-            text field.name
+            if field.type == :date
+              time field.name, multiple: true
+            elsif [:string, :html].include?(field.type)
+              text field.name
+            else
+              raise "unknown type #{field.type}"
+            end
           end
           string :type, stored: true
           string :thumbnail_url, stored: true

--- a/app/models/waggle/item.rb
+++ b/app/models/waggle/item.rb
@@ -1,5 +1,6 @@
 module Waggle
   class Item
+    TYPE = "Item"
     attr_reader :data
 
     def initialize(data)
@@ -10,17 +11,59 @@ module Waggle
       data.fetch("id")
     end
 
-    def name
-      data.fetch("name")
+    def type
+      TYPE
     end
 
-    def name_facet
-      name
+    def last_updated
+      @last_updated ||= Time.parse(data.fetch("last_updated")).utc
+    end
+
+    def thumbnail_url
+      if thumbnail
+        thumbnail["contentUrl"]
+      end
+    end
+
+    def metadata
+      @metadata ||= Waggle::Metadata::Set.new(data.fetch("metadata"), metadata_configuration)
+    end
+
+    def method_missing(method_name, *args, &block)
+      if metadata.field?(method_name)
+        metadata.value(method_name)
+      else
+        super
+      end
+    end
+
+    def respond_to?(method_name, include_private = false)
+      if metadata.field?(method_name)
+        true
+      else
+        super
+      end
     end
 
     def self.load(id)
       raw_data = File.read(Rails.root.join("spec/fixtures/v1/items/#{id}.json"))
       new(JSON.parse(raw_data).fetch("items"))
+    end
+
+    private
+
+    def metadata_configuration
+      ::Metadata::Configuration.item_configuration
+    end
+
+    def image
+      data.fetch("image")
+    end
+
+    def thumbnail
+      if image
+        image["thumbnail/small"]
+      end
     end
   end
 end

--- a/app/models/waggle/metadata/field.rb
+++ b/app/models/waggle/metadata/field.rb
@@ -1,0 +1,21 @@
+module Waggle
+  module Metadata
+    class Field
+      attr_reader :data, :type, :name, :label, :values
+      private :data
+
+      def initialize(data)
+        @type = data.fetch("@type")
+        @name = data.fetch("name")
+        @label = data.fetch("label")
+        @values = build_values(data.fetch("values"))
+      end
+
+      private
+
+      def build_values(values_data)
+        values_data.map { |value| Waggle::Metadata::Value.from_hash(value) }
+      end
+    end
+  end
+end

--- a/app/models/waggle/metadata/set.rb
+++ b/app/models/waggle/metadata/set.rb
@@ -5,22 +5,24 @@ module Waggle
 
       def initialize(data, configuration)
         @data = data
-        @values = {}
+        @fields = {}
         @configuration = configuration
       end
 
       def value(field_name)
-        @values[field_name] ||= raw_data(field_name).fetch("values").map { |v| v.fetch("value") }
+        if field(field_name)
+          field(field_name).values.map(&:value)
+        end
+      end
+
+      def field(field_name)
+        if field?(field_name) && data.has_key?(field_name.to_s)
+          @fields[field_name] ||= Waggle::Metadata::Field.new(data.fetch(field_name.to_s))
+        end
       end
 
       def field?(field_name)
         configuration.field?(field_name)
-      end
-
-      private
-
-      def raw_data(field_name)
-        data.fetch(field_name.to_s, "values" => [])
       end
     end
   end

--- a/app/models/waggle/metadata/set.rb
+++ b/app/models/waggle/metadata/set.rb
@@ -1,0 +1,27 @@
+module Waggle
+  module Metadata
+    class Set
+      attr_reader :data, :configuration
+
+      def initialize(data, configuration)
+        @data = data
+        @values = {}
+        @configuration = configuration
+      end
+
+      def value(field_name)
+        @values[field_name] ||= raw_data(field_name).fetch("values").map { |v| v.fetch("value") }
+      end
+
+      def field?(field_name)
+        configuration.field?(field_name)
+      end
+
+      private
+
+      def raw_data(field_name)
+        data.fetch(field_name.to_s, "values" => [])
+      end
+    end
+  end
+end

--- a/app/models/waggle/metadata/value.rb
+++ b/app/models/waggle/metadata/value.rb
@@ -1,8 +1,16 @@
 module Waggle
   module Metadata
     module Value
+      TYPE_MAP = {
+        "MetadataDate" => self::Date,
+        "MetadataHTML" => self::HTML,
+        "MetadataString" => self::String,
+      }.freeze
+
       def self.from_hash(hash)
-        Base.new(hash)
+        type = hash.fetch("@type")
+        type_class = TYPE_MAP.fetch(type)
+        type_class.new(hash)
       end
     end
   end

--- a/app/models/waggle/metadata/value.rb
+++ b/app/models/waggle/metadata/value.rb
@@ -1,0 +1,9 @@
+module Waggle
+  module Metadata
+    module Value
+      def self.from_hash(hash)
+        Base.new(hash)
+      end
+    end
+  end
+end

--- a/app/models/waggle/metadata/value/base.rb
+++ b/app/models/waggle/metadata/value/base.rb
@@ -1,0 +1,15 @@
+module Waggle
+  module Metadata
+    module Value
+      class Base
+        attr_reader :data, :type, :value
+        private :data
+
+        def initialize(data)
+          @type = data.fetch("@type")
+          @value = data.fetch("value")
+        end
+      end
+    end
+  end
+end

--- a/app/models/waggle/metadata/value/base.rb
+++ b/app/models/waggle/metadata/value/base.rb
@@ -2,12 +2,29 @@ module Waggle
   module Metadata
     module Value
       class Base
-        attr_reader :data, :type, :value
+        attr_reader :data
         private :data
 
         def initialize(data)
-          @type = data.fetch("@type")
-          @value = data.fetch("value")
+          @data = data
+        end
+
+        def type
+          fetch("@type")
+        end
+
+        def value
+          raise "not implemented"
+        end
+
+        def raw_value
+          fetch("value")
+        end
+
+        private
+
+        def fetch(key)
+          data.fetch(key)
         end
       end
     end

--- a/app/models/waggle/metadata/value/date.rb
+++ b/app/models/waggle/metadata/value/date.rb
@@ -1,0 +1,17 @@
+module Waggle
+  module Metadata
+    module Value
+      class Date < Base
+        def value
+          @value ||= ::DateTime.iso8601(iso8601)
+        end
+
+        private
+
+        def iso8601
+          fetch("iso8601")
+        end
+      end
+    end
+  end
+end

--- a/app/models/waggle/metadata/value/html.rb
+++ b/app/models/waggle/metadata/value/html.rb
@@ -1,0 +1,11 @@
+module Waggle
+  module Metadata
+    module Value
+      class HTML < Base
+        def value
+          Sanitize.fragment(raw_value.to_s).strip
+        end
+      end
+    end
+  end
+end

--- a/app/models/waggle/metadata/value/string.rb
+++ b/app/models/waggle/metadata/value/string.rb
@@ -2,8 +2,8 @@ module Waggle
   module Metadata
     module Value
       class String < Base
-        def to_s
-          value
+        def value
+          raw_value.to_s
         end
       end
     end

--- a/app/models/waggle/metadata/value/string.rb
+++ b/app/models/waggle/metadata/value/string.rb
@@ -1,0 +1,11 @@
+module Waggle
+  module Metadata
+    module Value
+      class String < Base
+        def to_s
+          value
+        end
+      end
+    end
+  end
+end

--- a/app/values/metadata_date.rb
+++ b/app/values/metadata_date.rb
@@ -8,6 +8,10 @@ class MetadataDate
   validates :day, numericality: { only_integer: true, allow_nil: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 31 }
   validates :month, presence: true, if: :month_required?
 
+  def self.from_hash(hash)
+    new(**hash.symbolize_keys)
+  end
+
   def initialize(year: nil, month: nil, day: nil, bc: nil, display_text: nil)
     @year = parse_value(year)
     @month = parse_value(month)

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -17,4 +17,5 @@
 ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.acronym "API"
   inflect.acronym "JSON"
+  inflect.acronym "HTML"
 end

--- a/config/initializers/waggle.rb
+++ b/config/initializers/waggle.rb
@@ -6,3 +6,5 @@ Sunspot::Adapters::DataAccessor.register(
   Waggle::Sunspot::Adapters::ItemDataAccessor,
   Waggle::Item
 )
+
+Waggle::Index::Item.setup

--- a/config/metadata/item.yml
+++ b/config/metadata/item.yml
@@ -1,0 +1,46 @@
+---
+- :name: :name
+  :type: :string
+  :label: Name
+- :name: :alternate_name
+  :type: :string
+  :label: Alternate Name
+- :name: :creator
+  :type: :string
+  :label: Creator
+- :name: :contributor
+  :type: :string
+  :label: Contributor
+- :name: :description
+  :type: :html
+  :label: Description
+- :name: :subject
+  :type: :html
+  :label: Subject
+- :name: :transcription
+  :type: :html
+  :label: Transcription
+- :name: :date_created
+  :type: :date
+  :label: Date Created
+- :name: :date_published
+  :type: :date
+  :label: Date Published
+- :name: :date_modified
+  :type: :date
+  :label: Date Modified
+- :name: :original_language
+  :type: :string
+  :label: Original Language
+- :name: :rights
+  :type: :string
+  :label: Rights
+- :name: :provenance
+  :type: :string
+  :label: Provenance
+- :name: :publisher
+  :type: :string
+  :label: Publisher
+- :name: :manuscript_url
+  :type: :string
+  :label: Digitized Manuscript

--- a/spec/decorators/v1/metadata_json_spec.rb
+++ b/spec/decorators/v1/metadata_json_spec.rb
@@ -9,10 +9,10 @@ RSpec.describe V1::MetadataJSON do
     it "calls the MetadataString class for string metadata" do
       allow(item).to receive(:name).and_return("name")
       expect_any_instance_of(MetadataString).to receive(:to_hash).and_return("hash")
-      expect(subject.metadata).to eq(name: { "@type"=>"MetadataField", "name" => :name, "label" => "Name", "values" => ["hash"] })
+      expect(subject.metadata).to eq(name: { "@type" => "MetadataField", "name" => :name, "label" => "Name", "values" => ["hash"] })
     end
 
-    it "calls the MetadataHtml class for html metadata" do
+    it "calls the MetadataHTML class for html metadata" do
       allow(item).to receive(:description).and_return("desc")
       expect_any_instance_of(MetadataHTML).to receive(:to_hash).and_return("hash")
       expect(subject.metadata).to eq(description: { "@type" => "MetadataField", "name" => :description, "label" => "Description", "values" => ["hash"] })

--- a/spec/fixtures/v1/items/pig-in-mud.json
+++ b/spec/fixtures/v1/items/pig-in-mud.json
@@ -13,7 +13,7 @@
   "description":"",
   "about":"",
   "image":null,
-  "last_updated":"2015-06-23T18:16:15.000Z",
+  "last_updated":"2015-08-04T12:39:35.000Z",
   "copyright":"\u003cp\u003e\u003ca href=\"http://www.nd.edu/copyright/\"\u003eCopyright\u003c/a\u003e 2015 \u003ca href=\"http://www.nd.edu\"\u003eUniversity of Notre Dame\u003c/a\u003e\u003c/p\u003e",
   "items":{
     "@context":"http://schema.org",
@@ -23,7 +23,7 @@
     "id":"pig-in-mud",
     "slug":"pig-in-mud",
     "name":"pig-in-mud",
-    "description":"Source: https://pixabay.com/en/pig-sow-animal-portrait-752555/",
+    "description":"\u003cp\u003eSource: \u003ca href=\"https://pixabay.com/en/pig-sow-animal-portrait-752555/\"\u003ehttps://pixabay.com/en/pig-sow-animal-portrait-752555/\u003c/a\u003e\n\u003c/p\u003e",
     "image":{
       "@context":"http://schema.org",
       "@type":"ImageObject",
@@ -85,7 +85,7 @@
         "values":[
           {
             "@type":"MetadataHTML",
-            "value":"<p>Source: https://pixabay.com/en/pig-sow-animal-portrait-752555/</p>"
+            "value":"\u003cp\u003eSource: \u003ca href=\"https://pixabay.com/en/pig-sow-animal-portrait-752555/\"\u003ehttps://pixabay.com/en/pig-sow-animal-portrait-752555/\u003c/a\u003e\n\u003c/p\u003e"
           }
         ]
       },
@@ -102,12 +102,12 @@
             "month":"03",
             "day":"24",
             "bc":"false",
-            "display-text":"March 2013"
+            "displayText":"March 2013"
           }
         ]
       }
     },
-    "last_updated":"2015-07-23T20:26:06.000Z",
+    "last_updated":"2015-08-04T12:47:17.000Z",
     "children":[
 
     ]

--- a/spec/fixtures/v1/items/pig-in-mud.json
+++ b/spec/fixtures/v1/items/pig-in-mud.json
@@ -55,24 +55,58 @@
         "contentUrl":"http://localhost:3019/images/honeycomb/000/001/000/013/small/pig-in-mud.jpg"
       }
     },
-    "metadata":[
-      {
+    "metadata":{
+      "name":{
+        "@type":"MetadataField",
+        "name":"name",
         "label":"Name",
-        "value":"pig-in-mud"
+        "values":[
+          {
+            "@type":"MetadataString",
+            "value":"pig-in-mud"
+          }
+        ]
       },
-      {
-        "label":"Description",
-        "value":"Source: https://pixabay.com/en/pig-sow-animal-portrait-752555/"
-      },
-      {
+      "creator":{
+        "@type":"MetadataField",
+        "name":"creator",
         "label":"Creator",
-        "value":"Bob"
+        "values":[
+          {
+            "@type":"MetadataString",
+            "value":"Bob"
+          }
+        ]
       },
-      {
+      "description":{
+        "@type":"MetadataField",
+        "name":"description",
+        "label":"Description",
+        "values":[
+          {
+            "@type":"MetadataHTML",
+            "value":"<p>Source: https://pixabay.com/en/pig-sow-animal-portrait-752555/</p>"
+          }
+        ]
+      },
+      "date_published":{
+        "@type":"MetadataField",
+        "name":"date_published",
         "label":"Date Published",
-        "value":"March 2013"
+        "values":[
+          {
+            "@type":"MetadataDate",
+            "value":"March 2013",
+            "iso8601":"2013-03-24",
+            "year":"2013",
+            "month":"03",
+            "day":"24",
+            "bc":"false",
+            "display-text":"March 2013"
+          }
+        ]
       }
-    ],
+    },
     "last_updated":"2015-07-23T20:26:06.000Z",
     "children":[
 

--- a/spec/models/metadata/configuration/config_yml_spec.rb
+++ b/spec/models/metadata/configuration/config_yml_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe Metadata::Configuration do
+  Dir.glob(Rails.root.join("config/metadata/*.yml")).each do |path|
+    describe path do
+      let(:data) { YAML.load_file(path) }
+
+      subject { described_class.new(data) }
+
+      it "is valid" do
+        expect(subject.fields).to be_kind_of(Array)
+        expect(subject.fields.first).to be_kind_of(described_class::Field)
+      end
+
+      it "doesn't contain duplicate fields" do
+        fields = data.map { |hash| hash[:name] }
+        expect(fields).to eq(fields.uniq)
+      end
+    end
+  end
+end

--- a/spec/models/metadata/configuration/field_spec.rb
+++ b/spec/models/metadata/configuration/field_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe Metadata::Configuration::Field do
+  let(:data) { { name: :string_field, type: :string, label: "String" } }
+
+  subject { described_class.new(data) }
+
+  describe "name" do
+    it "is the expected value" do
+      expect(subject.name).to eq(data[:name])
+    end
+  end
+
+  describe "type" do
+    it "is the expected value" do
+      expect(subject.type).to eq(data[:type])
+    end
+
+    described_class::TYPES.each do |type|
+      it "can be '#{type}'" do
+        data[:type] = type
+        expect(subject.type).to eq(type)
+      end
+    end
+
+    it "cannot be an unknown type" do
+      data[:type] = :fake_type
+      expect { subject }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe "label" do
+    it "is the expected value" do
+      expect(subject.label).to eq(data[:label])
+    end
+  end
+end

--- a/spec/models/metadata/configuration_spec.rb
+++ b/spec/models/metadata/configuration_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+RSpec.describe Metadata::Configuration do
+  let(:data) do
+    [
+      { name: :string_field, type: :string, label: "String" },
+      { name: :date_field, type: :date, label: "Date" },
+    ]
+  end
+
+  subject { described_class.new(data) }
+
+  describe "field" do
+    it "finds a field by its name" do
+      field = subject.field(:string_field)
+      expect(field).to be_kind_of(described_class::Field)
+      expect(field.name).to eq(:string_field)
+    end
+
+    it "returns nil if a field doesn't exist" do
+      expect(subject.field(:fake_field)).to be_nil
+    end
+  end
+
+  describe "field?" do
+    it "returns true for a field that exists" do
+      expect(subject.field?(:string_field)).to eq(true)
+    end
+
+    it "returns nil if a field doesn't exist" do
+      expect(subject.field?(:fake_field)).to eq(false)
+    end
+  end
+
+  context "self" do
+    describe "build_fields" do
+      subject { described_class.build_fields(data) }
+
+      it "creates an array of fields" do
+        expect(described_class::Field).to receive(:new).with(data[0]).and_call_original
+        expect(described_class::Field).to receive(:new).with(data[1]).and_call_original
+        expect(subject).to be_kind_of(Array)
+        expect(subject.first).to be_kind_of(described_class::Field)
+      end
+    end
+
+    describe "item_configuration" do
+      subject { described_class.item_configuration }
+
+      after do
+        described_class.instance_variable_set :@item_configuration, nil
+      end
+
+      it "loads configuration from a yml file" do
+        described_class.instance_variable_set :@item_configuration, nil
+        expect(YAML).to receive(:load_file).with(Rails.root.join("config/metadata/", "item.yml")).and_return([])
+        expect(subject.fields).to eq([])
+      end
+
+      it "returns a configuration with an array of fields" do
+        expect(subject).to be_kind_of(described_class)
+        expect(subject.fields.first).to be_kind_of(described_class::Field)
+      end
+    end
+  end
+end

--- a/spec/models/waggle/index/item_spec.rb
+++ b/spec/models/waggle/index/item_spec.rb
@@ -1,0 +1,123 @@
+require "rails_helper"
+
+RSpec.describe Waggle::Index::Item do
+  let(:item_id) { "pig-in-mud" }
+  let(:raw_data) { File.read(Rails.root.join("spec/fixtures/v1/items/#{item_id}.json")) }
+  let(:data) { JSON.parse(raw_data).fetch("items") }
+  let(:index_class) { Waggle::Item }
+  let(:instance) { index_class.new(data) }
+  let(:other_instance) do
+    data = instance.data.clone
+    data["id"] += "other"
+    data["metadata"]["name"]["values"].first["value"] += " pig"
+    index_class.new(data)
+  end
+
+  before :all do
+    unstub_solr
+  end
+
+  after :all do
+    stub_solr
+  end
+
+  describe "self.setup" do
+    subject { described_class.setup }
+
+    it "calls reset!" do
+      expect(described_class).to receive(:reset!)
+      subject
+    end
+
+    it "sets up Sunspot for Waggle::Item" do
+      described_class.reset!
+      expect(Sunspot::Setup.for(index_class)).to be_nil
+      subject
+      expect(Sunspot::Setup.for(index_class)).to be_kind_of(Sunspot::Setup)
+    end
+
+    describe "fields" do
+      before do
+        allow_any_instance_of(Sunspot::DSL::Fields).to receive(:text)
+        allow_any_instance_of(Sunspot::DSL::Fields).to receive(:string)
+      end
+
+      shared_examples_for "a field indexer" do |field_name, field_type, arguments|
+        it "indexes #{field_name} as #{field_type} with arguments: #{arguments}" do
+          if arguments
+            expect_any_instance_of(Sunspot::DSL::Fields).to receive(field_type).with(field_name, arguments)
+          else
+            expect_any_instance_of(Sunspot::DSL::Fields).to receive(field_type).with(field_name)
+          end
+          subject
+        end
+      end
+
+      it_behaves_like "a field indexer", :name, :text, stored: true
+
+      it_behaves_like "a field indexer", :type, :string, stored: true
+
+      it_behaves_like "a field indexer", :thumbnail_url, :string, stored: true
+
+      it_behaves_like "a field indexer", :last_updated, :time, stored: true
+
+      context "metadata fields" do
+        Metadata::Configuration.item_configuration.fields.each do |field|
+          it_behaves_like "a field indexer", field.name, :text
+        end
+      end
+    end
+  end
+
+  describe "self.reset!" do
+    subject { described_class.reset! }
+
+    it "resets an existing setup" do
+      described_class.setup
+      expect(Sunspot::Setup.for(index_class)).to be_kind_of(Sunspot::Setup)
+      subject
+      expect(Sunspot::Setup.for(index_class)).to be_nil
+    end
+  end
+
+  describe "Waggle::Item search" do
+    before :each do
+      described_class.setup
+    end
+
+    before do
+      Sunspot.remove_all(index_class)
+      Sunspot.commit
+    end
+
+    after do
+      Sunspot.remove_all(index_class)
+      Sunspot.commit
+    end
+
+    it "is searchable" do
+      Sunspot.index(instance)
+      Sunspot.index(other_instance)
+      Sunspot.commit
+
+      q = "pig"
+
+      search = Sunspot.search index_class do
+        fulltext q do
+          boost_fields name: 3.0
+          highlight :name
+        end
+      end
+
+      # search.hits.each do |hit|
+      #   stored_values = hit.instance_variable_get(:@stored_values)
+      #   pp stored_values
+      # end
+
+      hit = search.hits.detect { |h| h.primary_key == instance.id }
+      expect(hit.highlights.first).to be_kind_of(Sunspot::Search::Highlight)
+      expect(hit.highlights.first.formatted).to eq("<em>pig</em>-in-mud")
+      expect(hit.stored(:name)).to eq(["pig-in-mud"])
+    end
+  end
+end

--- a/spec/models/waggle/index/item_spec.rb
+++ b/spec/models/waggle/index/item_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe Waggle::Index::Item do
     describe "fields" do
       before do
         allow_any_instance_of(Sunspot::DSL::Fields).to receive(:text)
+        allow_any_instance_of(Sunspot::DSL::Fields).to receive(:time)
         allow_any_instance_of(Sunspot::DSL::Fields).to receive(:string)
       end
 
@@ -63,7 +64,11 @@ RSpec.describe Waggle::Index::Item do
 
       context "metadata fields" do
         Metadata::Configuration.item_configuration.fields.each do |field|
-          it_behaves_like "a field indexer", field.name, :text
+          if field.type == :date
+            it_behaves_like "a field indexer", field.name, :time, multiple: true
+          else
+            it_behaves_like "a field indexer", field.name, :text
+          end
         end
       end
     end

--- a/spec/models/waggle/metadata/field_spec.rb
+++ b/spec/models/waggle/metadata/field_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe Waggle::Metadata::Field do
+  let(:data) do
+    {
+      "@type" => "MetadataField",
+      "name" => "creator",
+      "label" => "Creator",
+      "values" => [
+        {
+          "@type" => "MetadataString",
+          "value" => "Bob Smith"
+        },
+        {
+          "@type" => "MetadataString",
+          "value" => "John Doe"
+        }
+      ]
+    }
+  end
+
+  subject { described_class.new(data) }
+
+  describe "type" do
+    it "is MetadataField" do
+      expect(subject.type).to eq("MetadataField")
+    end
+  end
+
+  describe "name" do
+    it "is the field name" do
+      expect(subject.name).to eq("creator")
+    end
+  end
+
+  describe "label" do
+    it "is the field label" do
+      expect(subject.label).to eq("Creator")
+    end
+  end
+
+  describe "values" do
+    it "is an array of values" do
+      expect(subject.values).to be_kind_of(Array)
+      expect(subject.values.first).to be_kind_of(Waggle::Metadata::Value::Base)
+    end
+  end
+end

--- a/spec/models/waggle/metadata/set_spec.rb
+++ b/spec/models/waggle/metadata/set_spec.rb
@@ -23,8 +23,13 @@ RSpec.describe Waggle::Metadata::Set do
       expect(subject.value(:name)).to eq(["pig-in-mud"])
     end
 
+    it "returns nil for a field with no value" do
+      data.delete("name")
+      expect(subject.value(:name)).to be_nil
+    end
+
     it "returns nil for a field that doesn't exist" do
-      expect(subject.value(:fake_field)).to eq([])
+      expect(subject.value(:fake_field)).to be_nil
     end
   end
 end

--- a/spec/models/waggle/metadata/set_spec.rb
+++ b/spec/models/waggle/metadata/set_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe Waggle::Metadata::Set do
+  let(:item_id) { "pig-in-mud" }
+  let(:raw_data) { File.read(Rails.root.join("spec/fixtures/v1/items/#{item_id}.json")) }
+  let(:data) { JSON.parse(raw_data).fetch("items").fetch("metadata") }
+  let(:configuration) { Metadata::Configuration.item_configuration }
+
+  subject { described_class.new(data, configuration) }
+
+  describe "field?" do
+    it "is true for a field that exists" do
+      expect(subject.field?(:name)).to eq(true)
+    end
+
+    it "is false for a field that doesn't exist" do
+      expect(subject.field?(:fake_field)).to eq(false)
+    end
+  end
+
+  describe "value" do
+    it "returns the value in an array" do
+      expect(subject.value(:name)).to eq(["pig-in-mud"])
+    end
+
+    it "returns nil for a field that doesn't exist" do
+      expect(subject.value(:fake_field)).to eq([])
+    end
+  end
+end

--- a/spec/models/waggle/metadata/value/base_spec.rb
+++ b/spec/models/waggle/metadata/value/base_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe Waggle::Metadata::Value::Base do
+  let(:data) { { "@type" => "MetadataString", "value" => "Bob Smith" } }
+
+  subject { described_class.new(data) }
+
+  it "works"
+end

--- a/spec/models/waggle/metadata/value/base_spec.rb
+++ b/spec/models/waggle/metadata/value/base_spec.rb
@@ -5,5 +5,27 @@ RSpec.describe Waggle::Metadata::Value::Base do
 
   subject { described_class.new(data) }
 
-  it "works"
+  describe "data" do
+    it "is stored" do
+      expect(subject.send(:data)).to eq(data)
+    end
+  end
+
+  describe "type" do
+    it "is the type" do
+      expect(subject.type).to eq("MetadataString")
+    end
+  end
+
+  describe "value" do
+    it "raises an error that it's not implemented" do
+      expect { subject.value }.to raise_error("not implemented")
+    end
+  end
+
+  describe "raw_value" do
+    it "is the original value" do
+      expect(subject.raw_value).to eq(data.fetch("value"))
+    end
+  end
 end

--- a/spec/models/waggle/metadata/value/date_spec.rb
+++ b/spec/models/waggle/metadata/value/date_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe Waggle::Metadata::Value::Date do
+  let(:data) do
+    {
+      "@type" => "MetadataDate",
+      "value" => "March 2013",
+      "iso8601" => "2013-03-24",
+      "year" => "2013",
+      "month" => "03",
+      "day" => "24",
+      "bc" => "false",
+      "displayText" => "March 2013"
+    }
+  end
+
+  subject { described_class.new(data) }
+
+  describe "value" do
+    it "is a datetime" do
+      expect(subject.value).to eq(DateTime.new(2013, 3, 24))
+    end
+
+    it "can be in bc" do
+      data["iso8601"] = "-2010-10-15"
+      expect(subject.value).to eq(DateTime.new(-2010, 10, 15))
+    end
+  end
+end

--- a/spec/models/waggle/metadata/value/html_spec.rb
+++ b/spec/models/waggle/metadata/value/html_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe Waggle::Metadata::Value::HTML do
+  let(:data) { { "@type" => "MetadataHTML", "value" => "<p>Lorem ipsum</p>" } }
+
+  subject { described_class.new(data) }
+
+  describe "value" do
+    it "strips html tags" do
+      data["value"] = "<p>Lorem ipsum</p>"
+      expect(subject.value).to eq("Lorem ipsum")
+    end
+
+    it "does not alter strings without tags" do
+      data["value"] = "No tags"
+      expect(subject.value).to eq("No tags")
+    end
+  end
+end

--- a/spec/models/waggle/metadata/value/string_spec.rb
+++ b/spec/models/waggle/metadata/value/string_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe Waggle::Metadata::Value::String do
+  it "works"
+end

--- a/spec/models/waggle/metadata/value/string_spec.rb
+++ b/spec/models/waggle/metadata/value/string_spec.rb
@@ -1,5 +1,18 @@
 require "rails_helper"
 
 RSpec.describe Waggle::Metadata::Value::String do
-  it "works"
+  let(:data) { { "@type" => "MetadataString", "value" => "Bob Smith" } }
+
+  subject { described_class.new(data) }
+
+  describe "value" do
+    it "is a string value" do
+      expect(subject.value).to eq("Bob Smith")
+    end
+
+    it "converts to a string" do
+      data["value"] = 123
+      expect(subject.value).to eq("123")
+    end
+  end
 end

--- a/spec/models/waggle/metadata/value_spec.rb
+++ b/spec/models/waggle/metadata/value_spec.rb
@@ -6,10 +6,19 @@ RSpec.describe Waggle::Metadata::Value do
   describe "from_hash" do
     subject { described_class.from_hash(data) }
 
-    it "returns a value" do
-      expect(subject).to be_kind_of(described_class::Base)
+    it "returns a String instance" do
+      data["@type"] = "MetadataString"
+      expect(subject).to be_kind_of(described_class::String)
     end
 
-    it "returns a value based on type"
+    it "returns a Date instance" do
+      data["@type"] = "MetadataDate"
+      expect(subject).to be_kind_of(described_class::Date)
+    end
+
+    it "returns an HTML instance" do
+      data["@type"] = "MetadataHTML"
+      expect(subject).to be_kind_of(described_class::HTML)
+    end
   end
 end

--- a/spec/models/waggle/metadata/value_spec.rb
+++ b/spec/models/waggle/metadata/value_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe Waggle::Metadata::Value do
+  let(:data) { { "@type" => "MetadataString", "value" => "Bob Smith" } }
+
+  describe "from_hash" do
+    subject { described_class.from_hash(data) }
+
+    it "returns a value" do
+      expect(subject).to be_kind_of(described_class::Base)
+    end
+
+    it "returns a value based on type"
+  end
+end

--- a/spec/values/metadata_date_spec.rb
+++ b/spec/values/metadata_date_spec.rb
@@ -1,6 +1,20 @@
 require "rails_helper"
 
 RSpec.describe MetadataDate do
+  describe "#from_hash" do
+    let(:hash) { { year: "2015", month: "7", day: "15" } }
+
+    it "works with string keys" do
+      expect(MetadataDate).to receive(:new).with(hash)
+      MetadataDate.from_hash(hash.stringify_keys)
+    end
+
+    it "works with symbol keys" do
+      expect(MetadataDate).to receive(:new).with(hash)
+      MetadataDate.from_hash(hash)
+    end
+  end
+
   describe :year do
     it "passes the value of the year field " do
       date = MetadataDate.new(year: "year")


### PR DESCRIPTION
This PR includes code to index Item API data into Solr using Sunspot.

I added a Metadata::Configuration class to contain the configuration information for item metadata.

The Waggle namespace includes all of the code for indexing item data.

Waggle::Item is a wrapper around the item API JSON output.  
Waggle::Metadata::Set is a wrapper around the item's metadata JSON.  It is used to return all metadata field values in their indexable form.
Waggle::Index::Item is responsible for setting up the indexing of Waggle::Item using Sunspot.

This does not include the functionality to index items automatically on save.  That will come in a separate pull request.

