### PR TITLE
DEC-631: Migrate enable_search

### DIFF
--- a/app/decorators/v1/collection_json_decorator.rb
+++ b/app/decorators/v1/collection_json_decorator.rb
@@ -36,7 +36,7 @@ module V1
     end
 
     def enable_search
-      !!object.exhibit.enable_search
+      !!object.enable_search
     end
 
     def enable_browse

--- a/db/migrate/20151014135912_add_enable_search_to_collections.rb
+++ b/db/migrate/20151014135912_add_enable_search_to_collections.rb
@@ -1,0 +1,5 @@
+class AddEnableSearchToCollections < ActiveRecord::Migration
+  def change
+    add_column :collections, :enable_search, :bool
+  end
+end

--- a/db/migrate/20151014135926_copy_enable_search_from_exhibits_to_collections.rb
+++ b/db/migrate/20151014135926_copy_enable_search_from_exhibits_to_collections.rb
@@ -1,0 +1,17 @@
+class CopyEnableSearchFromExhibitsToCollections < ActiveRecord::Migration
+  class ExhibitMigration < ActiveRecord::Base
+    self.table_name = "exhibits"
+  end
+
+  def up
+    ExhibitMigration.find_each do |exhibit|
+      enable_search = exhibit.enable_search
+      execute "UPDATE collections SET enable_search = #{enable_search} WHERE id = #{exhibit.collection_id}" unless enable_search.nil?
+    end
+    ExhibitMigration.reset_column_information
+  end
+
+  def down
+    ExhibitMigration.reset_column_information
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151012201503) do
+ActiveRecord::Schema.define(version: 20151014135926) do
+
   create_table "collection_users", force: :cascade do |t|
     t.integer  "user_id",       limit: 4, null: false
     t.integer  "collection_id", limit: 4, null: false
@@ -38,6 +39,7 @@ ActiveRecord::Schema.define(version: 20151012201503) do
     t.string   "url",          limit: 255
     t.text     "site_intro",   limit: 65535
     t.text     "short_intro",  limit: 65535
+    t.boolean  "enable_search"
   end
 
   add_index "collections", ["preview_mode"], name: "index_collections_on_preview_mode", using: :btree

--- a/spec/decorators/v1/collection_json_decorator_spec.rb
+++ b/spec/decorators/v1/collection_json_decorator_spec.rb
@@ -58,16 +58,15 @@ RSpec.describe V1::CollectionJSONDecorator do
   end
 
   describe "#enable_search" do
-    let(:exhibit) { instance_double(Exhibit) }
-    let(:collection) { instance_double(Collection, exhibit: exhibit) }
+    let(:collection) { instance_double(Collection) }
 
-    it "returns what enable_search says on exhibt" do
-      expect(exhibit).to receive(:enable_search).and_return(true)
+    it "returns what enable_search says on collection" do
+      allow(collection).to receive(:enable_search).and_return(true)
       expect(subject.enable_search).to eq(true)
     end
 
     it "converts null to false" do
-      allow(exhibit).to receive(:enable_search).and_return(nil)
+      allow(collection).to receive(:enable_search).and_return(nil)
       expect(subject.enable_search).to eq(false)
     end
   end


### PR DESCRIPTION
-Created migrations to add enable_search text column to Collections and copy existing data from the exhibits.enable_search into collections.enable_search
-Changed all references to exhibits.enable_search to collections.enable_search