### PR TITLE
Add missing beehive title

### DIFF
--- a/app/controllers/exhibits_controller.rb
+++ b/app/controllers/exhibits_controller.rb
@@ -32,7 +32,8 @@ class ExhibitsController < ApplicationController
       :uploaded_image,
       :short_description,
       :about,
-      :copyright
+      :copyright,
+      :show_page_title
     ])
   end
 end

--- a/app/decorators/v1/collection_json_decorator.rb
+++ b/app/decorators/v1/collection_json_decorator.rb
@@ -44,6 +44,10 @@ module V1
       end
     end
 
+    def show_page_title
+      object.exhibit.show_page_title ? true : false
+    end
+
     def slug
       CreateURLSlug.call(object.name_line_1)
     end

--- a/app/decorators/v1/collection_json_decorator.rb
+++ b/app/decorators/v1/collection_json_decorator.rb
@@ -45,7 +45,7 @@ module V1
     end
 
     def show_page_title
-      object.exhibit.show_page_title ? true : false
+      object.exhibit.show_page_title?
     end
 
     def slug

--- a/app/views/exhibits/_form.html.erb
+++ b/app/views/exhibits/_form.html.erb
@@ -4,6 +4,6 @@
 <%= HoneypotThumbnail.display(f.object.honeypot_image) %>
 <%= f.input :uploaded_image, as: :file %>
 
-<%= f.input :show_page_title, as: :boolean, label: false do %>
-  <label><%= f.check_box :show_page_title %> Uploaded Image has the home page title embeded in it.</label>
+<%= f.input :show_page_title, as: :boolean, label: false, hint: "Select this box if your homepage image does not have your site title already embeded in it" do %>
+  <label><%= f.check_box :show_page_title %> Overlay site title over homepage image.</label>
 <% end %>

--- a/app/views/exhibits/_form.html.erb
+++ b/app/views/exhibits/_form.html.erb
@@ -3,3 +3,7 @@
 
 <%= HoneypotThumbnail.display(f.object.honeypot_image) %>
 <%= f.input :uploaded_image, as: :file %>
+
+<%= f.input :show_page_title, as: :boolean, label: false do %>
+  <label><%= f.check_box :show_page_title %> Uploaded Image has the home page title embeded in it.</label>
+<% end %>

--- a/app/views/v1/collections/_collection.json.jbuilder
+++ b/app/views/v1/collections/_collection.json.jbuilder
@@ -11,6 +11,7 @@ json.name_line_2 collection_object.name_line_2
 json.short_description collection_object.short_intro
 json.description collection_object.site_intro
 json.about collection_object.about
+json.show_page_title collection_object.show_page_title
 json.image collection_object.image
 json.last_updated collection_object.updated_at
 json.copyright collection_object.copyright

--- a/db/migrate/20150804194246_add_show_page_title_to_exhibit.rb
+++ b/db/migrate/20150804194246_add_show_page_title_to_exhibit.rb
@@ -1,5 +1,7 @@
 class AddShowPageTitleToExhibit < ActiveRecord::Migration
   def change
     add_column :exhibits, :show_page_title, :boolean
+
+    Exhibit.update_all(show_page_title: true)
   end
 end

--- a/db/migrate/20150804194246_add_show_page_title_to_exhibit.rb
+++ b/db/migrate/20150804194246_add_show_page_title_to_exhibit.rb
@@ -1,0 +1,5 @@
+class AddShowPageTitleToExhibit < ActiveRecord::Migration
+  def change
+    add_column :exhibits, :show_page_title, :boolean
+  end
+end

--- a/db/migrate/20150804194246_add_show_page_title_to_exhibit.rb
+++ b/db/migrate/20150804194246_add_show_page_title_to_exhibit.rb
@@ -1,7 +1,5 @@
 class AddShowPageTitleToExhibit < ActiveRecord::Migration
   def change
     add_column :exhibits, :show_page_title, :boolean
-
-    Exhibit.update_all(show_page_title: true)
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150623132325) do
+ActiveRecord::Schema.define(version: 20150804194246) do
 
   create_table "collection_users", force: :cascade do |t|
     t.integer  "user_id",       limit: 4, null: false
