### PR TITLE
DEC-529: import validation

### DIFF
--- a/app/services/google_create_items.rb
+++ b/app/services/google_create_items.rb
@@ -2,6 +2,7 @@
 # Assumes you have a valid auth token to access the doc
 class GoogleCreateItems
   attr_reader :session
+  attr_reader :total_count, :valid_count, :new_count, :error_count, :changed_count
 
   # Simplified call to create_from_worksheet!
   def self.call(auth_code:, callback_uri:, collection_id:, file:, sheet:)
@@ -20,12 +21,22 @@ class GoogleCreateItems
     unless worksheet.nil?
       items = session.worksheet_to_hash(worksheet: worksheet)
       unless items.nil?
-        create!(items_hash: items) do |item_props|
-          item_props[:collection_id] = collection_id
+        errors_array = create!(collection_id: collection_id, items_hash: items) do |item_props|
           RewriteItemMetadata.call(item_hash: item_props)
         end
       end
     end
+
+    {
+      summary: {
+        total_count: total_count,
+        valid_count: valid_count,
+        new_count: new_count,
+        error_count: error_count,
+        changed_count: changed_count
+      },
+      errors: errors_array
+    }
   end
 
   protected
@@ -34,16 +45,44 @@ class GoogleCreateItems
   # for other bulk creation mechanisms, ex: our own csv importer, it might
   # be a good idea to pull this out into its own thing and have each specific
   # creation mechanism utilize it
-  def create!(items_hash:)
+  def create!(collection_id:, items_hash:)
+    reset_counts
     ActiveRecord::Base.transaction do
-      items_hash.each do |item_props|
+      errors_array = items_hash.map.with_index do |item_props, index|
         item_props = yield(item_props) if block_given?
-        item = Item.new(item_props)
-        unless SaveItem.call(item, item_props)
-          # Dumb way to handle presenting invalid records for now
-          raise "#{item.errors.messages}\n#{item.inspect}"
+        item = Item.new(collection_id: collection_id, **item_props)
+        CreateUniqueId.call(item)
+        update_counts(item: item)
+        if item.valid?
+          SaveItem.call(item, item_props)
+          nil
+        else
+          { index: index, errors: item.errors.full_messages, item: item }
         end
       end
+      errors_array.compact
     end
+  end
+
+  def reset_counts
+    @total_count = 0
+    @valid_count = 0
+    @new_count = 0
+    @error_count = 0
+    @changed_count = 0
+  end
+
+  def update_counts(item:)
+    if item.valid?
+      if item.new_record?
+        @new_count += 1
+      else
+        @changed_count += 1 if item.changed?
+      end
+      @valid_count += 1
+    else
+      @error_count += 1
+    end
+    @total_count += 1
   end
 end

--- a/app/services/google_create_items.rb
+++ b/app/services/google_create_items.rb
@@ -2,7 +2,6 @@
 # Assumes you have a valid auth token to access the doc
 class GoogleCreateItems
   attr_reader :session
-  attr_reader :total_count, :valid_count, :new_count, :error_count, :changed_count
 
   # Simplified call to create_from_worksheet!
   def self.call(auth_code:, callback_uri:, collection_id:, file:, sheet:)
@@ -17,25 +16,26 @@ class GoogleCreateItems
 
   # Adds new items to a collection for each row in a google spread sheet
   def create_from_worksheet!(collection_id:, file:, sheet:)
+    counts = {
+      total_count: 0,
+      valid_count: 0,
+      new_count: 0,
+      error_count: 0,
+      changed_count: 0
+    }
+    errors = []
+
     worksheet = session.get_worksheet(file: file, sheet: sheet)
-    unless worksheet.nil?
+    if worksheet.present?
       items = session.worksheet_to_hash(worksheet: worksheet)
