### PR TITLE
Fix for null data from the user api

### DIFF
--- a/app/services/map_user_to_api.rb
+++ b/app/services/map_user_to_api.rb
@@ -20,14 +20,28 @@ class MapUserToApi
   private
 
   def map_attributes
-    user.first_name = fetch("first_name")
-    user.last_name = fetch("last_name")
-    user.email = email
-    user.display_name = fetch("full_name")
+    [:first_name, :last_name, :email, :display_name].each do |field|
+      value = send(field)
+      if value.present?
+        user.send("#{field}=", value)
+      end
+    end
   end
 
   def api_attributes
     @api_attributes ||= HesburghAPI::PersonSearch.find(user.username)
+  end
+
+  def first_name
+    fetch("first_name")
+  end
+
+  def last_name
+    fetch("last_name")
+  end
+
+  def display_name
+    fetch("full_name")
   end
 
   def email

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -18,6 +18,12 @@ RSpec.describe User do
     end
   end
 
+  it "is valid and saves with just a username" do
+    user = described_class.new(username: "testuser")
+    expect(user).to be_valid
+    expect(user.save).to eq(true)
+  end
+
   it "uses MapUserToApi when user saved" do
     expect(MapUserToApi).to receive(:call)
     User.new.save

--- a/spec/services/map_user_to_api_spec.rb
+++ b/spec/services/map_user_to_api_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe MapUserToApi do
   subject { MapUserToApi.call(user) }
   let(:user) { double(User, username: "username", "first_name=" => true, "last_name=" => true, "display_name=" => true, "email=" => true) }
-  let(:api_data) { { "first_name" => "first_name", "contact_information" => { "email" => "email" } } }
+  let(:api_data) { { "first_name" => "first_name", "last_name" => "last_name", "full_name" => "display_name", "contact_information" => { "email" => "email" } } }
 
   before(:each) do
     remove_user_api_stub
@@ -22,15 +22,42 @@ describe MapUserToApi do
     subject
   end
 
-  [:first_name, :last_name, :display_name].each do |field|
+  [:first_name, :last_name].each do |field|
     it "sets the #{field} from the api data " do
-      expect(user).to receive("#{field}=").with(api_data["#{field}"])
+      expect(user).to receive("#{field}=").with(api_data.fetch(field.to_s))
+      subject
+    end
+
+    it "does not set the value if the api data is null" do
+      api_data[field.to_s] = nil
+      expect(user).to_not receive("#{field}=")
       subject
     end
   end
 
-  it "sets the email" do
-    expect(user).to receive("email=").with(api_data["contact_information"]["email"])
-    subject
+  context "display_name" do
+    it "sets the value" do
+      expect(user).to receive("display_name=").with(api_data.fetch("full_name"))
+      subject
+    end
+
+    it "does not set the value if the api data is null" do
+      api_data["full_name"] = nil
+      expect(user).to_not receive("display_name=")
+      subject
+    end
+  end
+
+  context "email" do
+    it "sets the value" do
+      expect(user).to receive("email=").with(api_data["contact_information"]["email"])
+      subject
+    end
+
+    it "does not set the value if the api data is null" do
+      api_data["contact_information"]["email"] = nil
+      expect(user).to_not receive("email=")
+      subject
+    end
   end
 end

--- a/spec/services/map_user_to_api_spec.rb
+++ b/spec/services/map_user_to_api_spec.rb
@@ -3,7 +3,14 @@ require "rails_helper"
 describe MapUserToApi do
   subject { MapUserToApi.call(user) }
   let(:user) { double(User, username: "username", "first_name=" => true, "last_name=" => true, "display_name=" => true, "email=" => true) }
-  let(:api_data) { { "first_name" => "first_name", "last_name" => "last_name", "full_name" => "display_name", "contact_information" => { "email" => "email" } } }
+  let(:api_data) do
+    {
+      "first_name" => "first_name",
+      "last_name" => "last_name",
+      "full_name" => "display_name",
+      "contact_information" => { "email" => "email" }
+    }
+  end
 
   before(:each) do
     remove_user_api_stub


### PR DESCRIPTION
Andy ran into an issue where a null values coming from the API set the user email address to null, violating the not null constraint on the user table.

We may also need to remove the not null constraint from the user table? (Or do that instead of this PR)