### PR TITLE
DEC-433: Records created without a unique_id

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -5,7 +5,7 @@ class Collection < ActiveRecord::Base
   has_many :users, through: :collection_users
   has_many :showcases, through: :exhibit
 
-  validates :name_line_1, presence: true
+  validates :name_line_1, :unique_id, presence: true
 
   has_paper_trail
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -34,7 +34,7 @@ class Item < ActiveRecord::Base
   has_attached_file :uploaded_image,
                     restricted_characters: /[&$+,\/:;=?@<>\[\]{}\|\\^~%#]/
 
-  validates :name, :collection, presence: true
+  validates :name, :collection, :unique_id, presence: true
   validates :date_created, :date_modified, :date_published, date: true
   validate :manuscript_url_is_valid_uri
 

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -3,7 +3,7 @@ class Section < ActiveRecord::Base
   belongs_to :item
   has_one :collection, through: :showcase
 
-  validates :showcase, presence: true
+  validates :showcase, :unique_id, presence: true
 
   has_paper_trail
 

--- a/app/models/showcase.rb
+++ b/app/models/showcase.rb
@@ -13,7 +13,7 @@ class Showcase < ActiveRecord::Base
   validates_attachment_content_type :image, content_type: /\Aimage\/.*\Z/
   validates_attachment_content_type :uploaded_image, content_type: /\Aimage\/.*\Z/
 
-  validates :name_line_1, :exhibit, presence: true
+  validates :name_line_1, :exhibit, :unique_id, presence: true
 
   has_paper_trail
 

--- a/app/services/create_unique_id.rb
+++ b/app/services/create_unique_id.rb
@@ -4,7 +4,7 @@ class CreateUniqueId
   attr_reader :object
 
   def self.call(object)
-    new(object).create!
+    new(object).create
   end
 
   def initialize(object)
@@ -12,13 +12,12 @@ class CreateUniqueId
     validate_interface!
   end
 
-  def create!
+  def create
     if object.unique_id.nil?
       object.unique_id = unique_id
-      return object.save
+    else
+      object.unique_id
     end
-
-    true
   end
 
   private

--- a/app/services/save_collection.rb
+++ b/app/services/save_collection.rb
@@ -12,9 +12,9 @@ class SaveCollection
 
   def save
     collection.attributes = params
+    check_unique_id
 
     if collection.save
-      check_unique_id
       EnsureCollectionHasExhibit.call(collection)
       true
     else

--- a/app/services/save_item.rb
+++ b/app/services/save_item.rb
@@ -15,10 +15,9 @@ class SaveItem
 
     item.attributes = params
     pre_process_name
+    check_unique_id
 
     if item.save && process_uploaded_image
-      check_unique_id
-
       item
     else
       false

--- a/app/services/save_section.rb
+++ b/app/services/save_section.rb
@@ -14,8 +14,8 @@ class SaveSection
     section.attributes = params
 
     current_order
+    check_unique_id
     if section.save && fix_order!
-      check_unique_id
       section
     else
       false

--- a/app/services/save_showcase.rb
+++ b/app/services/save_showcase.rb
@@ -14,9 +14,9 @@ class SaveShowcase
     fix_image_param!
 
     showcase.attributes = params
+    check_unique_id
 
-    if showcase.save && process_uploaded_image
-      check_unique_id
+    if showcase.save && process_uploaded_image  
       true
     else
       false

--- a/app/services/save_showcase.rb
+++ b/app/services/save_showcase.rb
@@ -16,7 +16,7 @@ class SaveShowcase
     showcase.attributes = params
     check_unique_id
 
-    if showcase.save && process_uploaded_image  
+    if showcase.save && process_uploaded_image
       true
     else
       false

--- a/spec/factories/collection.rb
+++ b/spec/factories/collection.rb
@@ -2,5 +2,6 @@ FactoryGirl.define do
   factory :collection do |s|
     s.id { 1 }
     s.name_line_1 { "Collection One" }
+    s.unique_id { "one" }
   end
 end

--- a/spec/factories/item.rb
+++ b/spec/factories/item.rb
@@ -4,7 +4,7 @@ FactoryGirl.define do
     i.name { "one" }
     i.collection_id { 1 }
     i.user_defined_id { "one" }
-    i.unique_id { "one"}
+    i.unique_id { "one" }
     image_file_name "one.jpg"
     image_content_type "image/jpeg"
     image_file_size 1.megabyte

--- a/spec/factories/item.rb
+++ b/spec/factories/item.rb
@@ -4,6 +4,7 @@ FactoryGirl.define do
     i.name { "one" }
     i.collection_id { 1 }
     i.user_defined_id { "one" }
+    i.unique_id { "one"}
     image_file_name "one.jpg"
     image_content_type "image/jpeg"
     image_file_size 1.megabyte

--- a/spec/factories/section.rb
+++ b/spec/factories/section.rb
@@ -2,6 +2,7 @@ FactoryGirl.define do
   factory :section do |s|
     s.id { 1 }
     s.showcase_id { 1 }
+    s.unique_id { "one" }
 
     factory :section_with_showcase do
       after(:build, :create) do |ss|

--- a/spec/factories/showcase.rb
+++ b/spec/factories/showcase.rb
@@ -3,6 +3,7 @@ FactoryGirl.define do
     id { 1 }
     exhibit_id { 1 }
     name_line_1 { "Showcase One" }
+    unique_id { "one" }
     image_file_name "one.jpg"
     image_content_type "image/jpeg"
     image_file_size 1.megabyte

--- a/spec/services/create_unique_id_spec.rb
+++ b/spec/services/create_unique_id_spec.rb
@@ -6,26 +6,21 @@ describe CreateUniqueId do
 
   it "generates a id" do
     expect(object).to receive(:unique_id=).with("6187bbca38")
-    subject.create!
+    subject.create
   end
 
   it "uses the md5 lib to generate the id " do
     expect(Digest::MD5).to receive(:hexdigest).with("#{object.id}-#{object.class}").and_return("adfadfafsdadsdasdafs")
-    subject.create!
+    subject.create
   end
 
   it "sets a unique_id when it is saved and one does not exist" do
     expect(object).to receive(:unique_id=)
-    subject.create!
+    subject.create
   end
 
-  it "returns true on save succes" do
-    expect(subject.create!).to eq(true)
-  end
-
-  it "returns false on save failure" do
-    allow(object).to receive(:save).and_return(false)
-    expect(subject.create!).to eq(false)
+  it "returns the generated id" do
+    expect(subject.create).to eq("6187bbca38")
   end
 
   describe "existing unique_id" do
@@ -35,11 +30,11 @@ describe CreateUniqueId do
 
     it "does not set unique_id when it is saved and one exists" do
       expect(object).to_not receive(:unique_id=)
-      subject.create!
+      subject.create
     end
 
-    it "returns true" do
-      expect(subject.create!).to eq(true)
+    it "returns the existing id" do
+      expect(subject.create).to eq("1231232")
     end
   end
 
@@ -51,7 +46,7 @@ describe CreateUniqueId do
 
   describe "#call" do
     it "calls publish!" do
-      expect_any_instance_of(described_class).to receive(:create!)
+      expect_any_instance_of(described_class).to receive(:create)
       described_class.call(object)
     end
   end

--- a/spec/services/save_collection_spec.rb
+++ b/spec/services/save_collection_spec.rb
@@ -30,12 +30,6 @@ RSpec.describe SaveCollection, type: :model do
       expect(CreateUniqueId).to receive(:call).with(collection)
       subject
     end
-
-    it "does not call create unique_id if the collection does not save" do
-      allow(collection).to receive(:save).and_return(false)
-      expect(CreateUniqueId).to_not receive(:call).with(collection)
-      subject
-    end
   end
 
   describe "exhibit" do

--- a/spec/services/save_item_spec.rb
+++ b/spec/services/save_item_spec.rb
@@ -48,12 +48,6 @@ RSpec.describe SaveItem, type: :model do
       expect(CreateUniqueId).to receive(:call).with(item)
       subject
     end
-
-    it "does not call create unique_id if the item does not save" do
-      allow(item).to receive(:save).and_return(false)
-      expect(CreateUniqueId).to_not receive(:call).with(item)
-      subject
-    end
   end
 
   describe "image processing" do

--- a/spec/services/save_section_spec.rb
+++ b/spec/services/save_section_spec.rb
@@ -54,11 +54,5 @@ describe SaveSection do
       expect(CreateUniqueId).to receive(:call).with(section)
       subject
     end
-
-    it "does not call create unique_id if the section does not save" do
-      allow(section).to receive(:save).and_return(false)
-      expect(CreateUniqueId).to_not receive(:call).with(section)
-      subject
-    end
   end
 end

--- a/spec/services/save_showcase_spec.rb
+++ b/spec/services/save_showcase_spec.rb
@@ -51,11 +51,5 @@ RSpec.describe SaveShowcase, type: :model do
       expect(CreateUniqueId).to receive(:call).with(showcase)
       subject
     end
-
-    it "does not call create unique_id if the showcase does not save" do
-      allow(showcase).to receive(:save).and_return(false)
-      expect(CreateUniqueId).to_not receive(:call).with(showcase)
-      subject
-    end
   end
 end


### PR DESCRIPTION
Why: There was potential for records being created without a unique_id, causing lots of other problems since this is expected to be populated for all records.
How:
-Changed CreateUniqueId to no longer save the item
-Moved the generation of the id in the Save services to happen prior to the initial save
-Added validation on all of the models that have a unique_id since we never want any of these objects to be created without it