### PR TITLE
Fix vips gifs

### DIFF
--- a/app/assets/javascripts/components/forms/ItemMetaDataForm.jsx
+++ b/app/assets/javascripts/components/forms/ItemMetaDataForm.jsx
@@ -1,3 +1,5 @@
+/*jshint esnext: true */
+
 //app/assets/javascripts/components/forms/ItemMetaDataForm.jsx
 var React = require('react');
 var mui = require("material-ui");
@@ -191,8 +193,8 @@ var ItemMetaDataForm = React.createClass({
     var map_function = function (data, field) {
       if (!this.state.displayedFields[field]) {
         var h = {};
-        h['payload'] = {field};
-        h['text'] = this.props.additionalFieldConfiguration[field].title;
+        h.payload = {field};
+        h.text = this.props.additionalFieldConfiguration[field].title;
         return (h);
       }
     };
@@ -200,8 +202,8 @@ var ItemMetaDataForm = React.createClass({
     var all_vals = _.map(this.props.additionalFieldConfiguration, map_function);
 
     var hDefault = {};
-    hDefault['payload'] = '';
-    hDefault['text'] = 'Add a New Field';
+    hDefault.payload = '';
+    hDefault.text = 'Add a New Field';
     return [hDefault].concat(_.reject(all_vals, function(val){ return _.isUndefined(val)}));
   },
 

--- a/app/services/preprocess_image.rb
+++ b/app/services/preprocess_image.rb
@@ -28,11 +28,15 @@ class PreprocessImage
   end
 
   def processing_needed?
-    uploaded_image.exists? && (tiff? || exceeds_max_pixels?)
+    uploaded_image.exists? && (tiff? || gif? || exceeds_max_pixels?)
   end
 
   def tiff?
     uploaded_image.content_type == "image/tiff"
+  end
+
+  def gif?
+    uploaded_image.content_type == "image/gif"
   end
 
   def exceeds_max_pixels?
@@ -61,6 +65,8 @@ class PreprocessImage
     style = "#{MAX_PIXELS}@"
     if tiff?
       style = [style, :jpg]
+    elsif gif?
+      style = [style, :png]
     end
     style
   end

--- a/spec/services/preprocess_image_spec.rb
+++ b/spec/services/preprocess_image_spec.rb
@@ -78,6 +78,11 @@ RSpec.describe PreprocessImage do
       expect(subject.send(:processing_needed?)).to eq(true)
     end
 
+    it "is true if the image is a gif" do
+      expect(subject).to receive(:gif?).and_return(true)
+      expect(subject.send(:processing_needed?)).to eq(true)
+    end
+
     it "is true if the image is exceeds the max pixels" do
       expect(subject).to receive(:exceeds_max_pixels?).and_return(true)
       expect(subject.send(:processing_needed?)).to eq(true)
@@ -93,6 +98,18 @@ RSpec.describe PreprocessImage do
     it "is false otherwise" do
       expect(uploaded_image).to receive(:content_type).and_return("image/jpeg")
       expect(subject.send(:tiff?)).to eq(false)
+    end
+  end
+
+  describe "#gif?" do
+    it "is true if the image is a tiff" do
+      expect(uploaded_image).to receive(:content_type).and_return("image/gif")
+      expect(subject.send(:gif?)).to eq(true)
+    end
+
+    it "is false otherwise" do
+      expect(uploaded_image).to receive(:content_type).and_return("image/jpeg")
+      expect(subject.send(:gif?)).to eq(false)
     end
   end
 
@@ -162,6 +179,11 @@ RSpec.describe PreprocessImage do
     it "converts tiffs to jpgs" do
       expect(subject).to receive(:tiff?).and_return(true)
       expect(subject.send(:processor_style)).to eq(["#{described_class::MAX_PIXELS}@", :jpg])
+    end
+
+    it "converts gifs to pngs" do
+      expect(subject).to receive(:gif?).and_return(true)
+      expect(subject.send(:processor_style)).to eq(["#{described_class::MAX_PIXELS}@", :png])      
     end
   end
 

--- a/spec/services/preprocess_image_spec.rb
+++ b/spec/services/preprocess_image_spec.rb
@@ -183,7 +183,7 @@ RSpec.describe PreprocessImage do
 
     it "converts gifs to pngs" do
       expect(subject).to receive(:gif?).and_return(true)
-      expect(subject.send(:processor_style)).to eq(["#{described_class::MAX_PIXELS}@", :png])      
+      expect(subject.send(:processor_style)).to eq(["#{described_class::MAX_PIXELS}@", :png])
     end
   end
 


### PR DESCRIPTION
gifs were not being processed by vips.  we are now converting them to pngs first. 