### PR TITLE
Dec 498 import migration

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -34,9 +34,8 @@ class Item < ActiveRecord::Base
   has_attached_file :uploaded_image,
                     restricted_characters: /[&$+,\/:;=?@<>\[\]{}\|\\^~%#]/
 
-  validates :name, :collection, :unique_id, presence: true
+  validates :name, :collection, :unique_id, :user_defined_id, presence: true
   validates :date_created, :date_modified, :date_published, date: true
-  validates :user_defined_id, presence: true
   validate :manuscript_url_is_valid_uri
 
   validates_attachment_content_type :image, content_type: /\Aimage\/.*\Z/

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -36,6 +36,7 @@ class Item < ActiveRecord::Base
 
   validates :name, :collection, :unique_id, presence: true
   validates :date_created, :date_modified, :date_published, date: true
+  validates :user_defined_id, presence: true
   validate :manuscript_url_is_valid_uri
 
   validates_attachment_content_type :image, content_type: /\Aimage\/.*\Z/

--- a/app/services/save_item.rb
+++ b/app/services/save_item.rb
@@ -16,6 +16,7 @@ class SaveItem
     item.attributes = params
     pre_process_name
     check_unique_id
+    set_user_defined_id
 
     if item.save && process_uploaded_image
       item
@@ -36,6 +37,13 @@ class SaveItem
 
   def name_should_be_filename?
     item.new_record? && item.name.blank?
+  end
+
+  # Sets the user defined id to the unique id if none is given
+  def set_user_defined_id
+    unless item.user_defined_id.present?
+      item.user_defined_id = item.unique_id
+    end
   end
 
   def fix_image_param!

--- a/app/services/save_item.rb
+++ b/app/services/save_item.rb
@@ -16,7 +16,7 @@ class SaveItem
     item.attributes = params
     pre_process_name
     check_unique_id
-    set_user_defined_id
+    check_user_defined_id
 
     if item.save && process_uploaded_image
       item
@@ -40,7 +40,7 @@ class SaveItem
   end
 
   # Sets the user defined id to the unique id if none is given
-  def set_user_defined_id
+  def check_user_defined_id
     unless item.user_defined_id.present?
       item.user_defined_id = item.unique_id
     end

--- a/db/migrate/20150916134407_copy_items_unique_id_to_user_defined_id.rb
+++ b/db/migrate/20150916134407_copy_items_unique_id_to_user_defined_id.rb
@@ -1,5 +1,5 @@
 class CopyItemsUniqueIdToUserDefinedId < ActiveRecord::Migration
   def up
-    connection.execute("UPDATE items SET user_defined_id = unique_id;")
+    connection.execute("UPDATE items SET user_defined_id = unique_id WHERE user_defined_id IS NULL OR user_defined_id = '';")
   end
 end

--- a/db/migrate/20150916134407_copy_items_unique_id_to_user_defined_id.rb
+++ b/db/migrate/20150916134407_copy_items_unique_id_to_user_defined_id.rb
@@ -1,0 +1,5 @@
+class CopyItemsUniqueIdToUserDefinedId < ActiveRecord::Migration
+  def up
+    connection.execute("UPDATE items SET user_defined_id = unique_id;")
+  end
+end

--- a/spec/services/save_item_spec.rb
+++ b/spec/services/save_item_spec.rb
@@ -50,6 +50,24 @@ RSpec.describe SaveItem, type: :model do
     end
   end
 
+  describe "user_defined_id" do
+    before(:each) do
+      allow(item).to receive(:save).and_return(true)
+    end
+
+    it "sets the user_defined_id to the unique_id if none is given" do
+      item.unique_id = "unique id"
+      expect(item).to receive(:user_defined_id=).with("unique id")
+      subject
+    end
+
+    it "does not change the user_defined_id if one is given" do
+      item.user_defined_id = "user defined id"
+      expect(item).not_to receive(:user_defined_id=)
+      subject
+    end
+  end
+
   describe "image processing" do
     it "Queues image processing if the image was updated" do
       params[:uploaded_image] = upload_image


### PR DESCRIPTION
Depends on https://github.com/ndlib/honeycomb/pull/240
Why: user_defined_id is now a required field, but the default path for creating items was not generating it.
How: Changed SaveItem to copy the unique_id into the user_defined_id field if it's not defined. If it is defined, such as through import, it will use the given id. The migration will do the same for records that already exist.