### PR TITLE
DEC-499: Update items on import

### DIFF
--- a/app/models/metadata/configuration.rb
+++ b/app/models/metadata/configuration.rb
@@ -33,6 +33,10 @@ module Metadata
       label(name).present?
     end
 
+    def field_names
+      field_map.keys
+    end
+
     private
 
     def build_fields(data)

--- a/app/services/create_items.rb
+++ b/app/services/create_items.rb
@@ -3,7 +3,11 @@
 # attempting to create the item.
 class CreateItems
   def self.call(collection_id:, find_by:, items_hash:, counts:, errors:)
-    new.create_or_update!(collection_id: collection_id, find_by: find_by, items_hash: items_hash, counts: counts, errors: errors) do |item_props, rewrite_errors|
+    new.create_or_update!(collection_id: collection_id,
+                          find_by: find_by,
+                          items_hash: items_hash,
+                          counts: counts,
+                          errors: errors) do |item_props, rewrite_errors|
       if block_given?
         yield(item_props, rewrite_errors)
       else

--- a/app/services/create_items.rb
+++ b/app/services/create_items.rb
@@ -1,0 +1,63 @@
+# Performs batch creation of items from an array of item hashes.
+# Allows injecting a block to change the item attributes before
+# attempting to create the item.
+class CreateItems
+  def self.call(collection_id:, items_hash:, counts:, errors:)
+    new.create!(collection_id: collection_id, items_hash: items_hash, counts: counts, errors: errors) do |item_props, rewrite_errors|
+      if block_given?
+        yield(item_props, rewrite_errors)
+      else
+        item_props
+      end
+    end
+  end
+
+  # Attempts to create/update items given in the items_hash. Increments keys in
+  # counts and appends any errors to the given errors array.
+  # Count hash keys are defined as:
+  #   new_count      - Count of how many new records were created
+  #   changed_count  - Count of how many items already existed but were changed
+  #   valid_count    - Count of how many items passed validation
+  #   error_count    - Count of how many items failed validation
+  #   total_count    - Total number of items processed
+  def create!(collection_id:, items_hash:, counts:, errors:)
+    ActiveRecord::Base.transaction do
+      items_hash.each.with_index do |item_props, index|
+        rewrite_errors = []
+        item_props = yield(item_props, rewrite_errors) if block_given?
+        item_creator = FindOrCreateItem.new(props: { collection_id: collection_id, **item_props })
+        item = item_creator.by_user_defined_id
+        saved = rewrite_errors.present? ? false : item_creator.save
+        add_to_errors(errors: errors, index: index, new_errors: rewrite_errors | item.errors.full_messages, item: item)
+        update_counts(save_successful: saved, item: item_creator, counts: counts)
+      end
+    end
+  end
+
+  private
+
+  def add_to_errors(errors:, index:, new_errors:, item:)
+    if new_errors.present?
+      errors[index] ||= { errors: [], item: item }
+      errors[index][:errors] = errors[index][:errors] | new_errors
+    end
+  end
+
+  def update_counts(save_successful:, item:, counts:)
+    counts[:total_count] += 1
+    if save_successful
+      if item.new_record?
+        counts[:new_count] += 1
+      else
+        if item.changed?
+          counts[:changed_count] += 1
+        else
+          counts[:unchanged_count] += 1
+        end
+      end
+      counts[:valid_count] += 1
+    else
+      counts[:error_count] += 1
+    end
+  end
+end

--- a/app/services/find_or_create_item.rb
+++ b/app/services/find_or_create_item.rb
@@ -2,17 +2,18 @@ class FindOrCreateItem
   attr_reader :props, :item, :is_new_record, :is_changed, :is_valid
   private :is_new_record, :is_changed, :is_valid
 
+  def self.call(props:, find_by:)
+    instance = new(props: props)
+    instance.using(prop_keys: find_by)
+    instance
+  end
+
   def initialize(props:)
     @item = nil
     @props = props
     @is_new_record = false
     @is_changed = false
     @is_valid = false
-  end
-
-  def by_user_defined_id
-    find_or_create_by(criteria: { collection_id: props[:collection_id],
-                                  user_defined_id: props[:user_defined_id] })
   end
 
   def new_record?
@@ -36,6 +37,16 @@ class FindOrCreateItem
     else
       false
     end
+  end
+
+  # Calls find_or_create_by using the specified key/value pairs given in the props
+  # when this class was instantiated. Ex:
+  #   creator = FindOrCreateItem.new(props: { collection_id: 1, name: "name", description: "something" } )
+  #   creator.using([:collection_id, :name])
+  # will call find_or_create_by with criteria: { collection_id: 1, name: "name" }
+  def using(prop_keys:)
+    criteria = Hash[prop_keys.map { |key| [key, props[key]] }]
+    find_or_create_by(criteria: criteria)
   end
 
   def find_or_create_by(criteria:)

