### PR TITLE
DEC-497: Export collection

### DIFF
--- a/app/assets/javascripts/components.js
+++ b/app/assets/javascripts/components.js
@@ -12,6 +12,7 @@ HorizontalScrollMixin = require("./mixins/HorizontalScrollMixin");
 MuiThemeMixin = require("./mixins/MuiThemeMixin");
 TitleConcatMixin = require("./mixins/TitleConcatMixin");
 GooglePickerMixin = require("./mixins/GooglePickerMixin");
+GoogleCreatorMixin = require("./mixins/GoogleCreatorMixin");
 
 // Page
 FlashMessage = require("./components/FlashMessage");
@@ -35,6 +36,7 @@ ReactDropzone = require("./components/ReactDropzone");
 ShowcasesPanel = require("./components/ShowcasesPanel");
 Thumbnail = require("./components/Thumbnail");
 GoogleImportButton = require("./components/GoogleImportButton");
+GoogleExportButton = require("./components/GoogleExportButton");
 
 // embed
 EmbedCode = require("./components/embed/EmbedCode");

--- a/app/assets/javascripts/components/GoogleExportButton.jsx
+++ b/app/assets/javascripts/components/GoogleExportButton.jsx
@@ -1,0 +1,65 @@
+/** @jsx React.DOM */
+var React = require('react');
+var mui = require("material-ui");
+var FlatButton = mui.FlatButton;
+var FontIcon = mui.FontIcon;
+
+var GoogleExportButton = React.createClass({
+  mixins: [MuiThemeMixin, GoogleCreatorMixin],
+
+  propTypes: {
+    collection: React.PropTypes.object.isRequired,
+  },
+
+  touchHandler: function() {
+    this.loadCreator();
+  },
+
+  getFileData: function() {
+    return {
+      fileName: "Export of " + this.props.collection.name_line_1 + " " + (new Date()).toLocaleString(),
+      mimeType: "application/vnd.google-apps.spreadsheet"
+    }
+  },
+
+  fileCreated: function(data) {
+    var fileId = data.alternateLink;
+
+    $.ajax({
+      url: this.props.authUri,
+      dataType: "json",
+      data: {
+        file_name: fileId,
+        sheet_name: ""
+      },
+      method: "POST",
+      success: (function(data, textStatus) {
+        window.open(data.auth_uri, '_blank');
+      }),
+      error: (function(xhr) {
+        alert(xhr);
+      })
+    });
+  },
+
+  render: function() {
+    var iconStyle = {fontSize: 14, marginRight: ".5em"};
+    var buttonLabel = (
+      <span>
+        <FontIcon className="glyphicon glyphicon-plus" label="Download" color="#000" style={iconStyle}/>
+        <span>Export Metadata</span>
+      </span>
+    );
+    return (
+      <div>
+        <FlatButton
+          primary={false}
+          onTouchTap={this.touchHandler}
+          label={buttonLabel}
+        />
+      </div>
+    );
+  }
+});
+
+module.exports = GoogleExportButton;

