### PR TITLE
DEC-615: Merge exhibit name into collection name_line_1, name_line_2

### DIFF
--- a/app/models/exhibition.rb
+++ b/app/models/exhibition.rb
@@ -19,7 +19,6 @@ class Exhibition
   ]
   exhibit_methods = [
     :image,
-    :name,
     :honeypot_image,
     :uploaded_image,
     :showcases,


### PR DESCRIPTION
There don't seem to be any references to exhibit.name other than exhibition. Most objects are already using collection.name_line_1 and name_line_2.