--- a/app/services/find_or_create_item.rb
+++ b/app/services/find_or_create_item.rb
@@ -1,0 +1,56 @@
+class FindOrCreateItem
+  attr_reader :props, :item, :is_new_record, :is_changed, :is_valid
+  private :is_new_record, :is_changed, :is_valid
+
+  def initialize(props:)
+    @item = nil
+    @props = props
+    @is_new_record = false
+    @is_changed = false
+    @is_valid = false
+  end
+
+  def by_user_defined_id
+    find_or_create_by(criteria: { collection_id: props[:collection_id],
+                                  user_defined_id: props[:user_defined_id] })
+  end
+
+  def new_record?
+    is_new_record
+  end
+
+  # Returns true if the Item previously existed in the database and was changed.
+  # This is different from just calling Item.changed? since a new item can appear
+  # to have changed after assigning the attributes to the new item
+  def changed?
+    is_changed
+  end
+
+  def valid?
+    is_valid
+  end
+
+  def save
+    if is_valid && SaveItem.call(item, {})
+      true
+    else
+      false
+    end
+  end
+
+  def find_or_create_by(criteria:)
+    @item = Item.find_or_create_by(criteria)
+    @is_new_record = item.new_record?
+    update_props
+    @is_changed = !item.new_record? && item.changed?
+    item
+  end
+
+  private
+
+  def update_props
+    item.assign_attributes(props)
+    CreateUniqueId.call(item)
+    @is_valid = item.valid?
+  end
+end

--- a/app/services/google_create_items.rb
+++ b/app/services/google_create_items.rb
@@ -29,7 +29,11 @@ class GoogleCreateItems
     worksheet = session.get_worksheet(file: file, sheet: sheet)
     if worksheet.present?
       items = session.worksheet_to_hash(worksheet: worksheet)
-      CreateItems.call(collection_id: collection_id, items_hash: items, counts: counts, errors: errors) do |item_props, rewrite_errors|
+      CreateItems.call(collection_id: collection_id,
+                       find_by: [:collection_id, :user_defined_id],
+                       items_hash: items,
+                       counts: counts,
+                       errors: errors) do |item_props, rewrite_errors|
         RewriteItemMetadata.call(item_hash: item_props, errors: rewrite_errors)
       end
     end

--- a/app/services/google_create_items.rb
+++ b/app/services/google_create_items.rb
@@ -21,64 +21,21 @@ class GoogleCreateItems
       valid_count: 0,
       new_count: 0,
       error_count: 0,
-      changed_count: 0
+      changed_count: 0,
+      unchanged_count: 0
     }
-    errors = []
+    errors = {}
 
     worksheet = session.get_worksheet(file: file, sheet: sheet)
     if worksheet.present?
       items = session.worksheet_to_hash(worksheet: worksheet)
-      create!(collection_id: collection_id, items_hash: items, counts: counts, errors: errors) do |item_props|
-        RewriteItemMetadata.call(item_hash: item_props)
+      CreateItems.call(collection_id: collection_id, items_hash: items, counts: counts, errors: errors) do |item_props, rewrite_errors|
+        RewriteItemMetadata.call(item_hash: item_props, errors: rewrite_errors)
       end
     end
-
     {
       summary: counts,
       errors: errors
     }
-  end
-
-  protected
-
-  # This is written to be fairly generic. If we find that we have a need
-  # for other bulk creation mechanisms, ex: our own csv importer, it might
-  # be a good idea to pull this out into its own thing and have each specific
-  # creation mechanism utilize it
-  #
-  # Attempts to create/update items given ithe items_hash. Increments keys in
-  # counts and appends any errors to the given errors array.
-  # Count hash keys are defined as:
-  #   new_count      - Count of how many new records were created
-  #   changed_count  - Count of how many items already existed but were changed
-  #   valid_count    - Count of how many items passed validation
-  #   error_count    - Count of how many items failed validation
-  #   total_count    - Total number of items processed
-  def create!(collection_id:, items_hash:, counts:, errors:)
-    ActiveRecord::Base.transaction do
-      items_hash.each.with_index do |item_props, index|
-        item_props = yield(item_props) if block_given?
-        item = Item.new(collection_id: collection_id, **item_props)
-        CreateUniqueId.call(item)
-        update_counts(item: item, counts: counts)
-        unless item.valid? && SaveItem.call(item, {})
-          errors << { index: index, errors: item.errors.full_messages, item: item }
-        end
-      end
-    end
-  end
-
-  def update_counts(item:, counts:)
-    if item.valid?
-      if item.new_record?
-        counts[:new_count] += 1
-      else
-        counts[:changed_count] += 1 if item.changed?
-      end
-      counts[:valid_count] += 1
-    else
-      counts[:error_count] += 1
-    end
-    counts[:total_count] += 1
   end
 end

--- a/app/views/import/_import_results.html.erb
+++ b/app/views/import/_import_results.html.erb
@@ -1,21 +1,32 @@
 <div>
   <h2>Import Results</h2>
   <div>Of <%= @results[:summary][:total_count] %> total rows:</div>
-  <div><%= @results[:summary][:new_count] %> items were created.</div>
-  <div><%= @results[:summary][:changed_count] %> items were updated.</div>
+  <% if  @results[:summary][:new_count] > 0 %>
+    <div><%= @results[:summary][:new_count] %> items were created.</div>
+  <% end %>
+  <% if  @results[:summary][:changed_count] > 0 %>
+    <div><%= @results[:summary][:changed_count] %> items were updated.</div>
+  <% end %>
+  <% if  @results[:summary][:unchanged_count] > 0 %>
+    <div><%= @results[:summary][:unchanged_count] %> items had no changes.</div>
+  <% end %>
   <% if @results[:summary][:error_count] > 0 %>
     <div><%= @results[:summary][:error_count] %> rows were not imported due to the following errors:</div>
     <table class="table table-striped">
       <thead>
         <tr>
           <th>Row</th>
+          <th>Item Id</th>
+          <th>Item Name</th>
           <th>Errors</th>
         </tr>
       </thead>
       <tbody>