-      unless items.nil?
-        errors_array = create!(collection_id: collection_id, items_hash: items) do |item_props|
-          RewriteItemMetadata.call(item_hash: item_props)
-        end
+      create!(collection_id: collection_id, items_hash: items, counts: counts, errors: errors) do |item_props|
+        RewriteItemMetadata.call(item_hash: item_props)
       end
     end
 
     {
-      summary: {
-        total_count: total_count,
-        valid_count: valid_count,
-        new_count: new_count,
-        error_count: error_count,
-        changed_count: changed_count
-      },
-      errors: errors_array
+      summary: counts,
+      errors: errors
     }
   end
 
@@ -45,44 +45,40 @@ class GoogleCreateItems
   # for other bulk creation mechanisms, ex: our own csv importer, it might
   # be a good idea to pull this out into its own thing and have each specific
   # creation mechanism utilize it
-  def create!(collection_id:, items_hash:)
-    reset_counts
+  #
+  # Attempts to create/update items given ithe items_hash. Increments keys in
+  # counts and appends any errors to the given errors array.
+  # Count hash keys are defined as:
+  #   new_count      - Count of how many new records were created
+  #   changed_count  - Count of how many items already existed but were changed
+  #   valid_count    - Count of how many items passed validation
+  #   error_count    - Count of how many items failed validation
+  #   total_count    - Total number of items processed
+  def create!(collection_id:, items_hash:, counts:, errors:)
     ActiveRecord::Base.transaction do
-      errors_array = items_hash.map.with_index do |item_props, index|
+      items_hash.each.with_index do |item_props, index|
         item_props = yield(item_props) if block_given?
         item = Item.new(collection_id: collection_id, **item_props)
         CreateUniqueId.call(item)
-        update_counts(item: item)
-        if item.valid?
-          SaveItem.call(item, item_props)
-          nil
-        else
-          { index: index, errors: item.errors.full_messages, item: item }
+        update_counts(item: item, counts: counts)
+        unless item.valid? && SaveItem.call(item, {})
+          errors << { index: index, errors: item.errors.full_messages, item: item }
         end
       end
-      errors_array.compact
     end
   end
 
-  def reset_counts
-    @total_count = 0
-    @valid_count = 0
-    @new_count = 0
-    @error_count = 0
-    @changed_count = 0
-  end
-
-  def update_counts(item:)
+  def update_counts(item:, counts:)
     if item.valid?
       if item.new_record?
-        @new_count += 1
+        counts[:new_count] += 1
       else
-        @changed_count += 1 if item.changed?
+        counts[:changed_count] += 1 if item.changed?
       end
-      @valid_count += 1
+      counts[:valid_count] += 1
     else
-      @error_count += 1
+      counts[:error_count] += 1
     end
-    @total_count += 1
+    counts[:total_count] += 1
   end
 end

--- a/app/services/google_session.rb
+++ b/app/services/google_session.rb
@@ -44,12 +44,14 @@ class GoogleSession
     end
   end
 
+  # Returns an array of hashes where the hash keys are the column names
   # Worksheet must have a header row to use as keys in the hash
   def worksheet_to_hash(worksheet:)
+    results = []
     rows = worksheet.rows
-    unless rows.nil?
+    if rows.present?
       header_row = rows[0]
-      rows[1..rows.size].map do |row|
+      results = rows[1..rows.size].map do |row|
         hash = Hash.new
         row.each_with_index do |cell, cell_index|
           if cell.present?
@@ -59,5 +61,6 @@ class GoogleSession
         hash
       end
     end
+    results
   end
 end

--- a/app/views/import/_import_results.html.erb
+++ b/app/views/import/_import_results.html.erb
@@ -1,0 +1,29 @@
+<div>
+  <h2>Import Results</h2>
+  <div>Of <%= @results[:summary][:total_count] %> total rows:</div>
+  <div><%= @results[:summary][:new_count] %> items were created.</div>
+  <div><%= @results[:summary][:changed_count] %> items were updated.</div>
+  <% if @results[:summary][:error_count] > 0 %>
+    <div><%= @results[:summary][:error_count] %> rows were not imported due to the following errors:</div>
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>Row</th>
+          <th>Errors</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @results[:errors].each do |row| %>
+          <tr>
+            <td><%= row[:index] + 2 %></td>
+            <td>
+              <% row[:errors].each do |error| %>
+                <div><%= error %></div>
+              <% end %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+<% end %>

