### PR TITLE
Import images script

### DIFF
--- a/lib/tasks/adhoc_upload_images.rake
+++ b/lib/tasks/adhoc_upload_images.rake
@@ -13,10 +13,22 @@ namespace :adhoc do
   #
   # Example usage:
   # bundle exec rake adhoc:upload_images[49,"image_paths.txt"]
+  #
+  # If it encounters an error importing a file, it will append that file to an error file
+  # of the same name as the given file with .err added. Ex:
+  #   bundle exec rake adhoc:upload_images[49,"image_paths.txt"]
+  # will create a image_paths.txt.err file with a list of files that were not imported.
   task :upload_images, [:collection_id, :file_path] => :environment do |_t, args|
     paths_file = File.new(args[:file_path], "r")
     while (line = paths_file.gets)
-      local_upload(collection_id: args[:collection_id], file_path: line.chomp)
+      begin
+        local_upload(collection_id: args[:collection_id], file_path: line.chomp)
+      rescue
+        open("#{args[:file_path]}.err", "a") do |f|
+          f << "#{line}\n"
+        end
+        next
+      end
     end
     paths_file.close
   end

--- a/lib/tasks/adhoc_upload_images.rake
+++ b/lib/tasks/adhoc_upload_images.rake
@@ -1,0 +1,31 @@
+# Before using this, make sure local_upload is updated to replicate anything new that has been
+# added to the items_controller#create code path
+
+namespace :adhoc do
+  desc "Warning: This code is not maintained, and will likely only be here temporarily.
+        Uploads and creates new items using all images specified in a text file."
+
+  # file_path must point to a text file that has full paths to each file to import, separated
+  # by new lines. Ex:
+  # $ cat image_paths.txt
+  # /Users/jgondron/Documents/1.tif
+  # /Users/jgondron/Documents/2.tif
+  # $
+  task :upload_images, [:collection_id, :file_path] => :environment do |_t, args|
+    paths_file = File.new(args[:file_path], "r")
+    while (line = paths_file.gets)
+      local_upload(collection_id: args[:collection_id], file_path: line.chomp)
+    end
+    paths_file.close
+  end
+
+  def local_upload(collection_id:, file_path:)
+    collection = CollectionQuery.new.find(collection_id)
+    item = ItemQuery.new(collection.items).build
+    file = File.open(file_path)
+    save_params = { uploaded_image: file }
+    SaveItem.call(item, save_params)
+    Index::Item.index!(item)
+    file.close
+  end
+end

--- a/lib/tasks/adhoc_upload_images.rake
+++ b/lib/tasks/adhoc_upload_images.rake
@@ -10,7 +10,9 @@ namespace :adhoc do
   # $ cat image_paths.txt
   # /Users/jgondron/Documents/1.tif
   # /Users/jgondron/Documents/2.tif
-  # $
+  #
+  # Example usage:
+  # bundle exec rake adhoc:upload_images[49,"image_paths.txt"]
   task :upload_images, [:collection_id, :file_path] => :environment do |_t, args|
     paths_file = File.new(args[:file_path], "r")
     while (line = paths_file.gets)


### PR DESCRIPTION
Why: Need a way to import images in bulk to support one-off collections that need to be created prior to supporting bulk image import through the interface.
How: Created a temporary rake task that we can use in the interim. It expects a collection id and a single text file with paths to the files that need to be imported on separate lines. It does not handle traversing directories to magically pull files in, so any collating of files will need to happen prior to the import when generating the text file.