### PR TITLE
Fix display of the add items dialog

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -27,4 +27,4 @@
 //= require menu-bar
 //= require flash
 //= require jquery.cookie
-$ = jQuery = require('jquery');
+window.$ = window.jQuery = require('jquery');

--- a/app/assets/javascripts/components.js
+++ b/app/assets/javascripts/components.js
@@ -1,7 +1,6 @@
 //app/assets/javascripts/components.js
 //= require_self
 //= require react_ujs
-
 React = require("react");
 
 // mixins

--- a/app/assets/javascripts/components.js
+++ b/app/assets/javascripts/components.js
@@ -52,6 +52,7 @@ DateField = require("./components/forms/DateField");
 HtmlField = require("./components/forms/HtmlField");
 MultipleField = require("./components/forms/MultipleField");
 MultipleFieldDisplayValue = require("./components/forms/MultipleFieldDisplayValue");
+DropzoneForm = require("./components/forms/DropzoneForm");
 
 // panel
 Panel = require("./components/panel/Panel");

--- a/app/assets/javascripts/components/CollectionPreviewModeToggle.jsx
+++ b/app/assets/javascripts/components/CollectionPreviewModeToggle.jsx
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 var React = require("react");
 var mui = require("material-ui");
 var Toggle = mui.Toggle;

--- a/app/assets/javascripts/components/CollectionPreviewPublishLink.jsx
+++ b/app/assets/javascripts/components/CollectionPreviewPublishLink.jsx
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 var React = require("react");
 var CollectionStore = require('stores/Collection');
 

