### PR TITLE
DEC-630: Migrate enable_browse

### DIFF
--- a/app/decorators/v1/collection_json_decorator.rb
+++ b/app/decorators/v1/collection_json_decorator.rb
@@ -40,7 +40,7 @@ module V1
     end
 
     def enable_browse
-      !!object.exhibit.enable_browse
+      !!object.enable_browse
     end
 
     def site_intro

--- a/db/migrate/20151012194643_add_enable_browse_to_collections.rb
+++ b/db/migrate/20151012194643_add_enable_browse_to_collections.rb
@@ -1,0 +1,5 @@
+class AddEnableBrowseToCollections < ActiveRecord::Migration
+  def change
+    add_column :collections, :enable_browse, :bool
+  end
+end

--- a/db/migrate/20151012201503_copy_enable_browse_from_exhibits_to_collections.rb
+++ b/db/migrate/20151012201503_copy_enable_browse_from_exhibits_to_collections.rb
@@ -1,0 +1,17 @@
+class CopyEnableBrowseFromExhibitsToCollections < ActiveRecord::Migration
+  class ExhibitMigration < ActiveRecord::Base
+    self.table_name = "exhibits"
+  end
+
+  def up
+    ExhibitMigration.find_each do |exhibit|
+      enable_browse = exhibit.enable_browse
+      execute "UPDATE collections SET enable_browse = #{enable_browse} WHERE id = #{exhibit.collection_id}" unless enable_browse.nil?
+    end
+    ExhibitMigration.reset_column_information
+  end
+
+  def down
+    ExhibitMigration.reset_column_information
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,8 +11,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151001004812) do
 
+ActiveRecord::Schema.define(version: 20151012201503) do
 
   create_table "collection_users", force: :cascade do |t|
     t.integer  "user_id",       limit: 4, null: false
@@ -34,6 +34,7 @@ ActiveRecord::Schema.define(version: 20151001004812) do
     t.boolean  "published"
     t.string   "name_line_2",  limit: 255
     t.boolean  "preview_mode"
+    t.boolean  "enable_browse"
   end
 
   add_index "collections", ["preview_mode"], name: "index_collections_on_preview_mode", using: :btree

--- a/spec/decorators/v1/collection_json_decorator_spec.rb
+++ b/spec/decorators/v1/collection_json_decorator_spec.rb
@@ -74,16 +74,15 @@ RSpec.describe V1::CollectionJSONDecorator do
   end
 
   describe "#enable_browse" do
-    let(:exhibit) { instance_double(Exhibit) }
-    let(:collection) { instance_double(Collection, exhibit: exhibit) }
+    let(:collection) { instance_double(Collection) }
 
     it "returns what enable_browse says on exhibt" do
-      expect(exhibit).to receive(:enable_browse).and_return(true)
+      allow(collection).to receive(:enable_browse).and_return(true)
       expect(subject.enable_browse).to eq(true)
     end
 
     it "converts null to false" do
-      allow(exhibit).to receive(:enable_browse).and_return(nil)
+      allow(collection).to receive(:enable_browse).and_return(nil)
       expect(subject.enable_browse).to eq(false)
     end
   end


### PR DESCRIPTION
-Created migrations to add enable_browse text column to Collections and copy existing data from the exhibits. enable_browse into collections. enable_browse
-Changed all references to exhibits. enable_browse to collections. enable_browse