-        <% @results[:errors].each do |row| %>
+        <% @results[:errors].each do |index, row| %>
           <tr>
-            <td><%= row[:index] + 2 %></td>
+            <td><%= index + 2 %></td>
+            <td><%= row[:item].user_defined_id %></td>
+            <td><%= row[:item].name %></td>
             <td>
               <% row[:errors].each do |error| %>
                 <div><%= error %></div>

--- a/db/migrate/20150918201430_add_unique_user_defined_id_constraint.rb
+++ b/db/migrate/20150918201430_add_unique_user_defined_id_constraint.rb
@@ -1,0 +1,5 @@
+class AddUniqueUserDefinedIdConstraint < ActiveRecord::Migration
+  def change
+    add_index :items, [:collection_id, :user_defined_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150916134407) do
+ActiveRecord::Schema.define(version: 20150918201430) do
 
   create_table "collection_users", force: :cascade do |t|
     t.integer  "user_id",       limit: 4, null: false
@@ -98,6 +98,7 @@ ActiveRecord::Schema.define(version: 20150916134407) do
     t.string   "user_defined_id",             limit: 255,                    null: false
   end
 
+  add_index "items", ["collection_id", "user_defined_id"], name: "index_items_on_collection_id_and_user_defined_id", unique: true, using: :btree
   add_index "items", ["collection_id"], name: "index_items_on_collection_id", using: :btree
   add_index "items", ["parent_id"], name: "index_items_on_parent_id", using: :btree
   add_index "items", ["published"], name: "index_items_on_published", using: :btree

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe Item do
         FactoryGirl.create(:exhibit)
         FactoryGirl.create(:showcase)
         subject = FactoryGirl.create(:item)
-        FactoryGirl.create(:item, id: 2, parent_id: 1)
+        FactoryGirl.create(:item, id: 2, parent_id: 1, user_defined_id: "two")
         expect { subject.destroy }.to raise_error
       end
     end

--- a/spec/models/metadata/configuration_spec.rb
+++ b/spec/models/metadata/configuration_spec.rb
@@ -31,6 +31,13 @@ RSpec.describe Metadata::Configuration do
       expect(subject.field?(:fake_field)).to eq(false)
     end
   end
+
+  describe "field_names" do
+    it "returns an array of field names" do
+      expect(subject.field_names).to eq(data.map { |f| f[:name] })
+    end
+  end
+
   describe "label" do
     it "finds a field by its label" do
       field = subject.label("String")

--- a/spec/services/create_items_spec.rb
+++ b/spec/services/create_items_spec.rb
@@ -25,10 +25,10 @@ RSpec.describe CreateItems, helpers: :item_meta_helpers do
       unchanged_count: 0
     }
   end
-  let(:creator) { instance_double(FindOrCreateItem, by_user_defined_id: item, new_record?: true, changed?: false, save: true) }
+  let(:creator) { instance_double(FindOrCreateItem, using: item, new_record?: true, changed?: false, save: true, item: item) }
   let(:item) { instance_double(Item, valid?: true, changed?: false, new_record?: false, errors: item_errors) }
   let(:subject) do
-    described_class.call(collection_id: 1, items_hash: items, counts: counts, errors: errors)
+    described_class.call(collection_id: 1, find_by:[], items_hash: items, counts: counts, errors: errors)
   end
 
   before (:each) do
@@ -43,14 +43,14 @@ RSpec.describe CreateItems, helpers: :item_meta_helpers do
     expect(FindOrCreateItem).to receive(:new).with(props: { collection_id: 1, item_name: rewritten[0][:name] }).and_return(creator).ordered
     expect(FindOrCreateItem).to receive(:new).with(props: { collection_id: 1, item_name: rewritten[1][:name] }).and_return(creator).ordered
     expect(FindOrCreateItem).to receive(:new).with(props: { collection_id: 1, item_name: rewritten[2][:name] }).and_return(creator).ordered
-    described_class.call(collection_id: 1, items_hash: items, counts: counts, errors: errors) do |item_props, _rewrite_errors|
+    described_class.call(collection_id: 1, find_by: [], items_hash: items, counts: counts, errors: errors) do |item_props, _rewrite_errors|
       { item_name: item_props[:name] }
     end
   end
 
   context "when it receives errors from the injected block" do
     let(:subject) do
-      described_class.call(collection_id: 1, items_hash: items, counts: counts, errors: errors) do |item_props, rewrite_errors|
+      described_class.call(collection_id: 1, find_by: [], items_hash: items, counts: counts, errors: errors) do |item_props, rewrite_errors|
         rewrite_errors << ["Rewrite error 1 on #{item_props[:name]}", "Rewrite error 2 on #{item_props[:name]}"]
         item_props
       end
@@ -112,7 +112,7 @@ RSpec.describe CreateItems, helpers: :item_meta_helpers do
 
     context "that validate successfully as changed items" do
       let(:item_errors) { instance_double(ActiveModel::Errors, full_messages: []) }
-      let(:creator) { instance_double(FindOrCreateItem, by_user_defined_id: item, new_record?: false, changed?: true, save: true) }
+      let(:creator) { instance_double(FindOrCreateItem, using: item, new_record?: false, changed?: true, save: true, item: item) }
       let(:item) { instance_double(Item, valid?: true, changed?: false, new_record?: false, errors: item_errors, validate: true) }
 
       it "returns correct summary" do
