### PR TITLE
Travis CI notifications in Hipchat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,11 @@ rvm:
 before_install:
   - npm install
 script:
-  - RAILS_ENV=test bundle exec rake --trace db:migrate test
   - bundle exec rspec spec
 before_script:
   - cp config/secrets.example.yml config/secrets.yml  
   - mysql -e 'create database honeycomb_test'
+  - RAILS_ENV=test bundle exec rake --trace db:migrate test
 cache:
   bundler: true
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,10 @@ cache:
   bundler: true
   directories:
   - node_modules
+notifications:
+  hipchat:
+    on_success: change
+    on_failure: change
+    notify: true
+    rooms:
+      secure: JyXM6Tb27tNx38Pd4BH7ClCRuAYrajmYBWAbFDGRDWSSvpFJyouPIrs90fEgQd3FVnr7QV1Y1qdJsInPAK7NokACXOjk7sEb7ibXyZzy+q4rsGffVK6lL+5eYBEw2JL1ZZwa5O3l5TkDDnyexou3GVbhTAbRS84JmlmunbbZhVs=

--- a/spec/support/solr_spec_helper.rb
+++ b/spec/support/solr_spec_helper.rb
@@ -15,7 +15,7 @@ module SolrSpecHelper
       # shut down the Solr server
       at_exit { Process.kill("TERM", pid) }
       # wait for solr to start
-      20.times do
+      50.times do
         if solr_running?
           break
         end


### PR DESCRIPTION
## Travis CI
This adds travis notifications in our Hipchat room.  It will only notify when the build status changes.
I also moved the database migrate from `scripts` to `before_script`.  The reason for this is because travis will collapse the output from anything run in `before_script`.  Anything run in `scripts` won't be collapsed, and the migrate task is very verbose, leading to builds that are hard to read.

## Spec fix
I also increased the time given for allowing Solr to start, since the original 10 seconds sometimes was not enough time for Travis to start Solr.