### PR TITLE
Update the showcase listing page

### DIFF
--- a/app/views/showcases/_list.html.erb
+++ b/app/views/showcases/_list.html.erb
@@ -3,8 +3,6 @@
     <tr>
       <th><%= t('.title') %></th>
       <th></th>
-      <th><%= t('.url') %></th>
-      <th><%= t('.status') %></th>
       <th><%= t('.updated_at') %></th>
     </tr>
   </thead>
@@ -17,12 +15,6 @@
         <td>
           <h4 class="media-heading"><%= h link_to showcase.name_line_1, showcase_path(showcase) %></h4>
           <%= h showcase.description %>
-        </td>
-        <td>
-          <a href="<%= CreateBeehiveURL.call(showcase) %>" target="_blank">View</a>
-        </td>
-        <td>
-          <%= PublishedText.display(showcase) %>
         </td>
         <td>
            <%= ListTime.display(showcase.updated_at) %>


### PR DESCRIPTION
no need for a published field and the preview link breaks the model of how preview is working in other parts of the site.  