@@ -129,7 +129,7 @@ RSpec.describe CreateItems, helpers: :item_meta_helpers do
 
     context "that validate successfully as unchanged items" do
       let(:item_errors) { instance_double(ActiveModel::Errors, full_messages: []) }
-      let(:creator) { instance_double(FindOrCreateItem, by_user_defined_id: item, new_record?: false, changed?: false, save: true) }
+      let(:creator) { instance_double(FindOrCreateItem, using: item, new_record?: false, changed?: false, save: true, item: item) }
       let(:item) { instance_double(Item, valid?: true, changed?: false, new_record?: false, errors: item_errors, validate: true) }
 
       it "returns correct summary" do
@@ -145,7 +145,7 @@ RSpec.describe CreateItems, helpers: :item_meta_helpers do
     end
 
     context "that do not validate successfully" do
-      let(:creator) { instance_double(FindOrCreateItem, by_user_defined_id: item, new_record?: true, changed?: false, valid?: false, save: false) }
+      let(:creator) { instance_double(FindOrCreateItem, using: item, new_record?: true, changed?: false, valid?: false, save: false, item: item) }
       let(:item_errors) { instance_double(ActiveModel::Errors, full_messages: ["Item validation error"]) }
       let(:item) { instance_double(Item, valid?: false, changed?: false, new_record?: false, errors: item_errors) }
 

--- a/spec/services/create_items_spec.rb
+++ b/spec/services/create_items_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe CreateItems, helpers: :item_meta_helpers do
   let(:creator) { instance_double(FindOrCreateItem, using: item, new_record?: true, changed?: false, save: true, item: item) }
   let(:item) { instance_double(Item, valid?: true, changed?: false, new_record?: false, errors: item_errors) }
   let(:subject) do
-    described_class.call(collection_id: 1, find_by:[], items_hash: items, counts: counts, errors: errors)
+    described_class.call(collection_id: 1, find_by: [], items_hash: items, counts: counts, errors: errors)
   end
 
   before (:each) do

