### PR TITLE
DEC-625: Migrate about text to collections

### DIFF
--- a/app/decorators/v1/collection_json_decorator.rb
+++ b/app/decorators/v1/collection_json_decorator.rb
@@ -52,7 +52,7 @@ module V1
     end
 
     def about
-      object.exhibit.about.to_s
+      object.about.to_s
     end
 
     def copyright

--- a/app/models/exhibition.rb
+++ b/app/models/exhibition.rb
@@ -13,6 +13,7 @@ class Exhibition
     :unique_id,
     :exhibit,
     :description,
+    :about,
     :published,
     :preview_mode,
     :updated_at
@@ -23,7 +24,6 @@ class Exhibition
     :honeypot_image,
     :uploaded_image,
     :showcases,
-    :about,
     :copyright,
     :hide_title_on_home_page,
     :short_description,

--- a/db/migrate/20151012145424_add_about_to_collections.rb
+++ b/db/migrate/20151012145424_add_about_to_collections.rb
@@ -1,0 +1,5 @@
+class AddAboutToCollections < ActiveRecord::Migration
+  def change
+    add_column :collections, :about, :text
+  end
+end

--- a/db/migrate/20151012145424_migrate_about_from_exhibits_to_collections.rb
+++ b/db/migrate/20151012145424_migrate_about_from_exhibits_to_collections.rb
@@ -1,0 +1,19 @@
+class MigrateAboutFromExhibitsToCollections < ActiveRecord::Migration
+  class ExhibitMigration < ActiveRecord::Base
+    self.table_name = "exhibits"
+  end
+
+  def up
+    add_column :collections, :about, :text
+    ExhibitMigration.find_each do |exhibit|
+      about = exhibit.about
+      execute "UPDATE collections SET about = '#{about}' WHERE id = #{exhibit.collection_id}" unless about.nil?
+    end
+    ExhibitMigration.reset_column_information
+  end
+
+  def down
+    remove_column :collections, :about
+    ExhibitMigration.reset_column_information
+  end
+end

--- a/db/migrate/20151012145430_copy_about_from_exhibits_to_collections.rb
+++ b/db/migrate/20151012145430_copy_about_from_exhibits_to_collections.rb
@@ -1,10 +1,9 @@
-class MigrateAboutFromExhibitsToCollections < ActiveRecord::Migration
+class CopyAboutFromExhibitsToCollections < ActiveRecord::Migration
   class ExhibitMigration < ActiveRecord::Base
     self.table_name = "exhibits"
   end
 
   def up
-    add_column :collections, :about, :text
     ExhibitMigration.find_each do |exhibit|
       about = exhibit.about
       execute "UPDATE collections SET about = '#{about}' WHERE id = #{exhibit.collection_id}" unless about.nil?
@@ -13,7 +12,6 @@ class MigrateAboutFromExhibitsToCollections < ActiveRecord::Migration
   end
 
   def down
-    remove_column :collections, :about
     ExhibitMigration.reset_column_information
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,8 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151001004812) do
-
+ActiveRecord::Schema.define(version: 20151012145424) do
 
   create_table "collection_users", force: :cascade do |t|
     t.integer  "user_id",       limit: 4, null: false
@@ -34,6 +33,7 @@ ActiveRecord::Schema.define(version: 20151001004812) do
     t.boolean  "published"
     t.string   "name_line_2",  limit: 255
     t.boolean  "preview_mode"
+    t.text     "about",        limit: 65535
   end
 
   add_index "collections", ["preview_mode"], name: "index_collections_on_preview_mode", using: :btree

--- a/spec/decorators/v1/collection_json_decorator_spec.rb
+++ b/spec/decorators/v1/collection_json_decorator_spec.rb
@@ -30,15 +30,14 @@ RSpec.describe V1::CollectionJSONDecorator do
   end
 
   describe "#about" do
-    let(:exhibit) { double(Exhibit, about: nil) }
-    let(:collection) { double(Collection, exhibit: exhibit) }
+    let(:collection) { double(Collection, about: nil) }
 
     it "converts null to empty string" do
       expect(subject.about).to eq("")
     end
 
-    it "gets the value from the exhibit" do
-      expect(exhibit).to receive(:about).and_return("about")
+    it "gets the value from the collection" do
+      allow(collection).to receive(:about).and_return("about")
       expect(subject.about).to eq("about")
     end
   end


### PR DESCRIPTION
-Created migration to add about text column to Collections and copy existing data from the exhibits.about into collections.about
-Changed all references to exhibits.about to collections.about