### PR TITLE
Dropzone modal

### DIFF
--- a/app/assets/javascripts/components/ReactDropzone.jsx
+++ b/app/assets/javascripts/components/ReactDropzone.jsx
@@ -144,6 +144,7 @@ var ReactDropzone = React.createClass({
           ref="addItems"
           autoDetectWindowHeight={true}
           autoScrollBodyContent={true}
+          modal={true}
           title={this.props.modalTitle}
           actions={this.okDismiss()}
           openImmediately={false}


### PR DESCRIPTION
Turn the add items dialog into a modal so it can't be closed accidentally by clicking on the overlay