### PR TITLE
Section does not show the correct image

### DIFF
--- a/app/views/sections/_show.json.jbuilder
+++ b/app/views/sections/_show.json.jbuilder
@@ -1,7 +1,7 @@
 json.id section.id
 json.name section.name
 json.description section.description
-json.image section.image
+json.image section.item.image
 json.caption section.caption
 json.order section.order
 json.display_type SectionType.new(section).type


### PR DESCRIPTION
Why: If a section is created in a showcase using an image, then the user changes that image, the section is not updated in the honeycomb showcase editor.
How: Changed the section to use the associated items image instead of the section image, since section.image is only ever touched when the section is first created.