@@ -56,6 +56,7 @@ ActiveRecord::Schema.define(version: 20150623132325) do
     t.integer  "uploaded_image_file_size",    limit: 4
     t.datetime "uploaded_image_updated_at"
     t.text     "copyright",                   limit: 65535
+    t.boolean  "show_page_title",             limit: 1
   end
 
   add_index "exhibits", ["collection_id"], name: "fk_rails_b56f41d7b6", using: :btree

--- a/spec/decorators/v1/collection_json_decorator_spec.rb
+++ b/spec/decorators/v1/collection_json_decorator_spec.rb
@@ -43,6 +43,26 @@ RSpec.describe V1::CollectionJSONDecorator do
     end
   end
 
+  describe "#show_page_title" do
+    let(:exhibit) { double(Exhibit, show_page_title: nil) }
+    let(:collection) { double(Collection, exhibit: exhibit) }
+
+    it "converts nil to false" do
+      expect(subject.show_page_title).to eq(false)
+    end
+
+    it "returns true value from the exhibit" do
+      expect(exhibit).to receive(:show_page_title).and_return(true)
+      expect(subject.show_page_title).to eq(true)
+    end
+
+    it "returns true false when the exhibi is false" do
+      expect(exhibit).to receive(:show_page_title).and_return(false)
+      expect(subject.show_page_title).to eq(false)
+    end
+
+  end
+
   describe "#copyright" do
     let(:exhibit) { double(Exhibit) }
     let(:collection) { double(Collection, exhibit: exhibit) }

--- a/spec/decorators/v1/collection_json_decorator_spec.rb
+++ b/spec/decorators/v1/collection_json_decorator_spec.rb
@@ -44,20 +44,16 @@ RSpec.describe V1::CollectionJSONDecorator do
   end
 
   describe "#show_page_title" do
-    let(:exhibit) { instance_double(Exhibit, show_page_title: nil) }
+    let(:exhibit) { instance_double(Exhibit) }
     let(:collection) { instance_double(Collection, exhibit: exhibit) }
 
-    it "converts nil to false" do
-      expect(subject.show_page_title).to eq(false)
-    end
-
     it "returns true value from the exhibit" do
-      expect(exhibit).to receive(:show_page_title).and_return(true)
+      expect(exhibit).to receive(:show_page_title?).and_return(true)
       expect(subject.show_page_title).to eq(true)
     end
 
-    it "returns true false when the exhibi is false" do
-      expect(exhibit).to receive(:show_page_title).and_return(false)
+    it "returns false when the exhibi is false" do
+      expect(exhibit).to receive(:show_page_title?).and_return(false)
       expect(subject.show_page_title).to eq(false)
     end
   end

--- a/spec/decorators/v1/collection_json_decorator_spec.rb
+++ b/spec/decorators/v1/collection_json_decorator_spec.rb
@@ -60,7 +60,6 @@ RSpec.describe V1::CollectionJSONDecorator do
       expect(exhibit).to receive(:show_page_title).and_return(false)
       expect(subject.show_page_title).to eq(false)
     end
-
   end
 
   describe "#copyright" do

--- a/spec/decorators/v1/collection_json_decorator_spec.rb
+++ b/spec/decorators/v1/collection_json_decorator_spec.rb
@@ -44,8 +44,8 @@ RSpec.describe V1::CollectionJSONDecorator do
   end
 
   describe "#show_page_title" do
-    let(:exhibit) { double(Exhibit, show_page_title: nil) }
-    let(:collection) { double(Collection, exhibit: exhibit) }
+    let(:exhibit) { instance_double(Exhibit, show_page_title: nil) }
+    let(:collection) { instance_double(Collection, exhibit: exhibit) }
 
     it "converts nil to false" do
       expect(subject.show_page_title).to eq(false)

--- a/spec/models/exhibit_spec.rb
+++ b/spec/models/exhibit_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Exhibit do
-  [:name, :description, :short_description, :showcases, :collection_id, :about, :updated_at, :created_at, :copyright].each do |field|
+  [:name, :description, :short_description, :showcases, :show_page_title, :collection_id, :about, :updated_at, :created_at, :copyright].each do |field|
     it "has the field #{field}" do
       expect(subject).to respond_to(field)
       expect(subject).to respond_to("#{field}=")


### PR DESCRIPTION
We don't have a way to control if we should show the site title as text in beehive this creates a way. 

