### PR TITLE
Showcase list bug

### DIFF
--- a/app/assets/javascripts/components/ShowcasesPanel.jsx
+++ b/app/assets/javascripts/components/ShowcasesPanel.jsx
@@ -1,5 +1,6 @@
 /** @jsx React.DOM */
 var React = require('react');
+
 var ShowcasesPanel = React.createClass({
   mixins: [TitleConcatMixin],
   propTypes: {
@@ -13,10 +14,28 @@ var ShowcasesPanel = React.createClass({
     };
   },
 
-  imageStyle: function() {
-    return {
-      height: '100',
-    };
+  showcaseImageDiv: function (showcase) {
+    if(showcase.image) {
+      return (
+        <div className="image">
+          <HoneypotImage honeypot_image={showcase.image} style="small" />
+        </div>
+      )
+    } else {
+      return (
+        <div className="image" >
+          <img src="/assets/logo.w.svg" style={{ "background-color": "#d9a300"}} />
+        </div>
+      )
+    }
+  },
+
+  showcaseNameDiv: function (showcase) {
+    return (
+      <div className="name">
+        { this.titleConcat(showcase.name_line_1, showcase.name_line_2) }
+      </div>
+    )
   },
 
   showcaseNodes: function () {
@@ -28,12 +47,8 @@ var ShowcasesPanel = React.createClass({
       return (
         <div key={key} className="row">
           <a href={showcase["@id"]}>
-            <div className="image">
-              <HoneypotImage honeypot_image={showcase.image} style="small" />
-            </div>
-            <div className="name">
-              {this.titleConcat(showcase.name_line_1, showcase.name_line_2)}
-            </div>
+            { this.showcaseImageDiv(showcase) }
+            { this.showcaseNameDiv(showcase) }
           </a>
         </div>
       )
@@ -47,7 +62,7 @@ var ShowcasesPanel = React.createClass({
         <PanelHeading>{this.props.panelTitle}</PanelHeading>
         <PanelBody>
           <div className="showcases-panel">
-          {this.showcaseNodes()}
+            {this.showcaseNodes()}
           </div>
         </PanelBody>
       </Panel>
@@ -63,4 +78,5 @@ var ShowcasesPanel = React.createClass({
   }
 
 });
+
 module.exports = ShowcasesPanel;

--- a/app/assets/javascripts/components/ShowcasesPanel.jsx
+++ b/app/assets/javascripts/components/ShowcasesPanel.jsx
@@ -1,8 +1,10 @@
 /** @jsx React.DOM */
 var React = require('react');
+var mui = require("material-ui");
+var Avatar = mui.Avatar;
 
 var ShowcasesPanel = React.createClass({
-  mixins: [TitleConcatMixin],
+  mixins: [TitleConcatMixin, MuiThemeMixin],
   propTypes: {
     showcases: React.PropTypes.array.isRequired,
     panelTitle: React.PropTypes.string.isRequired,
@@ -18,13 +20,13 @@ var ShowcasesPanel = React.createClass({
     if(showcase.image) {
       return (
         <div className="image">
-          <HoneypotImage honeypot_image={showcase.image} style="small" />
+          <Avatar src={ showcase.image["thumbnail/small"]["contentUrl"] } />
         </div>
       )
     } else {
       return (
         <div className="image" >
-          <img src="/assets/logo.w.svg" style={{ "background-color": "#d9a300"}} />
+          <Avatar>{ showcase.name_line_1[0].toUpperCase() }</Avatar>
         </div>
       )
     }

--- a/app/assets/stylesheets/ui-customizations.css.scss
+++ b/app/assets/stylesheets/ui-customizations.css.scss
@@ -362,7 +362,6 @@ div.dataTables_filter {
 }
 
 .showcases-panel {
-
   .row {
     display: inline-block;
     width: 100%;
@@ -370,9 +369,9 @@ div.dataTables_filter {
 
   .image {
     float: left;
-	  margin-right: 10px;
-		width: 40px;
 		height: 40px;
+    margin-right: 10px;
+    width: 40px;
   }
 
   .name {

--- a/app/assets/stylesheets/ui-customizations.css.scss
+++ b/app/assets/stylesheets/ui-customizations.css.scss
@@ -370,13 +370,9 @@ div.dataTables_filter {
 
   .image {
     float: left;
-    height: 3em;
-
-    img {
-      border: 1px solid Black;
-      margin: 5px;
-      width: 70px;
-    }
+	  margin-right: 10px;
+		width: 40px;
+		height: 40px;
   }
 
   .name {

--- a/app/assets/stylesheets/ui-customizations.css.scss
+++ b/app/assets/stylesheets/ui-customizations.css.scss
@@ -369,7 +369,7 @@ div.dataTables_filter {
 
   .image {
     float: left;
-		height: 40px;
+    height: 40px;
     margin-right: 10px;
     width: 40px;
   }


### PR DESCRIPTION
Why: If an item belongs to a showcase that does not have a background image, it will fail to render the showcase list in the edit page for that item
How: Changed to use material ui avatars. Will use an avatar image if the showcase has a background image, and an avatar with the first letter of the showcase if it does not.