### PR TITLE
Replace image refresh bug

### DIFF
--- a/app/assets/javascripts/components/ItemShowImageBox.jsx
+++ b/app/assets/javascripts/components/ItemShowImageBox.jsx
@@ -1,27 +1,109 @@
 var React = require('react');
+var mui = require('material-ui');
+var CircularProgress = mui.CircularProgress;
+var EventEmitter = require("../EventEmitter");
+
 var ItemShowImageBox = React.createClass({
+  mixins: [MuiThemeMixin],
+
   propTypes: {
     image: React.PropTypes.oneOfType([
       React.PropTypes.string,
       React.PropTypes.object,
     ]),
-    thumbnailSrc: React.PropTypes.string,
     itemID: React.PropTypes.string.isRequired,
+    item: React.PropTypes.object,         // Item object from ItemDecorator
+    itemPath: React.PropTypes.string,     // The path to the API to retrieve item's image details
+    maxRetries: React.PropTypes.number,   // Max number of times it should retry to get the image
+    retryInterval: React.PropTypes.number // How frequent it should retry to get the image, in ms
+  },
+
+  getDefaultProps: function() {
+    return {
+      maxRetries: 3,       // Defaulting to 3 retries, 5s apart, total wait of 15s
+      retryInterval: 5000
+    };
   },
 
   getInitialState: function() {
     return {
       image: null,
+      imageReady: false,
+      requestTimer: 0,
+      requestCount: 0,
+      image: this.props.image,
     };
   },
 
+  checkImageState: function(image) {
+    if(image["items"]["image_status"] == "image_ready") {
+      this.setState({
+        imageReady: true,
+        image: image["items"]["image"],
+      });
+      clearInterval(this.state.requestTimer);
+    } else if(image["items"]["image_status"] == "image_invalid") {
+      EventEmitter.emit("MessageCenterDisplay", "error", "There was a problem loading the media. Try replacing or contacting support.");
+      clearInterval(this.state.requestTimer);
+    }
+  },
+
+  pingItem: function() {
+    $.ajax({
+      url: this.props.itemPath,
+      dataType: "json",
+      method: "GET",
+      success: this.checkImageState,
+      error: (function(xhr) {
+        EventEmitter.emit("MessageCenterDisplay", "error", "There was a problem loading the media. Please contact support.");
+        console.log(xhr);
+      }),
+    });
+
+    this.setState({ requestCount: this.state.requestCount + 1 });
+    if(this.state.requestCount >= this.props.maxRetries) {
+      EventEmitter.emit("MessageCenterDisplay", "error", "Media is still being processed. Please try again later.");
+      clearInterval(this.state.requestTimer);
+    }
+  },
+
+  componentWillMount: function() {
+    if(this.props.item.image_status == "image_ready") {
+      this.setState({
+        imageReady: true,
+      });
+    } else if(this.props.item.image_status == "image_invalid") {
+      EventEmitter.emit("MessageCenterDisplay", "error", "There was a problem loading the media. Try replacing or contacting support.");
+    } else {
+      this.setState({
+        requestTimer: setInterval(this.pingItem, this.props.retryInterval),
+        imageReady: false,
+      });
+    }
+  },
+
+  componentWillUnmount: function() {
+    // just in case
+    if(this.state.requestTimer != 0) {
+      clearInterval(this.state.requestTimer);
+    }
+  },
+
   render: function() {
-    return (
-      <div className="hc-item-show-image-box">
-        <ItemImageZoomButton image={this.props.image} itemID={this.props.itemID} />
-        <Thumbnail image={this.props.image} thumbnailSrc={this.props.thumbnailSrc} />
-      </div>
-    );
+    if(this.state.imageReady) {
+      return (
+        <div className="hc-item-show-image-box">
+          <ItemImageZoomButton image={this.state.image} itemID={this.props.itemID} />
+          <Thumbnail image={this.state.image} />
+        </div>
+      );
+    } else {
+      return (
+        <div>
+          <CircularProgress mode="indeterminate" size={0.5} />
+        </div>
+      );
+    }
   }
 });
 module.exports = ItemShowImageBox;

--- a/app/decorators/item_decorator.rb
+++ b/app/decorators/item_decorator.rb
@@ -18,10 +18,12 @@ class ItemDecorator < Draper::Decorator
   end
 
   def status_text
-    if object.honeypot_image
+    if object.image_ready?
       status_text_span(className: "text-success", icon: "ok", text: h.t("status.complete"))
-    else
+    elsif object.image_processing?
       status_text_span(className: "text-info", icon: "minus", text: h.t("status.processing"))
+    else
+      status_text_span(className: "text-danger", icon: "minus", text: h.t("status.error"))
     end
   end
 
@@ -40,7 +42,11 @@ class ItemDecorator < Draper::Decorator
   end
 
   def show_image_box
