### PR TITLE
Add additional type designation in V1 output for collections

### DIFF
--- a/app/decorators/v1/collection_json_decorator.rb
+++ b/app/decorators/v1/collection_json_decorator.rb
@@ -27,6 +27,10 @@ module V1
       object.exhibit.url ? object.exhibit.url : ""
     end
 
+    def additional_type
+      object.exhibit.url ? "https://github.com/ndlib/honeycomb/wiki/ExternalCollection": "https://github.com/ndlib/honeycomb/wiki/DecCollection"
+    end
+
     def description
       object.description.to_s
     end

--- a/app/decorators/v1/collection_json_decorator.rb
+++ b/app/decorators/v1/collection_json_decorator.rb
@@ -28,7 +28,7 @@ module V1
     end
 
     def additional_type
-      object.exhibit.url ? "https://github.com/ndlib/honeycomb/wiki/ExternalCollection": "https://github.com/ndlib/honeycomb/wiki/DecCollection"
+      object.exhibit.url ? "https://github.com/ndlib/honeycomb/wiki/ExternalCollection" : "https://github.com/ndlib/honeycomb/wiki/DecCollection"
     end
 
     def description

--- a/app/views/v1/collections/_collection.json.jbuilder
+++ b/app/views/v1/collections/_collection.json.jbuilder
@@ -1,6 +1,7 @@
-json.set! "@context", "http://schema.org"
-json.set! "@type", "CreativeWork"
+json.set! "@context", "http://bib.schema.org"
+json.set! "@type", "Collection"
 json.set! "@id", collection_object.at_id
+json.set! "additionalType", collection_object.additional_type
 json.set! "hasPart/items", collection_object.items_url
 json.set! "hasPart/showcases", collection_object.showcases_url
 json.set! "hasPart/metadataConfiguration", collection_object.metadata_configuration_url

--- a/spec/decorators/v1/collection_json_decorator_spec.rb
+++ b/spec/decorators/v1/collection_json_decorator_spec.rb
@@ -185,6 +185,26 @@ RSpec.describe V1::CollectionJSONDecorator do
     end
   end
 
+  describe "#additional_type" do
+    context "when exhibit url is populated" do
+      let(:exhibit) { double(Exhibit, url: "http://nosite.com") }
+      let(:collection) { double(Collection, exhibit: exhibit) }
+
+      it "returns link to ExternalCollection definition" do
+        expect(subject.additional_type).to eq "https://github.com/ndlib/honeycomb/wiki/ExternalCollection"
+      end
+    end
+
+    context "when exibit url is nil" do
+      let(:exhibit) { double(Exhibit, url: nil) }
+      let(:collection) { double(Collection, exhibit: exhibit) }
+
+      it "returns link to DecCollection definition" do
+        expect(subject.additional_type).to eq "https://github.com/ndlib/honeycomb/wiki/DecCollection"
+      end
+    end
+  end
+
   describe "#slug" do
     let(:collection) { double(Collection, name_line_1: "sluggish") }
 


### PR DESCRIPTION
**What** Added additional type designation for collections output via the V1 API. Schema.org allows for an "additionalType" field which is typed as a URL. I also added definitions for the two new sub-types on the honeycomb wiki. I modified the parent context for collections to be "bib.schema.org" and changed the type to "Collection".

**Why** This gives the API consumer a way to easily identify what type of collection is being output. The "Collection" type, which is a sub-type of "CreativeWork" is also more appropriate for the type of things being output via the API in aggregate.

**What** Added a new method to the collection decorator, unit tests, and modified the jbuilder file as outlined above.