--- a/spec/services/create_items_spec.rb
+++ b/spec/services/create_items_spec.rb
@@ -1,0 +1,181 @@
+require "rails_helper"
+require "support/item_meta_helpers"
+
+RSpec.configure do |c|
+  c.include ItemMetaHelpers, helpers: :item_meta_helpers
+end
+
+RSpec.describe CreateItems, helpers: :item_meta_helpers do
+  let(:items) do
+    [
+      item_meta_hash_remapped(item_id: 1),
+      item_meta_hash_remapped(item_id: 2),
+      item_meta_hash_remapped(item_id: 3),
+    ]
+  end
+  let(:item_errors) { instance_double(ActiveModel::Errors, full_messages: ["Item validation error"]) }
+  let(:errors) { [] }
+  let(:counts) do
+    {
+      total_count: 0,
+      valid_count: 0,
+      new_count: 0,
+      error_count: 0,
+      changed_count: 0,
+      unchanged_count: 0
+    }
+  end
+  let(:creator) { instance_double(FindOrCreateItem, by_user_defined_id: item, new_record?: true, changed?: false, save: true) }
+  let(:item) { instance_double(Item, valid?: true, changed?: false, new_record?: false, errors: item_errors) }
+  let(:subject) do
+    described_class.call(collection_id: 1, items_hash: items, counts: counts, errors: errors)
+  end
+
+  before (:each) do
+    allow(Item).to receive(:new).and_return(item)
+    allow(Item).to receive(:find_or_create_by).and_return(item)
+    allow(SaveItem).to receive(:call).and_return true
+    allow(FindOrCreateItem).to receive(:new).and_return(creator)
+  end
+
+  it "allows injecting a block to edit the properties before creating the item" do
+    rewritten = items.each { |item_hash| { item_name: item_hash[:name] } }
+    expect(FindOrCreateItem).to receive(:new).with(props: { collection_id: 1, item_name: rewritten[0][:name] }).and_return(creator).ordered
+    expect(FindOrCreateItem).to receive(:new).with(props: { collection_id: 1, item_name: rewritten[1][:name] }).and_return(creator).ordered
+    expect(FindOrCreateItem).to receive(:new).with(props: { collection_id: 1, item_name: rewritten[2][:name] }).and_return(creator).ordered
+    described_class.call(collection_id: 1, items_hash: items, counts: counts, errors: errors) do |item_props, _rewrite_errors|
+      { item_name: item_props[:name] }
+    end
+  end
+
+  context "when it receives errors from the injected block" do
+    let(:subject) do
+      described_class.call(collection_id: 1, items_hash: items, counts: counts, errors: errors) do |item_props, rewrite_errors|
+        rewrite_errors << ["Rewrite error 1 on #{item_props[:name]}", "Rewrite error 2 on #{item_props[:name]}"]
+        item_props
+      end
+    end
+
+    it "adds these errors to the items" do
+      expected_errors = [
+        { errors: [["Rewrite error 1 on name1", "Rewrite error 2 on name1"], "Item validation error"], item: item },
+        { errors: [["Rewrite error 1 on name2", "Rewrite error 2 on name2"], "Item validation error"], item: item },
+        { errors: [["Rewrite error 1 on name3", "Rewrite error 2 on name3"], "Item validation error"], item: item }
+      ]
+      subject
+      expect(errors).to eq(expected_errors)
+    end
+
+    it "does not try to save the item" do
+      expect(SaveItem).not_to receive(:call)
+      subject
+    end
+
+    it "counts these as overall errors" do
+      expected = { total_count: 3, valid_count: 0, new_count: 0, error_count: 3, changed_count: 0, unchanged_count: 0 }
+      subject
+      expect(counts).to include(expected)
+    end
+  end
+
+  context "called with items" do
+    it "uses FindOrCreateItem to create the item with the given properties" do
+      allow(CreateUniqueId).to receive(:call).and_return(true)
+      expect(FindOrCreateItem).to receive(:new).with(props: hash_including(items[0])).ordered
+      expect(FindOrCreateItem).to receive(:new).with(props: hash_including(items[1])).ordered
+      expect(FindOrCreateItem).to receive(:new).with(props: hash_including(items[2])).ordered
+      subject
+    end
+
+    it "uses FindOrCreateItem service to save all items" do
+      allow(item).to receive(:assign_attributes).and_return(true)
+      allow(CreateUniqueId).to receive(:call).and_return(true)
+      expect(creator).to receive(:save).exactly(3).and_return true
+      subject
+    end
+
+    context "that validate successfully as new items" do
+      let(:item_errors) { instance_double(ActiveModel::Errors, full_messages: []) }
+      let(:item) { instance_double(Item, valid?: true, changed?: false, new_record?: false, errors: item_errors, validate: true) }
+
+      it "returns correct summary" do
+        expected = { total_count: 3, valid_count: 3, new_count: 3, error_count: 0, changed_count: 0, unchanged_count: 0 }
+        subject
+        expect(counts).to include(expected)
+      end
+
+      it "returns no errors" do
+        subject
+        expect(errors).to eq([])
+      end
+    end
+
+    context "that validate successfully as changed items" do
+      let(:item_errors) { instance_double(ActiveModel::Errors, full_messages: []) }
+      let(:creator) { instance_double(FindOrCreateItem, by_user_defined_id: item, new_record?: false, changed?: true, save: true) }
+      let(:item) { instance_double(Item, valid?: true, changed?: false, new_record?: false, errors: item_errors, validate: true) }
+
+      it "returns correct summary" do
+        expected = { total_count: 3, valid_count: 3, new_count: 0, error_count: 0, changed_count: 3, unchanged_count: 0 }
+        subject
+        expect(counts).to include(expected)
+      end
+
+      it "returns no errors" do
+        subject
+        expect(errors).to eq([])
+      end
+    end
+
+    context "that validate successfully as unchanged items" do
+      let(:item_errors) { instance_double(ActiveModel::Errors, full_messages: []) }
+      let(:creator) { instance_double(FindOrCreateItem, by_user_defined_id: item, new_record?: false, changed?: false, save: true) }
+      let(:item) { instance_double(Item, valid?: true, changed?: false, new_record?: false, errors: item_errors, validate: true) }
+
+      it "returns correct summary" do
+        expected = { total_count: 3, valid_count: 3, new_count: 0, error_count: 0, changed_count: 0, unchanged_count: 3 }
+        subject
+        expect(counts).to include(expected)
+      end
+
+      it "returns no errors" do
+        subject
+        expect(errors).to eq([])
+      end
+    end
+
+    context "that do not validate successfully" do
+      let(:creator) { instance_double(FindOrCreateItem, by_user_defined_id: item, new_record?: true, changed?: false, valid?: false, save: false) }
+      let(:item_errors) { instance_double(ActiveModel::Errors, full_messages: ["Item validation error"]) }
+      let(:item) { instance_double(Item, valid?: false, changed?: false, new_record?: false, errors: item_errors) }
+
+      it "returns a hash with correct summary" do
+        expected = { total_count: 3, valid_count: 0, new_count: 0, error_count: 3, changed_count: 0, unchanged_count: 0 }
+        subject
+        expect(counts).to include(expected)
+      end
+
+      it "returns a hash with errors" do
+        expected = [
+          { errors: ["Item validation error"], item: item },
+          { errors: ["Item validation error"], item: item },
+          { errors: ["Item validation error"], item: item }
+        ]
+        subject
+        expect(errors).to eq(expected)
+      end
+    end
+  end
+
+  context "called with no items" do
+    let(:items) { [] }
+
+    it "returns a hash with summary" do
+      expected = { total_count: 0, valid_count: 0, new_count: 0, error_count: 0, changed_count: 0, unchanged_count: 0 }
+      subject
+      expect(counts).to include(expected)
+    end
+
+    it "returns a hash with errors"
+  end
+end

--- a/spec/services/destroy/collection_spec.rb
+++ b/spec/services/destroy/collection_spec.rb
@@ -57,8 +57,8 @@ describe Destroy::Collection do
        FactoryGirl.create(:collection_user, id: 2, collection_id: collection.id)]
     end
     let(:items) do
-      [FactoryGirl.create(:item, id: 1, collection_id: collection.id),
-       FactoryGirl.create(:item, id: 2, collection_id: collection.id)]
+      [FactoryGirl.create(:item, id: 1, collection_id: collection.id, user_defined_id: "one"),
+       FactoryGirl.create(:item, id: 2, collection_id: collection.id, user_defined_id: "two")]
     end
 
     before(:each) do

--- a/spec/services/destroy/item_spec.rb
+++ b/spec/services/destroy/item_spec.rb
@@ -50,8 +50,14 @@ describe Destroy::Item do
     let(:item) { FactoryGirl.create(:item) }
     let(:showcase) { FactoryGirl.create(:showcase) }
     let(:exhibit) { FactoryGirl.create(:exhibit) }