-    h.react_component "ItemShowImageBox", image: image_json, thumbnailSrc: thumbnail_url, itemID: object.id.to_s
+    h.react_component "ItemShowImageBox",
+                      image: image_json,
+                      itemID: object.id.to_s,
+                      item: object,
+                      itemPath: Rails.application.routes.url_helpers.v1_item_path(object.unique_id)
   end
 
   def item_meta_data_form
@@ -87,7 +93,7 @@ class ItemDecorator < Draper::Decorator
   end
 
   def thumbnail_url
-    if object.image.exists?(:thumb)
+    if object.image_ready? && object.image.exists?(:thumb)
       object.image.url(:thumb)
     else
       return nil
@@ -101,7 +107,7 @@ class ItemDecorator < Draper::Decorator
   private
 
   def image_json
-    if object.honeypot_image
+    if object.image_ready? && object.honeypot_image
       object.honeypot_image.image_json
     else
       {}

--- a/app/decorators/v1/item_json_decorator.rb
+++ b/app/decorators/v1/item_json_decorator.rb
@@ -27,7 +27,7 @@ module V1
     end
 
     def image
-      if object.honeypot_image
+      if object.image_ready? && object.honeypot_image
         object.honeypot_image.json_response
       else
         nil

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -41,6 +41,8 @@ class Item < ActiveRecord::Base
   validates_attachment_content_type :image, content_type: /\Aimage\/.*\Z/
   validates_attachment_content_type :uploaded_image, content_type: /\Aimage\/.*\Z/
 
+  enum image_status: { image_invalid: 0, image_processing: 1, image_ready: 2 }
+
   private
 
   def manuscript_url_is_valid_uri

--- a/app/services/save_honeypot_image.rb
+++ b/app/services/save_honeypot_image.rb
@@ -30,6 +30,14 @@ class SaveHoneypotImage
     body = request.body.with_indifferent_access
     honeypot_image.json_response = body
 
+    # I realize this is ugly, but it's either this or add this image status to
+    # all other objects that use honeypot. This will all be resolved whenever we
+    # refactor/normalize the other models by pulling out all of the image data into
+    # an image or media entity, so this seems to introduce less tech debt than
+    # adding to all.
+    if object.respond_to?(:image_status)
+      object.image_status = "image_ready"
+    end
     honeypot_image.save && object.save
   end
 

--- a/app/services/save_item.rb
+++ b/app/services/save_item.rb
@@ -46,6 +46,7 @@ class SaveItem
 
   def process_uploaded_image
     if params[:uploaded_image]
+      item.image_processing!
       QueueJob.call(ProcessImageJob, object: item)
     else
       true

--- a/app/views/v1/items/_item.json.jbuilder
+++ b/app/views/v1/items/_item.json.jbuilder
@@ -6,6 +6,7 @@ json.id item_object.unique_id
 json.slug item_object.slug
 json.name item_object.name
 json.description item_object.description.to_s
+json.image_status item_object.object.image_status
 json.image item_object.image
 json.metadata item_object.metadata
 json.last_updated item_object.updated_at

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,6 +36,7 @@ en:
   status:
     complete: "OK"
     processing: "Processing"
+    error: "Error"
   buttons:
     save: 'Save'
     cancel: 'Cancel'

--- a/db/migrate/20150812192432_add_item_image_status.rb
+++ b/db/migrate/20150812192432_add_item_image_status.rb
@@ -1,0 +1,12 @@
+class AddItemImageStatus < ActiveRecord::Migration
+  def up
+    add_column :items, :image_status, :integer, default: 0
+    # Mark all items that have an associated honey pot image as having a status of image_ready
+    # all others will be left with the default of 0, image_invalid
+    execute "UPDATE items SET image_status = 2 where id in (select item_id from honeypot_images)"
+  end
+
+  def down
+    remove_column :items, :image_status
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -94,6 +94,7 @@ ActiveRecord::Schema.define(version: 20150813172206) do
     t.integer  "uploaded_image_file_size",    limit: 4
     t.datetime "uploaded_image_updated_at"
     t.text     "metadata",                    limit: 4294967295
+    t.integer  "image_status",                limit: 4,          default: 0
   end
 
   add_index "items", ["collection_id"], name: "index_items_on_collection_id", using: :btree

--- a/spec/decorators/item_decorator_spec.rb
+++ b/spec/decorators/item_decorator_spec.rb
@@ -114,7 +114,13 @@ RSpec.describe ItemDecorator do
     describe "#show_image_box" do
       it "renders a react component" do
         allow(item).to receive(:image).and_return(attachment)
-        expect(subject.show_image_box).to match("<div data-react-class=\"ItemShowImageBox\"")
+        allow(item).to receive(:image_ready?).and_return(true)
+        allow(item).to receive(:unique_id).and_return("unique_id")
+        expect_any_instance_of(Draper::HelperProxy).
+          to receive(:react_component).
+          with("ItemShowImageBox", image: honeypot_image.image_json, itemID: "#{item.id}", item: item, itemPath: "/v1/items/unique_id").
+          and_return(nil)
+        subject.show_image_box
       end
     end
   end
