### PR TITLE
DEC-433: Add Item Bug

### DIFF
--- a/app/services/create_unique_id.rb
+++ b/app/services/create_unique_id.rb
@@ -23,7 +23,7 @@ class CreateUniqueId
   private
 
   def unique_id
-    SecureRandom.uuid
+    SecureRandom.hex(5)
   end
 
   def validate_interface!

--- a/app/services/create_user_defined_id.rb
+++ b/app/services/create_user_defined_id.rb
@@ -1,6 +1,6 @@
 require "digest/md5"
 
-class CreateUniqueId
+class CreateUserDefinedId
   attr_reader :object
 
   def self.call(object)
@@ -13,10 +13,10 @@ class CreateUniqueId
   end
 
   def create
-    if object.unique_id.nil?
-      object.unique_id = unique_id
+    if object.user_defined_id.nil?
+      object.user_defined_id = unique_id
     else
-      object.unique_id
+      object.user_defined_id
     end
   end
 
@@ -27,8 +27,8 @@ class CreateUniqueId
   end
 
   def validate_interface!
-    unless object.respond_to?("unique_id=") && object.respond_to?(:unique_id) && object.respond_to?(:save)
-      fail "Object passed to CreateUniqueId is not valid"
+    unless object.respond_to?("user_defined_id=") && object.respond_to?(:user_defined_id) && object.respond_to?(:save)
+      fail "Object passed to CreateUserDefinedId is not valid"
     end
   end
 end

--- a/app/services/save_item.rb
+++ b/app/services/save_item.rb
@@ -40,11 +40,8 @@ class SaveItem
     item.new_record? && item.name.blank?
   end
 
-  # Sets the user defined id to the unique id if none is given
   def check_user_defined_id
-    unless item.user_defined_id.present?
-      item.user_defined_id = item.unique_id
-    end
+    CreateUserDefinedId.call(item)
   end
 
   def fix_image_param!

--- a/spec/services/create_items_spec.rb
+++ b/spec/services/create_items_spec.rb
@@ -176,6 +176,9 @@ RSpec.describe CreateItems, helpers: :item_meta_helpers do
       expect(counts).to include(expected)
     end
 
-    it "returns a hash with errors"
+    it "returns a hash with errors" do
+      subject
+      expect(errors).to eq([])
+    end
   end
 end

--- a/spec/services/create_unique_id_spec.rb
+++ b/spec/services/create_unique_id_spec.rb
@@ -10,7 +10,7 @@ describe CreateUniqueId do
   end
 
   it "uses the SecureRandom lib to generate the id " do
-    expect(SecureRandom).to receive(:uuid)
+    expect(SecureRandom).to receive(:hex)
     subject.create
   end
 
@@ -20,8 +20,8 @@ describe CreateUniqueId do
   end
 
   it "returns the generated id" do
-    allow(SecureRandom).to receive(:uuid).and_return("uuid")
-    expect(subject.create).to eq("uuid")
+    allow(SecureRandom).to receive(:hex).and_return("unique_id")
+    expect(subject.create).to eq("unique_id")
   end
 
   describe "existing unique_id" do

--- a/spec/services/create_user_defined_id_spec.rb
+++ b/spec/services/create_user_defined_id_spec.rb
@@ -1,11 +1,11 @@
 require "rails_helper"
 
-describe CreateUniqueId do
+describe CreateUserDefinedId do
   subject { described_class.new(object) }
-  let(:object) { double(id: 1, class: "Class", unique_id: nil, "unique_id=" => true, save: true) }
+  let(:object) { double(id: 1, class: "Class", user_defined_id: nil, "user_defined_id=" => true, save: true) }
 
   it "generates a id" do
-    expect(object).to receive(:unique_id=).with(anything)
+    expect(object).to receive(:user_defined_id=).with(anything)
     subject.create
   end
 
@@ -15,7 +15,7 @@ describe CreateUniqueId do
   end
 
   it "sets a unique_id when it is saved and one does not exist" do
-    expect(object).to receive(:unique_id=)
+    expect(object).to receive(:user_defined_id=)
     subject.create
   end
 
@@ -26,11 +26,11 @@ describe CreateUniqueId do
 
   describe "existing unique_id" do
     before(:each) do
-      allow(object).to receive(:unique_id).and_return("1231232")
+      allow(object).to receive(:user_defined_id).and_return("1231232")
     end
 
-    it "does not set unique_id when it is saved and one exists" do
-      expect(object).to_not receive(:unique_id=)
+    it "does not set user_defined_id when it is saved and one exists" do
+      expect(object).to_not receive(:user_defined_id=)
       subject.create
     end
 


### PR DESCRIPTION
Why: We are currently unable to add more than one new item through the add items form in HoneyComb.
How:
-Problem was due to the fact that CreateUniqueId required an id for the object, which required saving the object to the database prior to calling this service class. Changed it to use SecureRandom.hex to generate a unique (enough) id, removing this dependence.
-Also changed the initial population of user_defined_id to be independent of the unique_id. It now has its own service class that generates an id using SecureRandom.hex. This one doesn't require as complex an id because it just needs to be unique within a collection.
-Also fixed a stubbed out test was that never implemented within create_items_spec and changed a few tests in save_item_spec to be more unit testish.