### PR TITLE
DEC-617 Merge description fields into collection model

### DIFF
--- a/app/decorators/v1/collection_json_decorator.rb
+++ b/app/decorators/v1/collection_json_decorator.rb
@@ -44,11 +44,11 @@ module V1
     end
 
     def site_intro
-      object.exhibit.description.to_s
+      object.site_intro.to_s
     end
 
     def short_intro
-      object.exhibit.short_description.to_s
+      object.short_intro.to_s
     end
 
     def about

--- a/app/models/exhibition.rb
+++ b/app/models/exhibition.rb
@@ -15,6 +15,8 @@ class Exhibition
     :description,
     :published,
     :preview_mode,
+    :short_intro,
+    :site_intro,
     :updated_at
   ]
   exhibit_methods = [
@@ -26,7 +28,6 @@ class Exhibition
     :about,
     :copyright,
     :hide_title_on_home_page,
-    :short_description,
     :url
   ]
 

--- a/db/migrate/20151009171750_migrate_descriptions_to_collections.rb
+++ b/db/migrate/20151009171750_migrate_descriptions_to_collections.rb
@@ -1,0 +1,26 @@
+class MigrateDescriptionsToCollections < ActiveRecord::Migration
+  class Exhibit < ActiveRecord::Base
+  end
+
+  def up
+    add_column :collections, :site_intro, :text
+    add_column :collections, :short_intro, :text
+    Exhibit.find_each do |exhibit|
+      site_intro = exhibit.description
+      short_intro = exhibit.short_description
+      execute "UPDATE collections SET site_intro = '#{site_intro}' WHERE id = #{exhibit.collection_id}" unless site_intro.nil?
+      execute "UPDATE collections SET short_intro = '#{short_intro}' WHERE id = #{exhibit.collection_id}" unless short_intro.nil?
+    end
+
+    Exhibit.reset_column_information
+    Collection.reset_column_information
+  end
+
+  def down
+    remove_column :collections, :site_intro
+    remove_column :collections, :short_intro
+
+    Exhibit.reset_column_information
+    Collection.reset_column_information
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,8 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151001004812) do
-
+ActiveRecord::Schema.define(version: 20151009171750) do
 
   create_table "collection_users", force: :cascade do |t|
     t.integer  "user_id",       limit: 4, null: false
@@ -34,6 +33,9 @@ ActiveRecord::Schema.define(version: 20151001004812) do
     t.boolean  "published"
     t.string   "name_line_2",  limit: 255
     t.boolean  "preview_mode"
+    t.string   "url",          limit: 255
+    t.text     "site_intro",   limit: 65535
+    t.text     "short_intro",  limit: 65535
   end
 
   add_index "collections", ["preview_mode"], name: "index_collections_on_preview_mode", using: :btree

--- a/spec/decorators/v1/collection_json_decorator_spec.rb
+++ b/spec/decorators/v1/collection_json_decorator_spec.rb
@@ -114,29 +114,27 @@ RSpec.describe V1::CollectionJSONDecorator do
   end
 
   describe "#site_intro" do
-    let(:exhibit) { double(Exhibit, description: nil) }
-    let(:collection) { double(Collection, exhibit: exhibit) }
+    let(:collection) { double(Collection, site_intro: nil) }
 
     it "converts null to empty string" do
       expect(subject.site_intro).to eq("")
     end
 
-    it "gets the value from the exhibit" do
-      expect(exhibit).to receive(:description).and_return("intro")
+    it "gets the value from #site_intro" do
+      expect(subject).to receive(:site_intro).and_return("intro")
       expect(subject.site_intro).to eq("intro")
     end
   end
 
   describe "#short_intro" do
-    let(:exhibit) { double(Exhibit, short_description: nil) }
-    let(:collection) { double(Collection, exhibit: exhibit) }
+    let(:collection) { double(Collection, short_intro: nil) }
 
     it "converts null to empty string" do
       expect(subject.short_intro).to eq("")
     end
 
-    it "gets the value from the exhibit" do
-      expect(exhibit).to receive(:short_description).and_return("intro")
+    it "gets the value from #short_intro" do
+      expect(subject).to receive(:short_intro).and_return("intro")
       expect(subject.short_intro).to eq("intro")
     end
   end

--- a/spec/models/exhibition_spec.rb
+++ b/spec/models/exhibition_spec.rb
@@ -18,7 +18,8 @@ RSpec.describe Exhibition do
     :about,
     :copyright,
     :hide_title_on_home_page,
-    :short_description,
+    :short_intro,
+    :site_intro,
     :url
   ].each do |field|
     it "has field, #{field}" do


### PR DESCRIPTION
**What**: Two description fields have been merged into the collection model and renamed to site_intro and short_intro to be consistent with how we're using them in the application.
**How**: Two fields were added to the collection model and the API was updated.