@@ -178,5 +184,34 @@ RSpec.describe ItemDecorator do
 
   it "returns the edit path" do
     expect(subject.edit_path).to eq("/items/1/edit")
+  end
+
+  context "status_text" do
+    it "renders the correct success span when the image is ready" do
+      allow(item).to receive(:image_status).and_return(2)
+      allow(item).to receive(:image_ready?).and_return(true)
+      allow(item).to receive(:image_processing?).and_return(false)
+      allow(item).to receive(:image_invalid?).and_return(false)
+      expect(subject).to receive(:status_text_span).with(className: "text-success", icon: "ok", text: "OK")
+      subject.status_text
+    end
+
+    it "renders the correct success span when the image is invalid" do
+      allow(item).to receive(:image_status).and_return(0)
+      allow(item).to receive(:image_ready?).and_return(false)
+      allow(item).to receive(:image_processing?).and_return(false)
+      allow(item).to receive(:image_invalid?).and_return(true)
+      expect(subject).to receive(:status_text_span).with(className: "text-danger", icon: "minus", text: "Error")
+      subject.status_text
+    end
+
+    it "renders the correct success span when the image is processing" do
+      allow(item).to receive(:image_status).and_return(1)
+      allow(item).to receive(:image_ready?).and_return(false)
+      allow(item).to receive(:image_processing?).and_return(true)
+      allow(item).to receive(:image_invalid?).and_return(false)
+      expect(subject).to receive(:status_text_span).with(className: "text-info", icon: "minus", text: "Processing")
+      subject.status_text
+    end
   end
 end

--- a/spec/decorators/v1/item_json_decorator_spec.rb
+++ b/spec/decorators/v1/item_json_decorator_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe V1::ItemJSONDecorator do
   end
 
   describe "#image" do
-    let(:item) { double(Item, honeypot_image: honeypot_image) }
+    let(:item) { double(Item, honeypot_image: honeypot_image, image_ready?: true) }
     let(:honeypot_image) { double(HoneypotImage, json_response: "json_response") }
 
     it "gets the honeypot_image json_response" do

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -23,10 +23,22 @@ RSpec.describe Item do
     :date_created,
     :date_modified,
     :date_published,
+    :image_status
   ].each do |field|
     it "has field, #{field}" do
       expect(subject).to respond_to(field)
       expect(subject).to respond_to("#{field}=")
+    end
+  end
+
+  [
+    :image_ready,
+    :image_invalid,
+    :image_processing
+  ].each do |field|
+    it "has enum, #{field}" do
+      expect(subject).to respond_to("#{field}!")
+      expect(subject).to respond_to("#{field}?")
     end
   end
 

--- a/spec/services/save_honeypot_image_spec.rb
+++ b/spec/services/save_honeypot_image_spec.rb
@@ -66,6 +66,17 @@ RSpec.describe SaveHoneypotImage do
         expect_any_instance_of(HoneypotImage).to receive(:save).and_return(false)
         expect(subject).to be(false)
       end
+
+      it "sets the image_status if the object has one" do
+        allow(item).to receive(:image_status)
+        expect(item).to receive(:image_status=).with("image_ready")
+        subject
+      end
+
+      it "does not set the image_status if the object does not have one" do
+        expect(item).not_to receive(:image_status=)
+        subject
+      end
     end
   end
 

--- a/spec/services/save_item_spec.rb
+++ b/spec/services/save_item_spec.rb
@@ -59,9 +59,18 @@ RSpec.describe SaveItem, type: :model do
   describe "image processing" do
     it "Queues image processing if the image was updated" do
       params[:uploaded_image] = upload_image
+      allow(item).to receive(:image_processing!).and_return(true)
       expect(item).to receive(:save).and_return(true)
       expect(QueueJob).to receive(:call).with(ProcessImageJob, object: item).and_return(true)
       expect(subject).to eq(item)
+    end
+
+    it "sets the image status to processing if the image was updated" do
+      params[:uploaded_image] = upload_image
+      expect(item).to receive(:image_processing!).and_return(true)
+      allow(item).to receive(:save).and_return(true)
+      allow(QueueJob).to receive(:call).with(ProcessImageJob, object: item).and_return(true)
+      subject
     end
 
     it "is not called if the image is not changed" do


### PR DESCRIPTION
Why: Image processing is now performed in the background. When replacing an image in the item edit form, it loads the page before processing is performed and cannot render the image.
How: Modified the ItemShowImageBox to show an indeterminate progress circle until the image is finished processing. To do this it will make 3 calls, 5 seconds apart until it fails or receives an image_ready as the image_status, at which point it will render the image as before. This required several changes, including creating an image_status field on item and changing the data that is sent from the v1 api and the chain of calls prior to this component, such as the ItemJsonDecorator.