### PR TITLE
The Do not overlay site title over homepage image. was not saving 

### DIFF
--- a/app/controllers/exhibits_controller.rb
+++ b/app/controllers/exhibits_controller.rb
@@ -34,7 +34,7 @@ class ExhibitsController < ApplicationController
       :about,
       :copyright,
       :show_page_title,
-      :hide_title_on_home_page
+      :hide_title_on_home_page,
     ])
   end
 end

--- a/app/controllers/exhibits_controller.rb
+++ b/app/controllers/exhibits_controller.rb
@@ -33,7 +33,8 @@ class ExhibitsController < ApplicationController
       :short_description,
       :about,
       :copyright,
-      :show_page_title
+      :show_page_title,
+      :hide_title_on_home_page
     ])
   end
 end


### PR DESCRIPTION
because it was not in the allowed parameter list. 