--- a/app/assets/javascripts/components/DragContent.jsx
+++ b/app/assets/javascripts/components/DragContent.jsx
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 var React = require('react');
 
 var DragContent = React.createClass({

--- a/app/assets/javascripts/components/HoneypotImage.jsx
+++ b/app/assets/javascripts/components/HoneypotImage.jsx
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 var React = require('react');
 var HoneypotImage = React.createClass({
   mixins: [HoneypotImageMixin],

--- a/app/assets/javascripts/components/ImageCaptionEditor.jsx
+++ b/app/assets/javascripts/components/ImageCaptionEditor.jsx
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 var React = require('react');
 var ImageCaptionEditor = React.createClass({
   getInitialState: function() {

--- a/app/assets/javascripts/components/ItemShowImageBox.jsx
+++ b/app/assets/javascripts/components/ItemShowImageBox.jsx
@@ -27,7 +27,6 @@ var ItemShowImageBox = React.createClass({
 
   getInitialState: function() {
     return {
-      image: null,
       imageReady: false,
       requestTimer: 0,
       requestCount: 0,

--- a/app/assets/javascripts/components/LoadingImage.jsx
+++ b/app/assets/javascripts/components/LoadingImage.jsx
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 var React = require('react');
 var LoadingImage = React.createClass({
 

--- a/app/assets/javascripts/components/ReactDropzone.jsx
+++ b/app/assets/javascripts/components/ReactDropzone.jsx
@@ -172,6 +172,8 @@ var ReactDropzone = React.createClass({
           />
         <Dialog
           ref="addItems"
+          autoDetectWindowHeight={true}
+          autoScrollBodyContent={true}
           title={this.props.modalTitle}
           actions={this.okDismiss()}
           openImmediately={false}

--- a/app/assets/javascripts/components/ReactDropzone.jsx
+++ b/app/assets/javascripts/components/ReactDropzone.jsx
@@ -1,5 +1,3 @@
-var Dropzone = require("../dropzone");
-Dropzone.autoDiscover = false;
 var React = require('react');
 var mui = require("material-ui");
 var Dialog = mui.Dialog;
@@ -35,34 +33,10 @@ var ReactDropzone = React.createClass({
     };
   },
 
-  componentDidMount: function() {
-    if (!this.dropzone) {
-      this.dropzone = new Dropzone(this.refs.uploadForm.getDOMNode(), this.options());
-      this.dropzone.on('addedfile', this.checkfileCallback);
-      this.dropzone.on('removedfile', this.checkfileCallback);
-    }
-  },
-
-  componentWillUnmount: function() {
-    this.dropzone.destroy();
-    this.dropzone = null;
-  },
-
-  options: function() {
-    return {
-      paramName: "item[uploaded_image]",
-      acceptedFiles: "image/*",
-      addRemoveLinks: true,
-      autoProcessQueue: true,
-      url: this.props.formUrl,
-      previewsContainer: "#dz-preview-" + this.props.modalId,
-      clickable: "#dz-" + this.props.modalId,
-      parallelUploads: 100,
-      maxFiles: (this.props.multifileUpload ? 100 : 1),
-      dictRemoveFile: "Cancel Upload",
-      someprop: "prop",
-      complete: this.completeCallback,
-    };
+  dropzoneInitialized: function(dropzone) {
+    this.dropzone = dropzone;
+    this.dropzone.on('addedfile', this.checkfileCallback);
+    this.dropzone.on('removedfile', this.checkfileCallback);
   },
 
   closeCallback: function() {
@@ -83,6 +57,7 @@ var ReactDropzone = React.createClass({
   },
 
   checkfileCallback: function () {
+    console.log('checkfileCallback');
     var hasFiles = (this.dropzone.files.length > 0);
     this.setState( { hasFiles: hasFiles } );
   },
@@ -114,20 +89,16 @@ var ReactDropzone = React.createClass({
   dropzoneForm: function() {
     if (!this.state.closed) {
       return (
-        <form method="post" className={this.classes()} ref={"uploadForm"} id={"dz-" + this.props.modalId}>
-          <div>
-            <input name="utf8" type="hidden" value="✓" />
-            <input name="authenticity_token" type="hidden" value={this.props.authenticityToken} />
-            { this.formMethod() }
-          </div>
-          <div className="dz-clickable" onDrop={this.droppedCallback} >
-            <div className="dropzone-previews" id={"dz-preview-" + this.props.modalId}></div>
-            <div className="dz-message">
-              <h4>Drag images here</h4>
-              <p>or <br /> <a className="btn btn-raised">Select images from your computer.</a></p>
-            </div>
-          </div>
-        </form>
+        <DropzoneForm
+          authenticityToken={this.props.authenticityToken}
+          baseID={this.props.modalId}
+          completeCallback={this.completeCallback}
+          formUrl={this.props.formUrl}
+          initializeCallback={this.dropzoneInitialized}
+          method={this.formMethod()}
+          multifileUpload={this.props.multifileUpload}
+          paramName="item[uploaded_image]"
+        />
       );
     } else {
       return null;
@@ -136,9 +107,9 @@ var ReactDropzone = React.createClass({
 
   formMethod: function() {
     if (!this.props.multifileUpload) {
-      return (<input name="_method" type="hidden" value="put" />);
+      return "put"
     } else {
-      return null;
+      return "post";
     }
   },
 

--- a/app/assets/javascripts/components/ReactDropzone.jsx
+++ b/app/assets/javascripts/components/ReactDropzone.jsx
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 var Dropzone = require("../dropzone");
 Dropzone.autoDiscover = false;
 var React = require('react');

--- a/app/assets/javascripts/components/ShowcasesPanel.jsx
+++ b/app/assets/javascripts/components/ShowcasesPanel.jsx
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 var React = require('react');
 var mui = require("material-ui");
 var Avatar = mui.Avatar;

--- a/app/assets/javascripts/components/embed/EmbedCode.jsx
+++ b/app/assets/javascripts/components/embed/EmbedCode.jsx
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 var React = require('react');
 var EmbedCode = React.createClass({
   propTypes: {

--- a/app/assets/javascripts/components/forms/DropzoneForm.jsx
+++ b/app/assets/javascripts/components/forms/DropzoneForm.jsx
@@ -1,0 +1,95 @@
+var Dropzone = require("../../dropzone");
+Dropzone.autoDiscover = false;
+
+var DropzoneForm = React.createClass({
+  propTypes: {
+    authenticityToken: React.PropTypes.string.isRequired,
+    baseID: React.PropTypes.string.isRequired,
+    completeCallback: React.PropTypes.func,
+    formUrl: React.PropTypes.string.isRequired,
+    initializeCallback: React.PropTypes.func,
+    method: React.PropTypes.string.isRequired,
+    multifileUpload: React.PropTypes.bool,
+    paramName: React.PropTypes.string.isRequired,
+  },
+
+  componentDidMount: function() {
+    this.setupDropzone();
+  },
+
+  setupDropzone: function() {
+    if (!this.dropzone) {
+      this.dropzone = new Dropzone(React.findDOMNode(this), this.options());
+      if (this.props.initializeCallback) {
+        this.props.initializeCallback(this.dropzone);
+      }
+    }
+  },
+
+  options: function() {
+    return {
+      paramName: "item[uploaded_image]",
+      acceptedFiles: "image/*",
+      addRemoveLinks: true,
+      autoProcessQueue: true,
+      url: this.props.formUrl,
+      previewsContainer: "#dz-preview-" + this.props.baseID,
+      clickable: "#dz-" + this.props.baseID,
+      parallelUploads: 100,
+      maxFiles: (this.props.multifileUpload ? 100 : 1),
+      dictRemoveFile: "Cancel Upload",
+      someprop: "prop",
+      complete: this.completeCallback,
+    };
+  },
+
+  completeCallback: function() {
+    if (this.props.completeCallback) {
+      this.props.completeCallback();
+    }
+  },
+
+  componentWillUnmount: function() {
+    if (this.dropzone) {
+      this.dropzone.destroy();
+      this.dropzone = null;
+    }
+  },
+
+  classes: function () {
+    var classes = "dropzone";
+    if (this.dropzone && this.dropzone.files.length > 0) {
+      classes += " dz-started";
+    }
+    return classes;
+  },
+
+  formMethod: function() {
+    if (this.props.method == "put") {
+      return (<input name="_method" type="hidden" value="put" />);
+    } else {
+      return null;
+    }
+  },
+
+  render: function() {
+    return (
+      <form method="post" className={this.classes()} id={"dz-" + this.props.baseID}>
+        <div>
+          <input name="utf8" type="hidden" value="✓" />
+          <input name="authenticity_token" type="hidden" value={this.props.authenticityToken} />
+          { this.formMethod() }
+        </div>
+        <div className="dz-clickable">
+          <div className="dropzone-previews" id={"dz-preview-" + this.props.baseID}></div>
+          <div className="dz-message">
+            <h4>Drag images here</h4>
+            <p>or <br /> <a className="btn btn-raised">Select images from your computer.</a></p>
+          </div>
+        </div>
+      </form>
+    );
+  },
+})
+
+module.exports = DropzoneForm;

--- a/app/assets/javascripts/components/forms/FormRow.jsx
+++ b/app/assets/javascripts/components/forms/FormRow.jsx
@@ -23,7 +23,7 @@ var FormRow = React.createClass({
   },
 
   requiredClass: function() {
-    css = this.props.type + ' control-label'
+    var css = this.props.type + ' control-label'
     if (this.props.required) {
       css += ' required';
     }
@@ -32,7 +32,7 @@ var FormRow = React.createClass({
   },
 
   rowClass: function () {
-    css = "form-group " + this.props.type + ' control-label'
+    var css = "form-group " + this.props.type + ' control-label'
     if (this.props.required) {
       css += ' required';
     }

--- a/app/assets/javascripts/components/panel/Panel.jsx
+++ b/app/assets/javascripts/components/panel/Panel.jsx
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 var React = require('react');
 var Panel = React.createClass({
   propTypes: {

--- a/app/assets/javascripts/components/panel/PanelBody.jsx
+++ b/app/assets/javascripts/components/panel/PanelBody.jsx
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 var React = require('react');
 var PanelBody = React.createClass({
   propTypes: {

--- a/app/assets/javascripts/components/panel/PanelFooter.jsx
+++ b/app/assets/javascripts/components/panel/PanelFooter.jsx
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 var React = require('react');
 var PanelFooter = React.createClass({
   propTypes: {

--- a/app/assets/javascripts/components/panel/PanelHeading.jsx
+++ b/app/assets/javascripts/components/panel/PanelHeading.jsx
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 var React = require('react');
 var PanelHeading = React.createClass({
   propTypes: {

--- a/app/assets/javascripts/components/people_search/PeopleSearch.jsx
+++ b/app/assets/javascripts/components/people_search/PeopleSearch.jsx
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 var React = require('react');
 var PeopleSearch = React.createClass({
     getInitialState: function() {

--- a/app/assets/javascripts/components/publish/CollectionPublishToggle.jsx
+++ b/app/assets/javascripts/components/publish/CollectionPublishToggle.jsx
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 var React = require("react");
 var mui = require("material-ui");
 var Toggle = mui.Toggle;

--- a/app/assets/javascripts/components/publish/ItemPublishEmbedPanel.jsx
+++ b/app/assets/javascripts/components/publish/ItemPublishEmbedPanel.jsx
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 var React = require('react');
 var ItemPublishEmbedPanel = React.createClass({
   propTypes: {

--- a/app/assets/javascripts/components/publish/PublishToggle.jsx
+++ b/app/assets/javascripts/components/publish/PublishToggle.jsx
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 var React = require('react');
 var mui = require("material-ui");
 var Toggle = mui.Toggle;

--- a/app/assets/javascripts/components/publish/ShowcasePublishAction.jsx
+++ b/app/assets/javascripts/components/publish/ShowcasePublishAction.jsx
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 var React = require('react');
 var ShowcasePublishAction = React.createClass({
   propTypes: {

--- a/app/assets/javascripts/components/showcase_editor/AddItemsBar.jsx
+++ b/app/assets/javascripts/components/showcase_editor/AddItemsBar.jsx
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 var React = require('react');
 var AddItemsBar;
 

--- a/app/assets/javascripts/components/showcase_editor/EditLink.jsx
+++ b/app/assets/javascripts/components/showcase_editor/EditLink.jsx
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 var React = require('react');
 var EditLink = React.createClass({
 

--- a/app/assets/javascripts/components/showcase_editor/Item.jsx
+++ b/app/assets/javascripts/components/showcase_editor/Item.jsx
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 var React = require('react');
 var Item = React.createClass({
   mixins: [DraggableMixin],

--- a/app/assets/javascripts/components/showcase_editor/ItemList.jsx
+++ b/app/assets/javascripts/components/showcase_editor/ItemList.jsx
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 var React = require('react');
 var ItemList = React.createClass({
   style: function() {

--- a/app/assets/javascripts/components/showcase_editor/NewSectionDropzone.jsx
+++ b/app/assets/javascripts/components/showcase_editor/NewSectionDropzone.jsx
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 var React = require('react');
 var NewSectionDropzone = React.createClass({
   getInitialState: function() {

--- a/app/assets/javascripts/components/showcase_editor/Section.jsx
+++ b/app/assets/javascripts/components/showcase_editor/Section.jsx
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 var React = require('react');
 var Section = React.createClass({
   mixins: [DraggableMixin],

--- a/app/assets/javascripts/components/showcase_editor/SectionDescription.jsx
+++ b/app/assets/javascripts/components/showcase_editor/SectionDescription.jsx
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 var React = require('react');
 //= require showdown
 var converter = new Showdown.converter()

--- a/app/assets/javascripts/components/showcase_editor/SectionDragContent.jsx
+++ b/app/assets/javascripts/components/showcase_editor/SectionDragContent.jsx
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 var React = require('react');
 var SectionDragContent = React.createClass({
   propTypes: {

--- a/app/assets/javascripts/components/showcase_editor/SectionImage.jsx
+++ b/app/assets/javascripts/components/showcase_editor/SectionImage.jsx
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 var React = require('react');
 var SectionImage = React.createClass({
   propTypes: {

--- a/app/assets/javascripts/components/showcase_editor/SectionList.jsx
+++ b/app/assets/javascripts/components/showcase_editor/SectionList.jsx
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 var React = require('react');
 var SectionList = React.createClass({
   propTypes: {

--- a/app/assets/javascripts/components/showcase_editor/ShowcaseEditor.jsx
+++ b/app/assets/javascripts/components/showcase_editor/ShowcaseEditor.jsx
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 var React = require('react');
 var ShowcaseEditor = React.createClass({
   mixins: [HorizontalScrollMixin],

--- a/app/assets/javascripts/components/showcase_editor/ShowcaseEditorTitle.jsx
+++ b/app/assets/javascripts/components/showcase_editor/ShowcaseEditorTitle.jsx
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 var React = require('react');
 var ShowcaseEditorTitle = React.createClass({
   propTypes: {

--- a/app/assets/javascripts/components/store_initializers/collection.jsx
+++ b/app/assets/javascripts/components/store_initializers/collection.jsx
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 var React = require("react");
 var CollectionActions = require('../../actions/Collection');
 

--- a/app/assets/javascripts/components/user_panel/UserList.jsx
+++ b/app/assets/javascripts/components/user_panel/UserList.jsx
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 var React = require('react');
 var UserList = React.createClass({
   render: function() {

--- a/app/assets/javascripts/components/user_panel/UserListRow.jsx
+++ b/app/assets/javascripts/components/user_panel/UserListRow.jsx
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 var React = require('react');
 var UserListRow = React.createClass({
   render: function() {

--- a/app/assets/javascripts/components/user_panel/UserPanel.jsx
+++ b/app/assets/javascripts/components/user_panel/UserPanel.jsx
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 var React = require('react');
 var UserPanel = React.createClass({
   propTypes: {

--- a/app/assets/javascripts/dropzone.js
+++ b/app/assets/javascripts/dropzone.js
@@ -127,7 +127,6 @@
       thumbnailHeight: 120,
       filesizeBase: 1000,
       maxFiles: null,
-      filesizeBase: 1000,
       params: {},
       clickable: true,
       ignoreHiddenFiles: true,

--- a/app/assets/javascripts/mixins/DraggableMixin.jsx
+++ b/app/assets/javascripts/mixins/DraggableMixin.jsx
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 var LEFT_BUTTON = 0;
 var DRAG_THRESHOLD = 3;
 

--- a/app/assets/javascripts/mixins/HoneypotImageMixin.jsx
+++ b/app/assets/javascripts/mixins/HoneypotImageMixin.jsx
@@ -1,5 +1,3 @@
-/** @jsx React.DOM */
-
 var HoneypotImageMixin = {
   propTypes: {
     honeypot_image: React.PropTypes.object.isRequired,

--- a/app/assets/javascripts/mixins/HorizontalScrollMixin.jsx
+++ b/app/assets/javascripts/mixins/HorizontalScrollMixin.jsx
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 
 var HorizontalScrollMixin = {
   setElement: function(element) {

--- a/app/assets/javascripts/themes/HoneycombTheme.jsx
+++ b/app/assets/javascripts/themes/HoneycombTheme.jsx
@@ -1,8 +1,8 @@
 "use strict"
 
-var Colors = require("material-ui/src/styles/colors");
-var Spacing = require("material-ui/src/styles/spacing");
-var ColorManipulator = require("material-ui/src/utils/color-manipulator");
+var Colors = require("material-ui/lib/styles/colors");
+var Spacing = require("material-ui/lib/styles/spacing");
+var ColorManipulator = require("material-ui/lib/utils/color-manipulator");
 
 
 var HoneycombTheme = {

--- a/app/assets/stylesheets/ui-customizations.css.scss
+++ b/app/assets/stylesheets/ui-customizations.css.scss
@@ -33,7 +33,6 @@ filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#d9a500', end
 
 .navbar-collapse {
 	position: relative;
-	z-index: 0;
 }
 
 .navbar-nav {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,8 +22,8 @@
   </head>
   <body>
 
-<header id="banner" role="banner" class="home" style="z-index:1;">
-  <nav class="navbar navbar-default navbar-static-top" role="navigation">
+<header id="banner" role="banner" class="home">
+  <nav class="navbar navbar-default" role="navigation">
     <div class="brand-bar">
       <div class="container-fluid">
         <div class="row">
@@ -42,7 +42,7 @@
 </header>
 
 
-<div class="container-fluid content" style="z-index: 100;">
+<div class="container-fluid content">
   <div class="row row-fluid">
     <% if content_for?(:left_nav) %>
       <div class="col-md-2 col-sm-2" id="col1">

--- a/package.json
+++ b/package.json
@@ -3,14 +3,17 @@
   "description": "Dependencies for the Honeycomb application",
   "repository": "git@github.com:ndlib/honeycomb.git",
   "dependencies": {
+    "babel": "^5.8.23",
+    "babelify": "^6.3.0",
     "browserify": "^6.3.4",
     "browserify-incremental": "^1.5.0",
     "classnames": "^2.1.2",
+    "es6ify": "^1.6.0",
     "eventemitter": "^0.3.3",
     "flux": "^2.0.3",
     "jquery": "^2.1.4",
     "keymirror": "^0.1.1",
-    "material-ui": "^0.11.0",
+    "material-ui": "^0.9.2",
     "object-assign": "^3.0.0",
     "react": "^0.13.3",
     "react-scroll": "^0.18.0",
@@ -47,6 +50,13 @@
     ],
     "testPathIgnorePatterns": [
       "preprocessor.js"
+    ]
+  },
+  "browserify": {
+    "transform": [
+      "reactify",
+      "babelify",
+      "es6ify"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,12 +3,9 @@
   "description": "Dependencies for the Honeycomb application",
   "repository": "git@github.com:ndlib/honeycomb.git",
   "dependencies": {
-    "babel": "^5.8.23",
-    "babelify": "^6.3.0",
     "browserify": "^6.3.4",
     "browserify-incremental": "^1.5.0",
     "classnames": "^2.1.2",
-    "es6ify": "^1.6.0",
     "eventemitter": "^0.3.3",
     "flux": "^2.0.3",
     "jquery": "^2.1.4",
@@ -50,11 +47,6 @@
     ],
     "testPathIgnorePatterns": [
       "preprocessor.js"
-    ]
-  },
-  "browserify": {
-    "transform": [
-      "babelify"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "flux": "^2.0.3",
     "jquery": "^2.1.4",
     "keymirror": "^0.1.1",
-    "material-ui": "^0.9.2",
+    "material-ui": "^0.11.0",
     "object-assign": "^3.0.0",
     "react": "^0.13.3",
     "react-scroll": "^0.18.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "flux": "^2.0.3",
     "jquery": "^2.1.4",
     "keymirror": "^0.1.1",
-    "material-ui": "^0.9.2",
+    "material-ui": "^0.11.0",
     "object-assign": "^3.0.0",
     "react": "^0.13.3",
     "react-scroll": "^0.18.0",
@@ -54,9 +54,7 @@
   },
   "browserify": {
     "transform": [
-      "reactify",
-      "babelify",
-      "es6ify"
+      "babelify"
     ]
   }
 }


### PR DESCRIPTION
There were a couple problems with the add items dialog.

1) The nav header was appearing on top of the dialog overlay.  This was fixed by a z-index tweak.
2) The dialog did not resize to fit the window size, and if too much content was present inside the dialog, it would overflow below the bottom of the window.

The second issue led me down a long and sordid path involving an update to material-ui.  The update fixed the sizing issue, but I also had to add a new form component because nested refs stopped working at some point. (The ReactDropzone component could no longer access `this.refs.uploadForm`).