-    let(:sections) { [FactoryGirl.create(:section, id: 1, item_id: item.id), FactoryGirl.create(:section, id: 2, item_id: item.id)] }
-    let(:children) { [FactoryGirl.create(:item, id: 3, parent_id: item.id), FactoryGirl.create(:item, id: 4, parent_id: item.id)] }
+    let(:sections) do
+      [FactoryGirl.create(:section, id: 1, item_id: item.id),
+       FactoryGirl.create(:section, id: 2, item_id: item.id)]
+    end
+    let(:children) do
+      [FactoryGirl.create(:item, id: 3, parent_id: item.id, user_defined_id: "three"),
+       FactoryGirl.create(:item, id: 4, parent_id: item.id, user_defined_id: "four")]
+    end
 
     before(:each) do
       collection

--- a/spec/services/find_or_create_item_spec.rb
+++ b/spec/services/find_or_create_item_spec.rb
@@ -17,10 +17,15 @@ describe FindOrCreateItem do
     allow(Item).to receive(:find_or_create_by).and_return(item)
   end
 
-  context "by_user_defined_id" do
+  context "using method" do
     it "uses both collection id and user defined id to find the item" do
       expect(Item).to receive(:find_or_create_by).with(collection_id: 1, user_defined_id: "item").and_return(item)
-      subject.by_user_defined_id
+      subject.using(prop_keys: [:collection_id, :user_defined_id])
+    end
+
+    it "uses empty hash to find the item when no prop_keys are given" do
+      expect(Item).to receive(:find_or_create_by).with({}).and_return(item)
+      subject.using(prop_keys: [])
     end
   end
 
@@ -88,26 +93,26 @@ describe FindOrCreateItem do
   context "when saving the created item" do
     it "uses SaveItem to save the item" do
       expect(SaveItem).to receive(:call).with(item, {})
-      subject.by_user_defined_id
+      subject.find_or_create_by(criteria: {})
       subject.save
     end
 
     it "only saves the item if it's valid" do
       allow(item).to receive(:valid?).and_return(false)
       expect(SaveItem).not_to receive(:call)
-      subject.by_user_defined_id
+      subject.find_or_create_by(criteria: {})
       subject.save
     end
 
     it "returns false if SaveItem fails" do
       allow(SaveItem).to receive(:call).and_return(false)
-      subject.by_user_defined_id
+      subject.find_or_create_by(criteria: {})
       expect(subject.save).to eq(false)
     end
 
     it "true if SaveItem succeeds" do
       allow(SaveItem).to receive(:call).and_return(item)
-      subject.by_user_defined_id
+      subject.find_or_create_by(criteria: {})
       expect(subject.save).to eq(true)
     end
   end

--- a/spec/services/find_or_create_item_spec.rb
+++ b/spec/services/find_or_create_item_spec.rb
@@ -1,0 +1,114 @@
+require "rails_helper"
+
+describe FindOrCreateItem do
+  let(:subject) { described_class.new(props: item_hash) }
+  let(:item_hash) { { collection_id: 1, name: "item", unique_id: "item", user_defined_id: "item" } }
+  let(:item) do
+    instance_double(Item, save: true,
+                          new_record?: true,
+                          changed?: false,
+                          assign_attributes: true,
+                          "unique_id=" => true,
+                          valid?: true,
+                          **item_hash)
+  end
+
+  before(:each) do
+    allow(Item).to receive(:find_or_create_by).and_return(item)
+  end
+
+  context "by_user_defined_id" do
+    it "uses both collection id and user defined id to find the item" do
+      expect(Item).to receive(:find_or_create_by).with(collection_id: 1, user_defined_id: "item").and_return(item)
+      subject.by_user_defined_id
+    end
+  end
+
+  context "new item" do
+    before(:each) do
+      allow(item).to receive(:new_record?).and_return(true)
+      allow(item).to receive(:changed?).and_return(false)
+    end
+
+    it "new_record? returns true" do
+      subject.find_or_create_by(criteria: {})
+      expect(subject.new_record?).to eq(true)
+    end
+
+    it "changed? returns false" do
+      subject.find_or_create_by(criteria: {})
+      expect(subject.changed?).to eq(false)
+    end
+
+    it "changed? returns false even when item.changed? returns true" do
+      allow(item).to receive(:changed?).and_return(true)
+      subject.find_or_create_by(criteria: {})
+      expect(subject.changed?).to eq(false)
+    end
+  end
+
+  context "existing item" do
+    before(:each) do
+      allow(item).to receive(:new_record?).and_return(false)
+    end
+
+    it "new_record? returns false" do
+      subject.find_or_create_by(criteria: {})
+      expect(subject.new_record?).to eq(false)
+    end
+
+    it "changed? returns true if the item was changed" do
+      allow(item).to receive(:changed?).and_return(true)
+      subject.find_or_create_by(criteria: {})
+      expect(subject.changed?).to eq(true)
+    end
+
+    it "changed? returns false if the item was not changed" do
+      allow(item).to receive(:changed?).and_return(false)
+      subject.find_or_create_by(criteria: {})
+      expect(subject.changed?).to eq(false)
+    end
+  end
+
+  it "assigns the attributes given to the item" do
+    expect(item).to receive(:assign_attributes).with(item_hash)
+    subject.find_or_create_by(criteria: {})
+  end
+
+  it "generates a unique id" do
+    expect(CreateUniqueId).to receive(:call).with(item)
+    subject.find_or_create_by(criteria: {})
+  end
+
+  it "calls validation on the item" do
+    expect(item).to receive(:valid?)
+    subject.find_or_create_by(criteria: {})
+  end
+
+  context "when saving the created item" do
+    it "uses SaveItem to save the item" do
+      expect(SaveItem).to receive(:call).with(item, {})
+      subject.by_user_defined_id
+      subject.save
+    end
+
+    it "only saves the item if it's valid" do
+      allow(item).to receive(:valid?).and_return(false)
+      expect(SaveItem).not_to receive(:call)
+      subject.by_user_defined_id
+      subject.save
+    end
+
+    it "returns false if SaveItem fails" do
+      allow(SaveItem).to receive(:call).and_return(false)
+      subject.by_user_defined_id
+      expect(subject.save).to eq(false)
+    end
+
+    it "true if SaveItem succeeds" do
+      allow(SaveItem).to receive(:call).and_return(item)
+      subject.by_user_defined_id
+      expect(subject.save).to eq(true)
+    end
+  end
+end

