### PR TITLE
changed the default search response rows.

### DIFF
--- a/app/models/waggle/search/query.rb
+++ b/app/models/waggle/search/query.rb
@@ -1,7 +1,7 @@
 module Waggle
   module Search
     class Query
-      DEFAULT_ROWS = 10
+      DEFAULT_ROWS = 12
 
       attr_reader :q, :facets, :sort, :rows, :start, :filters
 


### PR DESCRIPTION
12 makes a better default number because it breaks even if there are 4, 3 and 2 results per line.