--- a/app/assets/javascripts/components/GoogleExportButton.jsx
+++ b/app/assets/javascripts/components/GoogleExportButton.jsx
@@ -46,7 +46,7 @@ var GoogleExportButton = React.createClass({
     var iconStyle = {fontSize: 14, marginRight: ".5em"};
     var buttonLabel = (
       <span>
-        <FontIcon className="glyphicon glyphicon-plus" label="Download" color="#000" style={iconStyle}/>
+        <FontIcon className="glyphicon glyphicon-export" label="Download" color="#000" style={iconStyle}/>
         <span>Export Metadata</span>
       </span>
     );

--- a/app/assets/javascripts/components/GoogleImportButton.jsx
+++ b/app/assets/javascripts/components/GoogleImportButton.jsx
@@ -11,7 +11,7 @@ var GoogleImportButton = React.createClass({
     var iconStyle = {fontSize: 14, marginRight: ".5em"};
     var buttonLabel = (
       <span>
-        <FontIcon className="glyphicon glyphicon-plus" label="Upload" color="#000" style={iconStyle}/>
+        <FontIcon className="glyphicon glyphicon-import" label="Upload" color="#000" style={iconStyle}/>
         <span>Import Metadata</span>
       </span>
     );

--- a/app/assets/javascripts/mixins/GoogleCreatorMixin.jsx
+++ b/app/assets/javascripts/mixins/GoogleCreatorMixin.jsx
@@ -1,0 +1,76 @@
+// Requires the following within the page that uses this mixin:
+//  <script type="text/javascript" src="https://apis.google.com/js/api.js"></script>
+//
+
+var GoogleCreatorMixin = {
+  propTypes: {
+    developerKey: React.PropTypes.string.isRequired,
+    clientId: React.PropTypes.string.isRequired,
+    appId: React.PropTypes.string.isRequired,
+    authUri: React.PropTypes.string.isRequired,
+  },
+
+  oauthToken: null,
+
+  clientApiLoaded: false,
+
+  loadCreator: function() {
+    if(this.clientApiLoaded && this.oauthToken){
+      this.createFile(this.fileCreated);
+    } else {
+      gapi.load("auth", {"callback": this.onAuthApiLoad});
+      gapi.load("client", {"callback": this.onClientApiLoad});
+    }
+  },
+
+  onClientApiLoad: function() {
+    this.clientApiLoaded = true;
+    this.createFile(this.fileCreated);
+  },
+
+  onAuthApiLoad: function() {
+    gapi.auth.init(this.onAuthApiInit);
+  },
+
+  onAuthApiInit: function(clientId) {
+    window.gapi.auth.authorize(
+      {
+        "client_id": this.props.clientId,
+        "scope": "https://www.googleapis.com/auth/drive.file",
+        "hd": "nd.edu"
+      },
+      this.handleAuthResult);
+  },
+
+  handleAuthResult: function(authResult) {
+    if (authResult && !authResult.error) {
+      this.oauthToken = authResult.access_token;
+      this.createFile(this.fileCreated);
+    }
+  },
+
+  createFile: function(callback) {
+    if(this.clientApiLoaded && this.oauthToken){
+      const boundary = 'foo_bar_baz';
+      const delimiter = "\r\n--" + boundary + "\r\n";
+      const close_delim = "\r\n--" + boundary + "--";
+
+      var fileData = this.getFileData();
+
+      var metadata = {
+        'title': fileData.fileName,
+        'mimeType': fileData.mimeType
+      };
+
+      var request = gapi.client.request({
+          'path': 'drive/v2/files',
+          'method': 'POST',
+          'params': {},
+          'headers': {},
+          'body': metadata});
+      request.execute(callback);
+    }
+  },
+};
+
+module.exports = GoogleCreatorMixin;

--- a/app/controllers/export_controller.rb
+++ b/app/controllers/export_controller.rb
@@ -1,10 +1,10 @@
-class ImportController < ApplicationController
+class ExportController < ApplicationController
   # Constructs an auth request to google. Packs the collection id, file, and sheet
   # into state data so that this data persists the round trip.
-  def get_google_import_authorization_uri
+  def get_google_export_authorization_uri
     session = GoogleSession.new
     authorization_uri = session.auth_request_uri(
-      callback_uri: import_google_sheet_callback_collections_url,
+      callback_uri: export_google_sheet_callback_collections_url,
       state_hash: {
         collection_id: params[:id],
         file: params[:file_name],
@@ -16,16 +16,18 @@ class ImportController < ApplicationController
   # This should get called whenever google redirects after a successful authorization request.
   # We'll get an authorization code in the params and use this to make the connection
   # to google to read the sheet data
-  def import_google_sheet_callback
+  def export_google_sheet_callback # rubocop:disable Metrics/AbcSize
     state_hash = decode_state(state_hash: params[:state])
     @collection = CollectionQuery.new.find(state_hash[:collection_id])
     check_user_edits!(@collection)
 
-    @results = GoogleCreateItems.call(auth_code: params[:code],
-                                      callback_uri: import_google_sheet_callback_collections_url,
-                                      collection_id: state_hash[:collection_id],
-                                      file: state_hash[:file],
-                                      sheet: state_hash[:sheet])
+    target_file = state_hash[:file]
+    GoogleExportItems.call(auth_code: params[:code],
+                           callback_uri: export_google_sheet_callback_collections_url,
+                           items: @collection.items,
+                           file: target_file,
+                           sheet: state_hash[:sheet])
+    redirect_to target_file
   end
 
   def decode_state(state_hash:)

--- a/app/models/metadata/configuration.rb
+++ b/app/models/metadata/configuration.rb
@@ -64,6 +64,10 @@ module Metadata
       field_map.keys
     end
 
+    def field_labels
+      field_map.map { |_key, value| value.label }
+    end
+
     private
 
     def field_map

--- a/app/services/google_export_items.rb
+++ b/app/services/google_export_items.rb
@@ -1,0 +1,40 @@
+# Performs batch export of items to a google doc
+# Assumes you have a valid auth token to access the doc
+class GoogleExportItems
+  attr_reader :session
+
+  # Simplified call to create_from_worksheet!
+  def self.call(auth_code:, callback_uri:, items:, file:, sheet:)
+    instance = new(auth_code: auth_code, callback_uri: callback_uri)
+    instance.export_to_worksheet!(items: items, file: file, sheet: sheet)
+  end
+
+  def initialize(auth_code:, callback_uri:)
+    @session = GoogleSession.new
+    session.connect(auth_code: auth_code, callback_uri: callback_uri)
+  end
+
+  def export_to_worksheet!(items:, file:, sheet:)
+    worksheet = session.get_worksheet(file: file, sheet: sheet)
+    if worksheet.present?
+      item_hashes = items.map do |item|
+        RewriteItemMetadataForExport.call(item_hash: item_hash(item: item))
+      end
+      session.hashes_to_worksheet(worksheet: worksheet, hashes: item_hashes)
+    end
+  end
+
+  private
+
+  def item_hash(item:)
+    item_fields =
+      {
+        user_defined_id: item.user_defined_id,
+        name: item.name,
+        description: item.description,
+        manuscript_url: item.manuscript_url,
+        transcription: item.transcription
+      }
+    item_fields.merge(item.metadata)
+  end
+end

--- a/app/services/google_session.rb
+++ b/app/services/google_session.rb
@@ -63,4 +63,33 @@ class GoogleSession
     end
     results
   end
+
+  # Populates a worksheet with an array of hashes where the hash keys are
+  # used as the column names
+  def hashes_to_worksheet(worksheet:, hashes:)
+    header_row = []
+    rows = [header_row]
+    hashes.each do |hash|
+      # See if this hash has any new columns. If so, append it to the end
+      hash.keys.each do |key|
+        unless header_row.include?(key)
+          header_row << key
+        end
+      end
+
+      # Populate the row with values based on the order of the header row
+      row = []
+      header_row.each do |header|
+        if hash.include?(header)
+          row << hash[header]
+        else
+          row << ""
+        end
+      end
+      rows << row
+    end
+    rows[0] = header_row
+    worksheet.update_cells(1, 1, rows)
+    worksheet.save
+  end
 end

--- a/app/services/rewrite_item_metadata.rb
+++ b/app/services/rewrite_item_metadata.rb
@@ -5,7 +5,7 @@ class RewriteItemMetadata
 
   def initialize
     @configuration = Metadata::Configuration.item_configuration
-    @field_map = Hash[Metadata::Configuration.item_configuration.field_names.map { |name| [name, nil] }]
+    @field_map = Hash[configuration.field_names.map { |name| [name, nil] }]
   end
 
   def self.call(item_hash:, errors:)
@@ -34,7 +34,9 @@ class RewriteItemMetadata
     if configuration.label?(key)
       field = configuration.label(key)
       result.key = field.name
-      rewrite_values(field: field, pair: result)
+      if result.value.present?
+        rewrite_values(field: field, pair: result)
+      end
     end
     result
   end

--- a/app/services/rewrite_item_metadata_for_export.rb
+++ b/app/services/rewrite_item_metadata_for_export.rb
@@ -1,0 +1,50 @@
+# Translates a hash of Item properties to their common property names
+class RewriteItemMetadataForExport
+  attr_reader :configuration, :label_map
+  private :configuration, :label_map
+
+  def initialize
+    @configuration = Metadata::Configuration.item_configuration
+    @label_map = Hash[configuration.field_labels.map { |name| [name, nil] }]
+  end
+
+  def self.call(item_hash:)
+    new.rewrite(item_hash: item_hash)
+  end
+
+  def rewrite(item_hash:)
+    result = Hash.new
+    item_hash.each do |k, v|
+      new_pair = rewrite_pair(key: k, value: v)
+      result[new_pair.key] = new_pair.value
+    end
+    label_map.merge!(result)
+  end
+
+  private
+
+  # Maps labels to field names and rewrites some value types
+  # such as multiple value fields and date fields
+  def rewrite_pair(key:, value:)
+    key = key.to_sym
+    result = OpenStruct.new(key: key, value: value)
+    if configuration.field?(key)
+      field = configuration.field(key)
+      result.key = field.label
+      if result.value.present?
+        rewrite_values(field: field, pair: result)
+      end
+    end
+    result
+  end
+
+  def rewrite_values(field:, pair:)
+    if field.multiple
+      pair.value = pair.value.join("||")
+    end
+
+    if field.type == :date
+      pair.value = "'" + MetadataDate.from_hash(pair.value).to_string
+    end
+  end
+end

--- a/app/validators/date_validator.rb
+++ b/app/validators/date_validator.rb
@@ -1,7 +1,7 @@
 # Validator to make sure submitted date is correctly formatted
 class DateValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    return if !value
+    return if !value.present?
 
     date = MetadataDate.new(value.symbolize_keys)
     if !date.valid?

--- a/app/values/metadata_date.rb
+++ b/app/values/metadata_date.rb
@@ -59,6 +59,16 @@ class MetadataDate
     }.stringify_keys
   end
 
+  def to_string
+    result = ""
+    result << "-" if bc?
+    result << year.to_s.rjust(4, "0") if year.present?
+    result << "/#{month.to_s.rjust(2, "0")}" if month.present?
+    result << "/#{day.to_s.rjust(2, "0")}" if day.present?
+    result << ":#{display_text}" if display_text.present?
+    result
+  end
+
   def self.parse(string)
     date_and_display = string.split(":")
     if date_and_display.length > 0
@@ -82,7 +92,7 @@ class MetadataDate
   def self.parse_date(value:)
     date_array = value.split("/")
     {
-      year: date_array.length >= 1 ? date_array[0].to_i : nil,
+      year: date_array.length >= 1 ? date_array[0].tr("'", "").to_i : nil,
       month: date_array.length > 1 ? date_array[1].to_i : nil,
       day: date_array.length > 2 ? date_array[2].to_i : nil
     }

--- a/app/values/metadata_date.rb
+++ b/app/values/metadata_date.rb
@@ -59,12 +59,12 @@ class MetadataDate
     }.stringify_keys
   end
 
-  def to_string
+  def to_string # rubocop:disable Metrics/AbcSize
     result = ""
     result << "-" if bc?
     result << year.to_s.rjust(4, "0") if year.present?
-    result << "/#{month.to_s.rjust(2, "0")}" if month.present?
-    result << "/#{day.to_s.rjust(2, "0")}" if day.present?
+    result << "/#{month.to_s.rjust(2, '0')}" if month.present?
+    result << "/#{day.to_s.rjust(2, '0')}" if day.present?
     result << ":#{display_text}" if display_text.present?
     result
   end

--- a/app/views/items/_action_bar.html.erb
+++ b/app/views/items/_action_bar.html.erb
@@ -24,7 +24,16 @@
         developerKey: Rails.application.secrets.google["developer_key"],
         clientId: Rails.application.secrets.google["client_id"],
         appId: Rails.application.secrets.google["app_id"],
-        authUri: get_google_authorization_uri_collection_path(@collection)
+        authUri: get_google_import_authorization_uri_collection_path(@collection)
+      }) %>
+    </div>
+    <div style="float: left">
+      <%= react_component("GoogleExportButton", {
+        developerKey: Rails.application.secrets.google["developer_key"],
+        clientId: Rails.application.secrets.google["client_id"],
+        appId: Rails.application.secrets.google["app_id"],
+        authUri: get_google_export_authorization_uri_collection_path(@collection),
+        collection: @collection
       }) %>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,12 +19,14 @@ Rails.application.routes.draw do
 
     collection do
       get :import_google_sheet_callback, controller: "import"
+      get :export_google_sheet_callback, controller: "export"
     end
 
     member do
       put :publish
       put :unpublish
-      post :get_google_authorization_uri, controller: "import"
+      post :get_google_import_authorization_uri, controller: "import"
+      post :get_google_export_authorization_uri, controller: "export"
     end
 
     resources :items, only: [:index, :new, :create]

--- a/spec/controllers/export_controller_spec.rb
+++ b/spec/controllers/export_controller_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 require "cache_spec_helper"
 
-RSpec.describe ImportController, type: :controller do
+RSpec.describe ExportController, type: :controller do
   let(:collection) { instance_double(Collection, id: 1, name_line_1: "COLLECTION", destroy!: true, collection_users: [], exhibit: nil, items: []) }
 
   before(:each) do
@@ -11,32 +11,32 @@ RSpec.describe ImportController, type: :controller do
 
   describe "get_authorization_uri" do
     let(:state_hash) { { collection_id: "1", file: "test.file", sheet: "test.sheet" } }
-    let(:param_hash) { { callback_uri: import_google_sheet_callback_collections_url, state_hash: state_hash } }
+    let(:param_hash) { { callback_uri: export_google_sheet_callback_collections_url, state_hash: state_hash } }
 
     it "uses google api to request an auth uri" do
       expect_any_instance_of(GoogleSession).to receive(:auth_request_uri).with(hash_including(param_hash))
-      post :get_google_import_authorization_uri, id: 1, file_name: state_hash[:file], sheet_name: state_hash[:sheet]
+      post :get_google_export_authorization_uri, id: 1, file_name: state_hash[:file], sheet_name: state_hash[:sheet]
     end
 
     it "renders a json with the auth_uri" do
-      get :get_google_import_authorization_uri, id: 1, file_name: "test.file", sheet_name: "test.sheet"
+      get :get_google_export_authorization_uri, id: 1, file_name: "test.file", sheet_name: "test.sheet"
       expect(JSON.parse(response.body)).to include("auth_uri")
     end
   end
 
   describe "import_google_sheet_callback" do
     let(:state_hash) { { collection_id: "1", file: "test.file", sheet: "test.sheet" } }
-    let(:param_hash) { { auth_code: "auth", callback_uri: import_google_sheet_callback_collections_url } }
+    let(:param_hash) { { auth_code: "auth", callback_uri: export_google_sheet_callback_collections_url } }
     let(:encoded_state_hash) { Base64::encode64(state_hash.to_json) }
-    let(:subject) { get :import_google_sheet_callback, state: encoded_state_hash, code: "auth" }
+    let(:subject) { get :export_google_sheet_callback, state: encoded_state_hash, code: "auth" }
 
-    it "calls GoogleCreateItems using the given params" do
-      expect(GoogleCreateItems).to receive(:call).with(hash_including(param_hash))
+    it "calls GoogleExportItems using the given params" do
+      expect(GoogleExportItems).to receive(:call).with(hash_including(param_hash))
       subject
     end
 
     it "checks the editor permissions" do
-      allow(GoogleCreateItems).to receive(:call).with(hash_including(param_hash))
+      allow(GoogleExportItems).to receive(:call).with(hash_including(param_hash))
       expect_any_instance_of(described_class).to receive(:check_user_edits!).with(collection)
       subject
     end
@@ -44,9 +44,9 @@ RSpec.describe ImportController, type: :controller do
 
   describe "decode_state" do
     let(:state_hash) { { collection_id: "1", file: "test.file", sheet: "test.sheet" } }
-    let(:param_hash) { { auth_code: "auth", callback_uri: import_google_sheet_callback_collections_url } }
+    let(:param_hash) { { auth_code: "auth", callback_uri: export_google_sheet_callback_collections_url } }
     let(:encoded_state_hash) { Base64::encode64(state_hash.to_json) }
-    let(:subject) { ImportController.new }
+    let(:subject) { ExportController.new }
 
     it "properly decodes the state" do
       expect(subject.decode_state(state_hash: encoded_state_hash)).to eq(state_hash)

--- a/spec/models/metadata/configuration_spec.rb
+++ b/spec/models/metadata/configuration_spec.rb
@@ -58,6 +58,12 @@ RSpec.describe Metadata::Configuration do
     end
   end
 
+  describe "field_labels" do
+    it "returns an array of field labels" do
+      expect(subject.field_labels).to eq(data[:fields].map { |f| f[:label] })
+    end
+  end
+
   describe "label" do
     it "finds a field by its label" do
       field = subject.label("String")

--- a/spec/services/google_export_items_spec.rb
+++ b/spec/services/google_export_items_spec.rb
@@ -1,0 +1,75 @@
+require "rails_helper"
+require "support/item_meta_helpers"
+
+RSpec.configure do |c|
+  c.include ItemMetaHelpers, helpers: :item_meta_helpers
+end
+
+RSpec.describe GoogleExportItems, helpers: :item_meta_helpers do
+  let(:items) do
+    [
+      instance_double(Item, metadata: item_meta_hash_remapped(item_id: 1), **item_meta_hash_remapped(item_id: 1)),
+      instance_double(Item, metadata: item_meta_hash_remapped(item_id: 2), **item_meta_hash_remapped(item_id: 2)),
+      instance_double(Item, metadata: item_meta_hash_remapped(item_id: 3), **item_meta_hash_remapped(item_id: 3)),
+    ]
+  end
+  let(:item_label_hashes) do
+    [
+      item_meta_hash_remapped_to_labels(item_id: 1),
+      item_meta_hash_remapped_to_labels(item_id: 2),
+      item_meta_hash_remapped_to_labels(item_id: 3)
+    ]
+  end
+  let(:item_hashes) do
+    [
+      item_meta_hash_remapped(item_id: 1),
+      item_meta_hash_remapped(item_id: 2),
+      item_meta_hash_remapped(item_id: 3),
+    ]
+  end
+  let(:errors) { instance_double(ActiveModel::Errors, full_messages: []) }
+  let(:item) { instance_double(Item, valid?: true, changed?: false, new_record?: false, errors: errors, validate: true) }
+  let(:item_creator) { instance_double(FindOrCreateItem, using: item, save: true, new_record?: true, item: item) }
+  let(:worksheet) { instance_double(GoogleDrive::Worksheet, update_cells: true, save: true) }
+  let(:param_hash) { { auth_code: "auth", callback_uri: "callback", items: items, file: "file", sheet: "sheet" } }
+  let(:subject) { described_class.call(param_hash) }
+
+  before (:each) do
+    allow_any_instance_of(GoogleSession).to receive(:connect)
+    allow_any_instance_of(GoogleSession).to receive(:get_worksheet).and_return(worksheet)
+  end
+
+  it "uses google api to retrieve the worksheet" do
+    expect_any_instance_of(GoogleSession).to receive(:get_worksheet).with(file: param_hash[:file], sheet: param_hash[:sheet]).and_return(worksheet)
+    subject
+  end
+
+  context "collection has items" do
+    it "uses GoogleSession to populate the worksheet" do
+      expect_any_instance_of(GoogleSession).to receive(:hashes_to_worksheet).with(worksheet: worksheet, hashes: item_label_hashes)
+      subject
+    end
+
+    it "calls RewriteItemMetadataForExport for each item" do
+      allow_any_instance_of(GoogleSession).to receive(:hashes_to_worksheet).and_return(true)
+      expect(RewriteItemMetadataForExport).to receive(:call).exactly(items.count)
+      subject
+    end
+
+    it "calls RewriteItemMetadataForExport with the correct item hashes" do
+      allow_any_instance_of(GoogleSession).to receive(:hashes_to_worksheet).and_return(true)
+      expect(RewriteItemMetadataForExport).to receive(:call).with(item_hash: item_meta_hash_remapped(item_id: 1))
+      expect(RewriteItemMetadataForExport).to receive(:call).with(item_hash: item_meta_hash_remapped(item_id: 2))
+      expect(RewriteItemMetadataForExport).to receive(:call).with(item_hash: item_meta_hash_remapped(item_id: 3))
+      subject
+    end
+  end
+
+  context "collection has no items" do
+    let(:items) { [] }
+    it "calls GoogleSession to populate the worksheet" do
+      expect_any_instance_of(GoogleSession).to receive(:hashes_to_worksheet).with(worksheet: worksheet, hashes: [])
+      subject
+    end
+  end
+end

--- a/spec/services/rewrite_item_metadata_fields_spec.rb
+++ b/spec/services/rewrite_item_metadata_fields_spec.rb
@@ -27,6 +27,12 @@ RSpec.describe RewriteItemMetadata, helpers: :item_meta_helpers do
       remapped_item[:date_created] = { "year" => "2001", "month" => "1", "day" => "1", "bc" => true, "display_text" => nil }
       expect(subject).to eq(remapped_item)
     end
+
+    it "can handle string literal indicator" do
+      item["Date Created"] = "'-2001/01/01"
+      remapped_item[:date_created] = { "year" => "2001", "month" => "1", "day" => "1", "bc" => true, "display_text" => nil }
+      expect(subject).to eq(remapped_item)
+    end
   end
 
   it "adds to the given errors array when a label is not found" do

--- a/spec/services/rewrite_item_metadata_for_export_spec.rb
+++ b/spec/services/rewrite_item_metadata_for_export_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+require "support/item_meta_helpers"
+
+RSpec.configure do |c|
+  c.include ItemMetaHelpers, helpers: :item_meta_helpers
+end
+
+RSpec.describe RewriteItemMetadataForExport, helpers: :item_meta_helpers do
+  let(:item) { item_meta_hash_field_names(item_id: 1) }
+  let(:remapped_item) { item_meta_hash_remapped_to_labels(item_id: 1) }
+  let(:subject) { described_class.call(item_hash: item) }
+
+  it "rewrites all fields from labels to field names" do
+    expect(subject).to eq(remapped_item)
+  end
+
+  it "rewrites multiples to an array" do
+    remapped_item["Alternate Name"] = "name1||name2"
+    item[:alternate_name] = ["name1", "name2"]
+    expect(subject).to eq(remapped_item)
+  end
+
+  context "rewrites dates" do
+    it "handles bc date" do
+      remapped_item["Date Created"] = "'-2001/01/01"
+      item[:date_created] = { "year" => "2001", "month" => "1", "day" => "1", "bc" => true, "display_text" => nil }
+      expect(subject).to eq(remapped_item)
+    end
+
+    it "adds a string literal indicator" do
+      remapped_item["Date Created"] = "'"
+      item[:date_created] = { "year" => "", "month" => "", "day" => "", "bc" => false, "display_text" => nil }
+      expect(subject).to eq(remapped_item)
+    end
+  end
+end

--- a/spec/support/item_meta_helpers.rb
+++ b/spec/support/item_meta_helpers.rb
@@ -5,7 +5,7 @@ module ItemMetaHelpers
       "name#{item_id}",
       "alternateName#{item_id}",
       "description#{item_id}",
-      "2015/01/01",
+      "'2015/01/01",
       # { year: item_id, month: nil, day: nil, bc: nil, display_text: "dateCreated#{item_id}" }
       "creator#{item_id}",
       "subject#{item_id}",
@@ -13,13 +13,14 @@ module ItemMetaHelpers
     ]
   end
 
+  # An example meta hash using labels
   def item_meta_hash(item_id:)
     {
       "Identifier" => "id#{item_id}",
       "Name" => "name#{item_id}",
       "Alternate Name" => "alternateName#{item_id}",
       "Description" => "description#{item_id}",
-      "Date Created" => "2015/01/01",
+      "Date Created" => "'2015/01/01",
       # dateCreated: { year: item_id, month: nil, day: nil, bc: nil, display_text: "dateCreated#{item_id}" },
       "Creator" => "creator#{item_id}",
       "Subject" => "subject#{item_id}",
@@ -27,6 +28,21 @@ module ItemMetaHelpers
     }
   end
 
+  # An example meta hash using field names
+  def item_meta_hash_field_names(item_id:)
+    {
+      user_defined_id: "id#{item_id}",
+      name: "name#{item_id}",
+      alternate_name: ["alternateName#{item_id}"],
+      creator: ["creator#{item_id}"],
+      description: "description#{item_id}",
+      subject: ["subject#{item_id}"],
+      date_created: { "year" => "2015", "month" => "1", "day" => "1", "bc" => false, "display_text" => nil },
+      original_language: ["originalLanguage#{item_id}"],
+    }
+  end
+
+  # Remapped to all field names
   def item_meta_hash_remapped(item_id:)
     {
       user_defined_id: "id#{item_id}",
@@ -46,6 +62,28 @@ module ItemMetaHelpers
       provenance: nil,
       publisher: nil,
       manuscript_url: nil
+    }
+  end
+
+  def item_meta_hash_remapped_to_labels(item_id:)
+    {
+      "Identifier" => "id#{item_id}",
+      "Name" => "name#{item_id}",
+      "Alternate Name" => "alternateName#{item_id}",
+      "Creator" => "creator#{item_id}",
+      "Contributor" => nil,
+      "Description" => "description#{item_id}",
+      "Subject" => "subject#{item_id}",
+      "Transcription" => nil,
+      "Date Created" => "'2015/01/01",
+      "Date Published" => nil,
+      "Date Modified" => nil,
+      "Original Language" => "originalLanguage#{item_id}",
+      "Rights" => nil,
+      "Call Number" => nil,
+      "Provenance" => nil,
+      "Publisher" => nil,
+      "Digitized Manuscript" => nil
     }
   end
 end

--- a/spec/values/metadata_date_spec.rb
+++ b/spec/values/metadata_date_spec.rb
@@ -203,6 +203,15 @@ RSpec.describe MetadataDate do
   end
 
   describe "parse" do
+    it "handles leading string literal character" do
+      date = MetadataDate.parse("'2001/01/01:display this instead")
+      expect(date.year).to eq("2001")
+      expect(date.month).to eq("1")
+      expect(date.day).to eq("1")
+      expect(date.bc).to eq(false)
+      expect(date.display_text).to eq("display this instead")
+    end
+
     context "with display text" do
       it "gets display text if given with a :" do
         date = MetadataDate.parse("2001/01/01:display this instead")
@@ -313,6 +322,33 @@ RSpec.describe MetadataDate do
         date = MetadataDate.parse("100")
         expect(date.day).to eq(nil)
       end
+    end
+  end
+
+  describe "to_string" do
+    it "adds :display_text when available" do
+      date = MetadataDate.new(year: "2001", month: nil, day: nil, bc: false, display_text: "display this instead")
+      expect(date.to_string).to eq("2001:display this instead")
+    end
+
+    it "adds the year when available" do
+      date = MetadataDate.new(year: "2001", month: nil, day: nil, bc: false, display_text: nil)
+      expect(date.to_string).to eq("2001")
+    end
+
+    it "adds the month when available" do
+      date = MetadataDate.new(year: "2001", month: "01", day: nil, bc: false, display_text: nil)
+      expect(date.to_string).to eq("2001/01")
+    end
+
+    it "adds the day when available" do
+      date = MetadataDate.new(year: "2001", month: "01", day: "02", bc: false, display_text: nil)
+      expect(date.to_string).to eq("2001/01/02")
+    end
+
+    it "adds - to bc dates when available" do
+      date = MetadataDate.new(year: "2001", month: nil, day: nil, bc: true, display_text: nil)
+      expect(date.to_string).to eq("-2001")
     end
   end
 end


### PR DESCRIPTION
Why: User needs a way to export a collection to a Google spreadsheet in the correct format
How: Added client side code that creates the spreadsheet then requests an auth token for access to the new sheet that the server can use to populate the data. Added routes/methods server side to export item data for a collection using the auth token and worksheet provided by the client. Once the export is complete the server will redirect the user to the new sheet.

Note: The google api does not currently allow programmatically setting a cells format. Because of this, by default, it will attempt to translate dates into a new format which will cause problems when reimporting. For the time being I'm using the old string literal trick (which google supports in its sheets) by prepending the value with a ' character. I don't *really* like this solution because it's known to cause problems for users who want to do additional processing with their data. In the future, we may want to just separate the date fields into separate columns, but this would be a fairly big change to both export and import so I want to try this simple method first.