--- a/spec/services/google_create_items_spec.rb
+++ b/spec/services/google_create_items_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe GoogleCreateItems, helpers: :item_meta_helpers do
   end
   let(:errors) { instance_double(ActiveModel::Errors, full_messages: []) }
   let(:item) { instance_double(Item, valid?: true, changed?: false, new_record?: false, errors: errors, validate: true) }
-  let(:item_creator) { instance_double(FindOrCreateItem, by_user_defined_id: item, save: true, new_record?: true) }
+  let(:item_creator) { instance_double(FindOrCreateItem, using: item, save: true, new_record?: true, item: item) }
   let(:worksheet) { instance_double(GoogleDrive::Worksheet) }
   let(:param_hash) { { auth_code: "auth", callback_uri: "callback", collection_id: 1, file: "file", sheet: "sheet" } }
   let(:subject) { described_class.call(param_hash) }

--- a/spec/services/google_create_items_spec.rb
+++ b/spec/services/google_create_items_spec.rb
@@ -20,7 +20,9 @@ RSpec.describe GoogleCreateItems, helpers: :item_meta_helpers do
       item_meta_hash_remapped(item_id: 3),
     ]
   end
-  let(:item) { instance_double(Item, valid?: true, changed?: false, new_record?: false, errors: []) }
+  let(:errors) { instance_double(ActiveModel::Errors, full_messages: []) }
+  let(:item) { instance_double(Item, valid?: true, changed?: false, new_record?: false, errors: errors, validate: true) }
+  let(:item_creator) { instance_double(FindOrCreateItem, by_user_defined_id: item, save: true, new_record?: true) }
   let(:worksheet) { instance_double(GoogleDrive::Worksheet) }
   let(:param_hash) { { auth_code: "auth", callback_uri: "callback", collection_id: 1, file: "file", sheet: "sheet" } }
   let(:subject) { described_class.call(param_hash) }
@@ -29,30 +31,13 @@ RSpec.describe GoogleCreateItems, helpers: :item_meta_helpers do
     allow_any_instance_of(GoogleSession).to receive(:connect)
     allow_any_instance_of(GoogleSession).to receive(:get_worksheet).and_return(worksheet)
     allow_any_instance_of(GoogleSession).to receive(:worksheet_to_hash).and_return(items)
+    allow(FindOrCreateItem).to receive(:new).and_return(item_creator)
     allow(SaveItem).to receive(:call).and_return true
-  end
-
-  it "creates new item with the remapped properties" do
-    allow(Item).to receive(:new).and_return(item)
-    allow(CreateUniqueId).to receive(:call).and_return(true)
-    expect(Item).to receive(:new).with(hash_including(remapped_items[0])).ordered
-    expect(Item).to receive(:new).with(hash_including(remapped_items[1])).ordered
-    expect(Item).to receive(:new).with(hash_including(remapped_items[2])).ordered
-    subject
-  end
-
-  it "uses SaveItem service to save all items" do
-    allow(Item).to receive(:new).and_return(item)
-    allow(CreateUniqueId).to receive(:call).and_return(true)
-    expect(SaveItem).to receive(:call).exactly(3).and_return true
-    subject
   end
 
   it "throws an exception if a label is not found" do
     items[0][:InvalidFieldName] = "invalid value"
-    expect do
-      subject
-    end.to raise_error(ActiveRecord::UnknownAttributeError)
+    expect(subject).to include(:errors)
   end
 
   it "uses google api to retrieve the worksheet" do
@@ -65,19 +50,28 @@ RSpec.describe GoogleCreateItems, helpers: :item_meta_helpers do
     subject
   end
 
-  it "calls create! with the hash read from the worksheet" do
+  it "calls CreateItems with the hash read from the worksheet" do
     allow_any_instance_of(GoogleSession).to receive(:worksheet_to_hash).and_return([{ item: "item" }])
     creator = GoogleCreateItems.new(auth_code: param_hash[:auth_code], callback_uri: param_hash[:callback_uri])
-    expect(creator).to receive(:create!).with(hash_including(items_hash: [{ item: "item" }]))
+    expect(CreateItems).to receive(:call).with(hash_including(items_hash: [{ item: "item" }]))
     creator.create_from_worksheet!(collection_id: param_hash[:collection_id], file: param_hash[:file], sheet: param_hash[:sheet])
   end
 
   context "worksheet has items" do
