### PR TITLE
fix bug with ruby's iso8601 parser.

### DIFF
--- a/app/models/waggle/metadata/value/date.rb
+++ b/app/models/waggle/metadata/value/date.rb
@@ -3,12 +3,6 @@ module Waggle
     module Value
       class Date < Base
         def value
-          @value ||= ::DateTime.iso8601(iso8601).utc
-        end
-
-        private
-
-        def iso8601
           fetch("iso8601")
         end
       end

--- a/spec/models/waggle/adapters/solr/index/item_spec.rb
+++ b/spec/models/waggle/adapters/solr/index/item_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Waggle::Adapters::Solr::Index::Item do
         name_t: ["pig-in-mud"],
         creator_t: ["Bob"],
         description_t: ["Source: https://pixabay.com/en/pig-sow-animal-portrait-752555/"],
-        date_published_t: ["2013-03-24T00:00:00+00:00"],
+        date_published_t: ["2013-03-24"],
         creator_facet: ["Bob"],
         name_sort: "pig-in-mud",
         creator_sort: "Bob",

--- a/spec/models/waggle/adapters/solr/index/metadata_spec.rb
+++ b/spec/models/waggle/adapters/solr/index/metadata_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Waggle::Adapters::Solr::Index::Metadata do
         name_t: ["pig-in-mud"],
         creator_t: ["Bob"],
         description_t: ["Source: https://pixabay.com/en/pig-sow-animal-portrait-752555/"],
-        date_published_t: ["2013-03-24T00:00:00+00:00"],
+        date_published_t: ["2013-03-24"],
         creator_facet: ["Bob"],
         name_sort: "pig-in-mud",
         creator_sort: "Bob",

--- a/spec/models/waggle/metadata/value/date_spec.rb
+++ b/spec/models/waggle/metadata/value/date_spec.rb
@@ -19,12 +19,12 @@ RSpec.describe Waggle::Metadata::Value::Date do
 
   describe "value" do
     it "is a datetime" do
-      expect(subject.value).to eq(DateTime.new(2013, 3, 24).utc.strftime(date_format))
+      expect(subject.value).to eq("2013-03-24")
     end
 
     it "can be in bc" do
       data["iso8601"] = "-2010-10-15"
-      expect(subject.value).to eq(DateTime.new(-2010, 10, 15).utc.strftime(date_format))
+      expect(subject.value).to eq("-2010-10-15")
     end
   end
 end


### PR DESCRIPTION
Also change the metadata date indexer to not convert an iso date to a
date so it can be converted back to iso to be indexed.