--- a/app/views/import/import_google_sheet_callback.html.erb
+++ b/app/views/import/import_google_sheet_callback.html.erb
@@ -1,0 +1,5 @@
+
+<%= page_title(t('.title'), @collection) %>
+<%= collection_nav(@collection, :items) %>
+
+<%= render partial: 'import_results' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -103,6 +103,9 @@ en:
     delete_panel:
       heading: Delete this Collection
       message: "Proceed with caution. This will also remove all items, exhibits, and showcases."
+  import:
+    import_google_sheet_callback:
+      title: "Import Results"
   items:
     index:
       title: "Items"

--- a/spec/controllers/import_controller_spec.rb
+++ b/spec/controllers/import_controller_spec.rb
@@ -2,8 +2,11 @@ require "rails_helper"
 require "cache_spec_helper"
 
 RSpec.describe ImportController, type: :controller do
+  let(:collection) { instance_double(Collection, id: 1, name_line_1: "COLLECTION", destroy!: true, collection_users: [], exhibit: nil, items: []) }
+
   before(:each) do
     @user = sign_in_admin
+    allow_any_instance_of(CollectionQuery).to receive(:find).and_return(collection)
   end
 
   describe "get_authorization_uri" do
@@ -27,19 +30,26 @@ RSpec.describe ImportController, type: :controller do
     let(:encoded_state_hash) { Base64::encode64(state_hash.to_json) }
     let(:subject) { get :import_google_sheet_callback, state: encoded_state_hash, code: "auth" }
 
-    it "calls GoogleCreateItems using the encoded state" do
-      expect(GoogleCreateItems).to receive(:call).with(hash_including(state_hash))
-      subject
-    end
-
     it "calls GoogleCreateItems using the given params" do
       expect(GoogleCreateItems).to receive(:call).with(hash_including(param_hash))
       subject
     end
 
-    it "redirects to the items page" do
-      allow(GoogleCreateItems).to receive(:call)
-      expect(subject).to redirect_to(collection_items_path(1))
+    it "checks the editor permissions" do
+      allow(GoogleCreateItems).to receive(:call).with(hash_including(param_hash))
+      expect_any_instance_of(described_class).to receive(:check_user_edits!).with(collection)
+      subject
+    end
+  end
+
+  describe "decode_state" do
+    let(:state_hash) { { collection_id: "1", file: "test.file", sheet: "test.sheet" } }
+    let(:param_hash) { { auth_code: "auth", callback_uri: import_google_sheet_callback_collections_url } }
+    let(:encoded_state_hash) { Base64::encode64(state_hash.to_json) }
+    let(:subject) { ImportController.new }
+
+    it "properly decodes the state" do
+      expect(subject.decode_state(state_hash: encoded_state_hash)).to eq(state_hash)
     end
   end
 end

--- a/spec/services/google_create_items_spec.rb
+++ b/spec/services/google_create_items_spec.rb
@@ -72,18 +72,38 @@ RSpec.describe GoogleCreateItems, helpers: :item_meta_helpers do
     creator.create_from_worksheet!(collection_id: param_hash[:collection_id], file: param_hash[:file], sheet: param_hash[:sheet])
   end
 
