### PR TITLE
Item form marked as dirty when it should be clean

### DIFF
--- a/app/assets/javascripts/components/forms/StringField.jsx
+++ b/app/assets/javascripts/components/forms/StringField.jsx
@@ -44,8 +44,23 @@ var StringField = React.createClass({
 
   render: function () {
     return (
-      <FormRow id={this.formId()} type="string" required={this.props.required} title={this.props.title} help={this.props.help} errorMsg={this.props.errorMsg} >
-        <input type="text" name={this.formName()} value={this.props.value} className={this.requiredClass()} id={this.formId()} onChange={this.handleChange} placeholder={this.props.placeholder} onBlur={this.handleChange} />
+      <FormRow
+        id={this.formId()}
+        type="string"
+        required={this.props.required}
+        title={this.props.title}
+        help={this.props.help}
+        errorMsg={this.props.errorMsg}
+      >
+        <input
+          type="text"
+          name={this.formName()}
+          value={this.props.value}
+          className={this.requiredClass()}
+          id={this.formId()}
+          onChange={this.handleChange}
+          placeholder={this.props.placeholder}
+        />
       </FormRow>
     );
   }


### PR DESCRIPTION
Fixed issue with form being marked as dirty whenever onblur was triggered on stringfields.

The only change other than adding newlines was removing `onBlur={this.handleChange}`