+    it "injects a RewriteItemMetadata call to properly map user data to valid item data" do
+      allow_any_instance_of(GoogleSession).to receive(:worksheet_to_hash).and_return(items)
+      creator = GoogleCreateItems.new(auth_code: param_hash[:auth_code], callback_uri: param_hash[:callback_uri])
+      expect(RewriteItemMetadata).to receive(:call).with(item_hash: items[0], errors: []).and_return({})
+      expect(RewriteItemMetadata).to receive(:call).with(item_hash: items[1], errors: []).and_return({})
+      expect(RewriteItemMetadata).to receive(:call).with(item_hash: items[2], errors: []).and_return({})
+      creator.create_from_worksheet!(collection_id: param_hash[:collection_id], file: param_hash[:file], sheet: param_hash[:sheet])
+    end
+
     it "returns a hash with summary" do
       allow_any_instance_of(GoogleSession).to receive(:worksheet_to_hash).and_return(items)
       creator = GoogleCreateItems.new(auth_code: param_hash[:auth_code], callback_uri: param_hash[:callback_uri])
       results = creator.create_from_worksheet!(collection_id: param_hash[:collection_id], file: param_hash[:file], sheet: param_hash[:sheet])
-      expected = { summary: { total_count: 3, valid_count: 0, new_count: 0, error_count: 3, changed_count: 0 } }
+      expected = { summary: { total_count: 3, valid_count: 3, new_count: 3, error_count: 0, changed_count: 0, unchanged_count: 0 } }
       expect(results).to include(expected)
     end
 
@@ -94,7 +88,7 @@ RSpec.describe GoogleCreateItems, helpers: :item_meta_helpers do
       allow_any_instance_of(GoogleSession).to receive(:worksheet_to_hash).and_return([])
       creator = GoogleCreateItems.new(auth_code: param_hash[:auth_code], callback_uri: param_hash[:callback_uri])
       results = creator.create_from_worksheet!(collection_id: param_hash[:collection_id], file: param_hash[:file], sheet: param_hash[:sheet])
-      expected = { summary: { total_count: 0, valid_count: 0, new_count: 0, error_count: 0, changed_count: 0 } }
+      expected = { summary: { total_count: 0, valid_count: 0, new_count: 0, error_count: 0, changed_count: 0, unchanged_count: 0 } }
       expect(results).to include(expected)
     end
 

--- a/spec/services/rewrite_item_metadata_fields_spec.rb
+++ b/spec/services/rewrite_item_metadata_fields_spec.rb
@@ -8,22 +8,31 @@ end
 RSpec.describe RewriteItemMetadata, helpers: :item_meta_helpers do
   let(:item) { item_meta_hash(item_id: 1) }
   let(:remapped_item) { item_meta_hash_remapped(item_id: 1) }
+  let(:errors) { [] }
+  let(:subject) { described_class.call(item_hash: item, errors: errors) }
 
   it "rewrites all fields from labels to field names" do
-    expect(described_class.call(item_hash: item)).to eq(remapped_item)
+    expect(subject).to eq(remapped_item)
   end
 
   it "rewrites multiples to an array" do
     item["Alternate Name"] = "name1||name2"
     remapped_item[:alternate_name] = ["name1", "name2"]
-    expect(described_class.call(item_hash: item)).to eq(remapped_item)
+    expect(subject).to eq(remapped_item)
   end
 
   context "rewrites dates" do
     it "handles bc date" do
       item["Date Created"] = "-2001/01/01"
       remapped_item[:date_created] = { "year" => "2001", "month" => "1", "day" => "1", "bc" => true, "display_text" => nil }
-      expect(described_class.call(item_hash: item)).to eq(remapped_item)
+      expect(subject).to eq(remapped_item)
     end
+  end
+
+  it "adds to the given errors array when a label is not found" do
+    allow(Item).to receive(:method_defined?).and_return false
+    subject
+    expected = item.keys.map { |attribute| "Unknown attribute #{attribute}" }
+    expect(errors).to eq(expected)
   end
 end

--- a/spec/support/item_meta_helpers.rb
+++ b/spec/support/item_meta_helpers.rb
@@ -32,11 +32,20 @@ module ItemMetaHelpers
       user_defined_id: "id#{item_id}",
       name: "name#{item_id}",
       alternate_name: ["alternateName#{item_id}"],
-      description: "description#{item_id}",
-      date_created: { "year" => "2015", "month" => "1", "day" => "1", "bc" => false, "display_text" => nil },
       creator: ["creator#{item_id}"],
+      contributor: nil,
+      description: "description#{item_id}",
       subject: ["subject#{item_id}"],
-      original_language: ["originalLanguage#{item_id}"]
+      transcription: nil,
+      date_created: { "year" => "2015", "month" => "1", "day" => "1", "bc" => false, "display_text" => nil },
+      date_published: nil,
+      date_modified: nil,
+      original_language: ["originalLanguage#{item_id}"],
+      rights: nil,
+      call_number: nil,
+      provenance: nil,
+      publisher: nil,
+      manuscript_url: nil
     }
   end
 end


### PR DESCRIPTION
Why: Users would like imports to update existing items, not just create new ones
How: 
-Updated the services that create the items to do a find or create by user defined id and collection id. This meant having to also add a unique constraint on collection_id, user_defined_id in items since we are relying on this to uniquely identify items for imports. 
-Added an unchanged count to the summary to inform the user how many items matched up to existing records but were not changed.
