### PR TITLE
DEC-540: Item showcase list caching bug

### DIFF
--- a/app/values/cache_keys/custom/items.rb
+++ b/app/values/cache_keys/custom/items.rb
@@ -7,7 +7,10 @@ module CacheKeys
       end
 
       def edit(decorated_item:)
-        CacheKeys::ActiveRecord.new.generate(record: [decorated_item.collection, decorated_item.recent_children, decorated_item.object])
+        CacheKeys::ActiveRecord.new.generate(record: [decorated_item.collection,
+                                                      decorated_item.recent_children,
+                                                      decorated_item.object,
+                                                      decorated_item.showcases])
       end
     end
   end

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -149,6 +149,7 @@ RSpec.describe ItemsController, type: :controller do
 
     before(:each) do
       allow_any_instance_of(ItemDecorator).to receive(:recent_children).and_return(nil)
+      allow_any_instance_of(ItemDecorator).to receive(:showcases).and_return(nil)
       allow_any_instance_of(ItemQuery).to receive(:find).and_return(item)
     end
 

--- a/spec/values/cache_keys/custom/items_spec.rb
+++ b/spec/values/cache_keys/custom/items_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe CacheKeys::Custom::Items do
 
   context "edit" do
     let(:collection) { instance_double(Collection, items: "items") }
-    let(:item) { instance_double(Item, collection: collection) }
+    let(:item) { instance_double(Item, collection: collection, showcases: ["showcase1", "showcase2"]) }
     let(:decorated_item) { ItemDecorator.new(item) }
 
     before(:each) do
@@ -30,7 +30,7 @@ RSpec.describe CacheKeys::Custom::Items do
     end
 
     it "uses the correct data" do
-      record = [decorated_item.collection, decorated_item.recent_children, decorated_item.object]
+      record = [decorated_item.collection, decorated_item.recent_children, decorated_item.object, decorated_item.showcases]
       expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with(record: record)
       subject.edit(decorated_item: decorated_item)
     end


### PR DESCRIPTION
Why: Item edit page is not updating the list of showcases if a user has previously visited the page
How: Added showcase list to cache key generation for item edit