-  it "returns a hash with summary" do
-    allow_any_instance_of(GoogleSession).to receive(:worksheet_to_hash).and_return(items)
-    creator = GoogleCreateItems.new(auth_code: param_hash[:auth_code], callback_uri: param_hash[:callback_uri])
-    results = creator.create_from_worksheet!(collection_id: param_hash[:collection_id], file: param_hash[:file], sheet: param_hash[:sheet])
-    expected = { summary: { total_count: 3, valid_count: 0, new_count: 0, error_count: 3, changed_count: 0 } }
-    expect(results).to include(expected)
+  context "worksheet has items" do
+    it "returns a hash with summary" do
+      allow_any_instance_of(GoogleSession).to receive(:worksheet_to_hash).and_return(items)
+      creator = GoogleCreateItems.new(auth_code: param_hash[:auth_code], callback_uri: param_hash[:callback_uri])
+      results = creator.create_from_worksheet!(collection_id: param_hash[:collection_id], file: param_hash[:file], sheet: param_hash[:sheet])
+      expected = { summary: { total_count: 3, valid_count: 0, new_count: 0, error_count: 3, changed_count: 0 } }
+      expect(results).to include(expected)
+    end
+
+    it "returns a hash with errors" do
+      allow_any_instance_of(GoogleSession).to receive(:worksheet_to_hash).and_return(items)
+      creator = GoogleCreateItems.new(auth_code: param_hash[:auth_code], callback_uri: param_hash[:callback_uri])
+      results = creator.create_from_worksheet!(collection_id: param_hash[:collection_id], file: param_hash[:file], sheet: param_hash[:sheet])
+      expect(results).to include(:errors)
+    end
   end
 
-  it "returns a hash with errors" do
-    allow_any_instance_of(GoogleSession).to receive(:worksheet_to_hash).and_return(items)
-    creator = GoogleCreateItems.new(auth_code: param_hash[:auth_code], callback_uri: param_hash[:callback_uri])
-    results = creator.create_from_worksheet!(collection_id: param_hash[:collection_id], file: param_hash[:file], sheet: param_hash[:sheet])
-    expect(results).to include(:errors)
+
+  context "worksheet has no items" do
+    it "returns a hash with summary" do
+      allow_any_instance_of(GoogleSession).to receive(:worksheet_to_hash).and_return([])
+      creator = GoogleCreateItems.new(auth_code: param_hash[:auth_code], callback_uri: param_hash[:callback_uri])
+      results = creator.create_from_worksheet!(collection_id: param_hash[:collection_id], file: param_hash[:file], sheet: param_hash[:sheet])
+      expected = { summary: { total_count: 0, valid_count: 0, new_count: 0, error_count: 0, changed_count: 0 } }
+      expect(results).to include(expected)
+    end
+
+    it "returns a hash with errors" do
+      allow_any_instance_of(GoogleSession).to receive(:worksheet_to_hash).and_return([])
+      creator = GoogleCreateItems.new(auth_code: param_hash[:auth_code], callback_uri: param_hash[:callback_uri])
+      results = creator.create_from_worksheet!(collection_id: param_hash[:collection_id], file: param_hash[:file], sheet: param_hash[:sheet])
+      expect(results).to include(errors: [])
+    end
   end
 end

--- a/spec/services/google_create_items_spec.rb
+++ b/spec/services/google_create_items_spec.rb
@@ -89,7 +89,6 @@ RSpec.describe GoogleCreateItems, helpers: :item_meta_helpers do
     end
   end
 
-
   context "worksheet has no items" do
     it "returns a hash with summary" do
       allow_any_instance_of(GoogleSession).to receive(:worksheet_to_hash).and_return([])

--- a/spec/services/google_session_spec.rb
+++ b/spec/services/google_session_spec.rb
@@ -105,6 +105,12 @@ RSpec.describe GoogleSession do
       expect(result).to eq(items)
     end
 
+    it "returns an empty array if there aren't any rows in the worksheet" do
+      allow(worksheet).to receive(:rows).and_return([])
+      result = subject.worksheet_to_hash(worksheet: worksheet)
+      expect(result).to eq([])
+    end
+
     it "does not return a property if the column has no value" do
       rows[1][3] = nil
       items[0].delete("Description")


### PR DESCRIPTION
Why: Need to validate all records and report back to the user meaningful information about the import
How: Refactored GoogleCreateItems and ImportController to provide more data about the valid/invalid records imported. GoogleCreateItems will now return a json with a summary and a list of errors. Created a basic view to show the data. This will likely move to a react component that can be displayed without leaving the items page (DEC-575) so I didn't spend a whole lot of time on its appearance.

Example of the results view:

![screen shot 2015-09-17 at 3 09 23 pm](https://cloud.githubusercontent.com/assets/11502744/9943238/4229bd12-5d4e-11e5-9e90-354c03876746.png)