### PR TITLE
DEC-632: Migrate hide title

### DIFF
--- a/app/decorators/v1/collection_json_decorator.rb
+++ b/app/decorators/v1/collection_json_decorator.rb
@@ -65,7 +65,7 @@ module V1
     end
 
     def display_page_title
-      !object.exhibit.hide_title_on_home_page?
+      !object.hide_title_on_home_page?
     end
 
     def slug

--- a/app/models/exhibition.rb
+++ b/app/models/exhibition.rb
@@ -20,6 +20,7 @@ class Exhibition
     :short_intro,
     :site_intro,
     :updated_at,
+    :hide_title_on_home_page,
     :url
   ]
   exhibit_methods = [
@@ -27,7 +28,6 @@ class Exhibition
     :honeypot_image,
     :uploaded_image,
     :showcases,
-    :hide_title_on_home_page,
   ]
 
   delegate *collection_methods, to: :collection

--- a/db/migrate/20151015142127_add_hide_title_to_collections.rb
+++ b/db/migrate/20151015142127_add_hide_title_to_collections.rb
@@ -1,0 +1,5 @@
+class AddHideTitleToCollections < ActiveRecord::Migration
+  def change
+    add_column :collections, :hide_title_on_home_page, :bool
+  end
+end

--- a/db/migrate/20151015142141_copy_hide_title_from_exhibits_to_collections.rb
+++ b/db/migrate/20151015142141_copy_hide_title_from_exhibits_to_collections.rb
@@ -1,0 +1,17 @@
+class CopyHideTitleFromExhibitsToCollections < ActiveRecord::Migration
+  class ExhibitMigration < ActiveRecord::Base
+    self.table_name = "exhibits"
+  end
+
+  def up
+    ExhibitMigration.find_each do |exhibit|
+      hide_title_on_home_page = exhibit.hide_title_on_home_page
+      execute "UPDATE collections SET hide_title_on_home_page = #{hide_title_on_home_page} WHERE id = #{exhibit.collection_id}" unless hide_title_on_home_page.nil?
+    end
+    ExhibitMigration.reset_column_information
+  end
+
+  def down
+    ExhibitMigration.reset_column_information
+  end
+end

--- a/db/migrate/20151015142141_copy_hide_title_from_exhibits_to_collections.rb
+++ b/db/migrate/20151015142141_copy_hide_title_from_exhibits_to_collections.rb
@@ -6,7 +6,8 @@ class CopyHideTitleFromExhibitsToCollections < ActiveRecord::Migration
   def up
     ExhibitMigration.find_each do |exhibit|
       hide_title_on_home_page = exhibit.hide_title_on_home_page
-      execute "UPDATE collections SET hide_title_on_home_page = #{hide_title_on_home_page} WHERE id = #{exhibit.collection_id}" unless hide_title_on_home_page.nil?
+      execute "UPDATE collections SET hide_title_on_home_page = #{hide_title_on_home_page}
+               WHERE id = #{exhibit.collection_id}" unless hide_title_on_home_page.nil?
     end
     ExhibitMigration.reset_column_information
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151012201503) do
+ActiveRecord::Schema.define(version: 20151015142141) do
+
   create_table "collection_users", force: :cascade do |t|
     t.integer  "user_id",       limit: 4, null: false
     t.integer  "collection_id", limit: 4, null: false
@@ -38,6 +39,7 @@ ActiveRecord::Schema.define(version: 20151012201503) do
     t.string   "url",          limit: 255
     t.text     "site_intro",   limit: 65535
     t.text     "short_intro",  limit: 65535
+    t.boolean  "hide_title_on_home_page"
   end
 
   add_index "collections", ["preview_mode"], name: "index_collections_on_preview_mode", using: :btree

--- a/spec/decorators/v1/collection_json_decorator_spec.rb
+++ b/spec/decorators/v1/collection_json_decorator_spec.rb
@@ -43,16 +43,15 @@ RSpec.describe V1::CollectionJSONDecorator do
   end
 
   describe "#display_page_title" do
-    let(:exhibit) { instance_double(Exhibit) }
-    let(:collection) { instance_double(Collection, exhibit: exhibit) }
+    let(:collection) { instance_double(Collection) }
 
-    it "returns true value from the exhibit when the flag is false" do
-      expect(exhibit).to receive(:hide_title_on_home_page?).and_return(false)
+    it "returns true value from the collection when the flag is false" do
+      allow(collection).to receive(:hide_title_on_home_page?).and_return(false)
       expect(subject.display_page_title).to eq(true)
     end
 
-    it "returns false when the exhibit when the flag is false" do
-      expect(exhibit).to receive(:hide_title_on_home_page?).and_return(true)
+    it "returns false when the collection when the flag is false" do
+      allow(collection).to receive(:hide_title_on_home_page?).and_return(true)
       expect(subject.display_page_title).to eq(false)
     end
   end


### PR DESCRIPTION
-Created migrations to add hide_title_on_home_page column to Collections and copy existing data from the exhibits.hide_title_on_home_page into collections.hide_title_on_home_page
-Changed all references to exhibits.hide_title_on_home_page to collections.hide_title_on_home_page