### PR TITLE
fix the status message on the collections listing page

### DIFF
--- a/app/decorators/published_text.rb
+++ b/app/decorators/published_text.rb
@@ -17,12 +17,5 @@ class PublishedText < Draper::Decorator
           h.t("published.unpublished")
       end
     end
-
-    h.content_tag("span", class: "text-success") do
-      h.content_tag("i", "", class: "glyphicon glyphicon-ok") + " " +
-        h.t("published.published")
-    end
   end
-
-  private
 end

--- a/app/views/collections/_list.html.erb
+++ b/app/views/collections/_list.html.erb
@@ -19,7 +19,7 @@
         </td>
         <td><span class="badge"><%= t('.items_badge', number: collection.items.size) %></span></td>
         <td>
-          <span class="text-success"><i class="glyphicon glyphicon-ok"></i> <%= t('.published') %></span>
+          <%= PublishedText.display(collection) %>          
         </td>
         <td>
            <%= ListTime.display(collection.updated_at) %>

--- a/spec/decorators/published_text_spec.rb
+++ b/spec/decorators/published_text_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe PublishedText do
 
     it "displays the unpublished text" do
       allow(object).to receive(:published).and_return(false)
-      # expect(subject.display).to eq("<span class=\"text-muted\"><i class=\"glyphicon glyphicon-ok\"></i> Not published</span>")
+      expect(subject.display).to eq("<span class=\"text-muted\"><i class=\"glyphicon glyphicon-ok\"></i> Not published</span>")
     end
   end
 


### PR DESCRIPTION
it was always showing published changed to reflect a collections actual status