### PR TITLE
Import incorrectly showing updates

### DIFF
--- a/app/decorators/item_decorator.rb
+++ b/app/decorators/item_decorator.rb
@@ -60,24 +60,7 @@ class ItemDecorator < Draper::Decorator
 
   def meta_data
     data = {}
-    [
-      :name,
-      :description,
-      :transcription,
-      :manuscript_url,
-      :creator,
-      :contributor,
-      :subject,
-      :publisher,
-      :alternate_name,
-      :rights,
-      :call_number,
-      :provenance,
-      :original_language,
-      :date_created,
-      :date_published,
-      :date_modified,
-    ].each do |key|
+    Metadata::Configuration.item_configuration.field_names.each do |key|
       value = object.send(key)
       if !value.nil?
         data[key] = value

--- a/app/decorators/item_decorator.rb
+++ b/app/decorators/item_decorator.rb
@@ -55,24 +55,35 @@ class ItemDecorator < Draper::Decorator
       authenticityToken: h.form_authenticity_token,
       url: h.v1_item_path(object.unique_id),
       method: "put",
-      data: {
-        name: object.name,
-        description: object.description,
-        transcription: object.transcription,
-        manuscript_url: object.manuscript_url,
-        creator: object.creator,
-        contributor: object.contributor,
-        subject: object.subject,
-        publisher: object.publisher,
-        alternate_name: object.alternate_name,
-        rights: object.rights,
-        call_number: object.call_number,
-        provenance: object.provenance,
-        original_language: object.original_language,
-        date_created: object.date_created,
-        date_published: object.date_published,
-        date_modified: object.date_modified,
-      })
+      data: meta_data)
+  end
+
+  def meta_data
+    data = {}
+    [
+      :name,
+      :description,
+      :transcription,
+      :manuscript_url,
+      :creator,
+      :contributor,
+      :subject,
+      :publisher,
+      :alternate_name,
+      :rights,
+      :call_number,
+      :provenance,
+      :original_language,
+      :date_created,
+      :date_published,
+      :date_modified,
+    ].each do |key|
+      value = object.send(key)
+      if !value.nil?
+        data[key] = value
+      end
+    end
+    data
   end
 
   def showcases_json

--- a/app/services/param_cleaner.rb
+++ b/app/services/param_cleaner.rb
@@ -1,0 +1,32 @@
+class ParamCleaner
+  # Transforms all values recursively using the map below:
+  # "true"  => true
+  # "false" => false
+  # ""      => nil
+  def self.call(hash:)
+    transform_values_recursively!(hash: hash) do |value|
+      case value
+      when "true"
+        true
+      when "false"
+        false
+      when ""
+        nil
+      else
+        value
+      end
+    end
+  end
+
+  # Similar to built-in Hash.transform_values! except it will transform it recursively
+  # for nested hashes
+  def self.transform_values_recursively!(hash:)
+    hash.each_pair do |key, value|
+      if value.respond_to?(:each_pair) && value.respond_to?("[]")
+        hash[key] = transform_values_recursively!(hash: value) { |v| yield(v) }
+      else
+        hash[key] = yield(value)
+      end
+    end
+  end
+end

--- a/app/services/save_item.rb
+++ b/app/services/save_item.rb
@@ -11,8 +11,7 @@ class SaveItem
   end
 
   def save
-    fix_image_param!
-
+    fix_params
     item.attributes = params
     pre_process_name
     check_unique_id
@@ -27,6 +26,11 @@ class SaveItem
   end
 
   private
+
+  def fix_params
+    fix_image_param!
+    ParamCleaner.call(hash: params)
+  end
 
   def pre_process_name
     if name_should_be_filename?

--- a/spec/decorators/item_decorator_spec.rb
+++ b/spec/decorators/item_decorator_spec.rb
@@ -65,7 +65,8 @@ RSpec.describe ItemDecorator do
         provenance: "provenance",
         date_created: "date_created",
         date_modified: "date_modified",
-        date_published: "date_published")
+        date_published: "date_published",
+        user_defined_id: 1)
     end
 
     it "renders the react component" do
@@ -92,6 +93,7 @@ RSpec.describe ItemDecorator do
           date_created: "date_created",
           date_modified: "date_modified",
           date_published: "date_published",
+          user_defined_id: 1
         }
       )
 

--- a/spec/services/param_cleaner_spec.rb
+++ b/spec/services/param_cleaner_spec.rb
@@ -1,0 +1,51 @@
+RSpec.describe ParamCleaner do
+  context "transform_values_recursively!" do
+    it "allows injecting a custom block to perform the rewrite" do
+      hash1 = { some_key: "previous value" }
+      hash2 = { some_key: "new value" }
+      described_class.transform_values_recursively!(hash: hash1) do |_value|
+        "new value"
+      end
+      expect(hash1).to eq(hash2)
+    end
+
+    it "works recursively" do
+      hash1 = { some_key: "previous value", some_hash: { some_key: "previous value" } }
+      hash2 = { some_key: "new value", some_hash: { some_key: "new value" } }
+      described_class.transform_values_recursively!(hash: hash1) do |_value|
+        "new value"
+      end
+      expect(hash1).to eq(hash2)
+    end
+  end
+
+  context "call" do
+    it "rewrites 'false' to false" do
+      hash1 = { some_key: "false" }
+      hash2 = { some_key: false }
+      described_class.call(hash: hash1)
+      expect(hash1).to eq(hash2)
+    end
+
+    it "rewrites 'true' to true" do
+      hash1 = { some_key: "true" }
+      hash2 = { some_key: true }
+      described_class.call(hash: hash1)
+      expect(hash1).to eq(hash2)
+    end
+
+    it "rewrites '' to nil" do
+      hash1 = { some_key: "" }
+      hash2 = { some_key: nil }
+      described_class.call(hash: hash1)
+      expect(hash1).to eq(hash2)
+    end
+
+    it "works recursively" do
+      hash1 = { some_key: "", some_hash: { some_key: "" } }
+      hash2 = { some_key: nil, some_hash: { some_key: nil } }
+      described_class.call(hash: hash1)
+      expect(hash1).to eq(hash2)
+    end
+  end
+end

--- a/spec/services/save_item_spec.rb
+++ b/spec/services/save_item_spec.rb
@@ -23,6 +23,12 @@ RSpec.describe SaveItem, type: :model do
     expect(subject).to be false
   end
 
+  it "uses the param cleaner before setting item attributes" do
+    expect(ParamCleaner).to receive(:call).with(hash: params).ordered
+    expect(item).to receive(:attributes=).with(params).ordered
+    subject
+  end
+
   it "sets the attributes of the item to be the passed in attributes " do
     expect(item).to receive(:attributes=).with(params)
     subject


### PR DESCRIPTION
Why: There is a difference between the item edit form and import in how they treat unset/empty metadata. This is causing import to report record changes when, from the user's perspective, there was no changes.
How:
-Modified item decorator to only send a metadata field if it actually has content. This is to prevent frontends from processing and sending update data for fields that actually have not been set.
-To catch any additional problems in the attribute data sent to SaveItem, added a ParamCleaner that does some common cleanup such as string bools to bools and empty string to nil