### PR TITLE
DEC-626: Fix views

### DIFF
--- a/app/assets/javascripts/components/forms/ExternalCollectionForm.jsx
+++ b/app/assets/javascripts/components/forms/ExternalCollectionForm.jsx
@@ -70,7 +70,7 @@ var ExternalCollectionForm = React.createClass({
         <Panel>
           <PanelHeading>External Collection</PanelHeading>
           <PanelBody>
-              <StringField objectType={this.props.objectType} name="name" required={true} title="Name" value={this.state.formValues.name} handleFieldChange={this.handleFieldChange} errorMsg={this.fieldError('name')} />
+              <StringField objectType={this.props.objectType} name="name_line_1" required={true} title="Name" value={this.state.formValues.name_line_1} handleFieldChange={this.handleFieldChange} errorMsg={this.fieldError('name_line_1')} />
               <StringField objectType={this.props.objectType} name="url" required={true} title="URL" value={this.state.formValues.url} handleFieldChange={this.handleFieldChange} errorMsg={this.fieldError('url')} />
               <HtmlField objectType={this.props.objectType} name="description" title="Description" value={this.state.formValues.description} handleFieldChange={this.handleFieldChange} errorMsg={this.fieldError('description')} placeholder="Example: This is an collection external to the honeycomb system" />
               {this.thumbnailImage()}

--- a/app/controllers/admin/external_collections_controller.rb
+++ b/app/controllers/admin/external_collections_controller.rb
@@ -30,13 +30,13 @@ module Admin
       @honeypot_image = external_collection.honeypot_image[:json_response]["thumbnail/small"]["contentUrl"] if external_collection.honeypot_image
     end
 
-    def update # rubocop:disable Metrics/AbcSize
+    def update
       check_admin_or_admin_masquerading_permission!
       @external_collection = CollectionQuery.new.find(params[:id])
 
-      if SaveCollection.call(external_collection, save_params)
+      if SaveCollection.call(@external_collection, save_params)
         flash[:notice] = t(".success")
-        redirect_to edit_admin_external_collection_path(external_collection)
+        redirect_to edit_admin_external_collection_path(@external_collection)
       else
         render :edit
       end

--- a/app/controllers/admin/external_collections_controller.rb
+++ b/app/controllers/admin/external_collections_controller.rb
@@ -1,64 +1,69 @@
 module Admin
   class ExternalCollectionsController < ApplicationController
     def index
+      check_admin_or_admin_masquerading_permission!
       @external_collections = CollectionQuery.new.all_external
     end
 
     def new
       check_admin_or_admin_masquerading_permission!
       @form_action = admin_external_collections_path
-      @external_collection = Exhibition.new
+      @external_collection = CollectionQuery.new.build
     end
 
     def create
       check_admin_or_admin_masquerading_permission!
-      build_collection.save!
-      redirect_to action: "index"
+
+      @external_collection = CollectionQuery.new.build(published: true)
+      if SaveCollection.call(external_collection, save_params)
+        flash[:notice] = t(".success")
+        redirect_to admin_external_collections_path
+      else
+        render :new
+      end
     end
 
     def edit
-      exhibit = Exhibit.find(params[:id])
-      @form_action = admin_external_collection_path(exhibit)
-      @external_collection = Exhibition.new(exhibit: exhibit)
-      @honeypot_image = exhibit.honeypot_image[:json_response]["thumbnail/small"]["contentUrl"] if exhibit.honeypot_image
+      check_admin_or_admin_masquerading_permission!
+      @external_collection = CollectionQuery.new.find(params[:id])
+      @form_action = admin_external_collection_path(external_collection)
+      @honeypot_image = external_collection.honeypot_image[:json_response]["thumbnail/small"]["contentUrl"] if external_collection.honeypot_image
     end
 
-    def update
-      exhibition = Exhibition.new(exhibit: Exhibit.find(params[:id]))
-      update_collection(exhibition).save!
-      redirect_to action: "index"
+    def update # rubocop:disable Metrics/AbcSize
+      check_admin_or_admin_masquerading_permission!
+      @external_collection = CollectionQuery.new.find(params[:id])
+
+      if SaveCollection.call(external_collection, save_params)
+        flash[:notice] = t(".success")
+        redirect_to edit_admin_external_collection_path(external_collection)
+      else
+        render :edit
+      end
     end
 
     def destroy
-      exhibition = Exhibition.new(exhibit: Exhibit.find(params[:id]))
-      Destroy::Collection.new.cascade!(collection: exhibition.collection)
-      redirect_to action: "index"
+      check_admin_or_admin_masquerading_permission!
+
+      @external_collection = CollectionQuery.new.find(params[:id])
+      Destroy::Collection.new.cascade!(collection: external_collection)
+
+      flash[:notice] = t(".success")
+      redirect_to admin_external_collections_path
     end
 
     private
 
-    # rubocop:disable Metrics/AbcSize
-    def build_collection
-      exhibition = Exhibition.new
-      exhibition.name_line_1 = params[:external_collection]["name"]
-      exhibition.name = params[:external_collection]["name"]
-      exhibition.url = params[:external_collection]["url"]
-      exhibition.published = true
-      exhibition.uploaded_image = params[:external_collection]["uploaded_image"]
-      exhibition.description = params[:external_collection]["description"]
-      exhibition
-    end
-    # rubocop:enable Metrics/AbcSize
+    attr_reader :external_collection
 
-    # rubocop:disable Metrics/AbcSize
-    def update_collection(exhibition)
-      exhibition.name_line_1 = params[:external_collection]["name"]
-      exhibition.name = params[:external_collection]["name"]
-      exhibition.url = params[:external_collection]["url"]
-      exhibition.uploaded_image = params[:external_collection]["uploaded_image"]
-      exhibition.description = params[:external_collection]["description"]
-      exhibition
+    def save_params
+      params.require(:external_collection).permit(
+        :name_line_1,
+        :description,
+        :id,
+        :url,
+        :uploaded_image,
+        :published)
     end
-    # rubocop:enable Metrics/AbcSize
   end
 end

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -62,6 +62,16 @@ class CollectionsController < ApplicationController
     redirect_to collections_path
   end
 
+  def site_setup
+    @collection = CollectionQuery.new.find(params[:id])
+    check_user_edits!(@collection)
+
+    cache_key = CacheKeys::Generator.new(key_generator: CacheKeys::Custom::Collections,
+                                        action: "site_setup",
+                                        collection: @collection)
+    fresh_when(etag: cache_key.generate)
+  end
+
   def publish
     collection = CollectionQuery.new.find(params[:id])
     check_user_edits!(collection)

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -99,6 +99,6 @@ class CollectionsController < ApplicationController
   protected
 
   def save_params
-    params.require(:collection).permit(:name_line_1, :name_line_2, :description, :id)
+    params.require(:collection).permit(:name_line_1, :name_line_2, :description, :id, :enable_search, :enable_browse)
   end
 end

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -72,6 +72,18 @@ class CollectionsController < ApplicationController
     fresh_when(etag: cache_key.generate)
   end
 
+  def site_setup_update
+    @collection = CollectionQuery.new.find(params[:id])
+    check_user_edits!(@collection)
+
+    if SaveCollection.call(@collection, save_params)
+      flash[:notice] = t(".success")
+      redirect_to site_setup_form_collection_path(@collection, form: params[:form])
+    else
+      render :site_setup
+    end
+  end
+
   def publish
     collection = CollectionQuery.new.find(params[:id])
     check_user_edits!(collection)
@@ -99,6 +111,18 @@ class CollectionsController < ApplicationController
   protected
 
   def save_params
-    params.require(:collection).permit(:name_line_1, :name_line_2, :description, :id, :enable_search, :enable_browse)
+    params.require(:collection).permit(
+      :name_line_1,
+      :name_line_2,
+      :description,
+      :id,
+      :enable_search,
+      :enable_browse,
+      :site_intro,
+      :short_intro,
+      :hide_title_on_home_page,
+      :uploaded_image,
+      :about,
+      :copyright)
   end
 end

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -67,12 +67,12 @@ class CollectionsController < ApplicationController
     check_user_edits!(@collection)
 
     cache_key = CacheKeys::Generator.new(key_generator: CacheKeys::Custom::Collections,
-                                        action: "site_setup",
-                                        collection: @collection)
+                                         action: "site_setup",
+                                         collection: @collection)
     fresh_when(etag: cache_key.generate)
   end
 
-  def site_setup_update
+  def site_setup_update # rubocop:disable Metrics/AbcSize
     @collection = CollectionQuery.new.find(params[:id])
     check_user_edits!(@collection)
 

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -6,12 +6,12 @@ class SectionsController < ApplicationController
   end
 
   def new
-    check_user_edits!(showcase.exhibit.collection)
+    check_user_edits!(showcase.collection)
     @section_form = SectionForm.build_from_params(self)
   end
 
   def create
-    check_user_edits!(showcase.exhibit.collection)
+    check_user_edits!(showcase.collection)
     @section = SectionQuery.new(showcase.sections).build
 
     respond_to do |format|
@@ -36,7 +36,7 @@ class SectionsController < ApplicationController
 
   def update
     @section = SectionQuery.new.find(params[:id])
-    check_user_edits!(@section.showcase.exhibit.collection)
+    check_user_edits!(@section.showcase.collection)
 
     respond_to do |format|
       if SaveSection.call(@section, section_params)
@@ -51,7 +51,7 @@ class SectionsController < ApplicationController
 
   def destroy
     @section = SectionQuery.new.find(params[:id])
-    check_user_edits!(@section.showcase.exhibit.collection)
+    check_user_edits!(@section.showcase.collection)
     Destroy::Section.new.cascade!(section: @section)
 
     flash[:notice] = t(".success")

--- a/app/controllers/showcases_controller.rb
+++ b/app/controllers/showcases_controller.rb
@@ -75,7 +75,7 @@ class ShowcasesController < ApplicationController
     Destroy::Showcase.new.cascade!(showcase: @showcase)
 
     flash[:notice] = t(".success")
-    redirect_to collection_path(@showcase.collection)
+    redirect_to collection_showcases_path(@showcase.collection)
   end
 
   def publish

--- a/app/decorators/collections_side_nav.rb
+++ b/app/decorators/collections_side_nav.rb
@@ -1,0 +1,27 @@
+class CollectionsSideNav < Draper::Decorator
+  attr_reader :collection, :form
+
+  def initialize(collection:, form:)
+    @collection = collection
+    @form = form
+  end
+
+  def homepage_link
+    "TODO: Homepage link"
+  end
+
+  def collection_introduction_link
+    "TODO: Introduction link"
+    #h.link_to("Collection Introduction", h.edit_collection_form_collection_path(collection, form: "collection_introduction"))
+  end
+
+  def about_text_link
+    h.link_to("About Text", h.edit_collection_form_collection_path(collection, form: "about_text"))
+  end
+
+  def active_tab_class(tab:)
+    return "active" if tab == form
+    return "active" if tab == "edit" && form.nil?
+    ""
+  end
+end

--- a/app/decorators/collections_side_nav.rb
+++ b/app/decorators/collections_side_nav.rb
@@ -7,16 +7,19 @@ class CollectionsSideNav < Draper::Decorator
   end
 
   def homepage_link
-    "TODO: Homepage link"
+    h.link_to("Homepage", h.site_setup_form_collection_path(collection, form: "homepage"))
   end
 
   def collection_introduction_link
-    "TODO: Introduction link"
-    #h.link_to("Collection Introduction", h.edit_collection_form_collection_path(collection, form: "collection_introduction"))
+    h.link_to("Introduction", h.site_setup_form_collection_path(collection, form: "collection_introduction"))
+  end
+
+  def copyright_text_link
+    h.link_to("Copyright", h.site_setup_form_collection_path(collection, form: "copyright_text"))
   end
 
   def about_text_link
-    h.link_to("About Text", h.edit_collection_form_collection_path(collection, form: "about_text"))
+    h.link_to("About", h.site_setup_form_collection_path(collection, form: "about_text"))
   end
 
   def active_tab_class(tab:)

--- a/app/decorators/showcase_list.rb
+++ b/app/decorators/showcase_list.rb
@@ -1,6 +1,6 @@
 class ShowcaseList
   attr_reader :showcase
-  delegate :exhibit, to: :showcase
+  delegate :collection, to: :showcase
 
   def initialize(showcase)
     @showcase = showcase
@@ -8,9 +8,5 @@ class ShowcaseList
 
   def sections
     SectionQuery.new(showcase.sections).ordered
-  end
-
-  def collection
-    exhibit.collection
   end
 end

--- a/app/form/section_form.rb
+++ b/app/form/section_form.rb
@@ -41,7 +41,7 @@ class SectionForm
   end
 
   def collection
-    section.showcase.exhibit.collection
+    section.showcase.collection
   end
 
   delegate :showcase, to: :section

--- a/app/services/save_honeypot_image.rb
+++ b/app/services/save_honeypot_image.rb
@@ -60,7 +60,11 @@ class SaveHoneypotImage
   end
 
   def group_id
-    object.collection.id
+    if object.respond_to?(:collection)
+      object.collection.id
+    else
+      object.id
+    end
   end
 
   def item_id

--- a/app/values/cache_keys/custom/collections.rb
+++ b/app/values/cache_keys/custom/collections.rb
@@ -9,6 +9,10 @@ module CacheKeys
       def edit(collection:)
         CacheKeys::ActiveRecord.new.generate(record: collection)
       end
+
+      def site_setup(collection:)
+        CacheKeys::ActiveRecord.new.generate(record: collection)
+      end
     end
   end
 end

--- a/app/views/admin/external_collections/_form.html.erb
+++ b/app/views/admin/external_collections/_form.html.erb
@@ -2,7 +2,7 @@
   authenticityToken: form_authenticity_token,
   method: form_method,
   data: {
-    name: @external_collection.name,
+    name_line_1: @external_collection.name_line_1,
     url: @external_collection.url,
     description: @external_collection.description,
     image: @external_collection.image

--- a/app/views/admin/external_collections/_list.html.erb
+++ b/app/views/admin/external_collections/_list.html.erb
@@ -27,9 +27,9 @@
           <% end %>
         </td>
         <td>
-          <a href="<%= edit_admin_external_collection_path(collection.exhibit) %>">
+          <a href="<%= edit_admin_external_collection_path(collection) %>">
             <span class="glyphicon glyphicon-edit"></span>
-            <%= raw collection.full_name %>
+            <%= raw collection.name_line_1 %>
           </a>
         </td>
         <td>
@@ -42,7 +42,7 @@
           <a className="remove-external-collection"
             data-confirm="Are you sure?"
             data-method="delete"
-            href="<%= admin_external_collection_path(collection.exhibit) %>"
+            href="<%= admin_external_collection_path(collection) %>"
             rel="nofollow">
             <span class="glyphicon glyphicon-trash"></span>
         </a>

--- a/app/views/collections/_about_text_form.html.erb
+++ b/app/views/collections/_about_text_form.html.erb
@@ -1,0 +1,11 @@
+
+<%= f.input :about, input_html: { class: 'honeycomb_redactor'  } %>
+
+<h3>Copy and Paste Example</h3>
+<hr>
+
+<h5>Name of Curator</h5>
+<p><em>Title or Position</em><br/>Hesburgh Libraries</p>
+<p>p: 124-123-1234<br/>e: name@nd.edu</p>
+
+<hr>

--- a/app/views/collections/_collection_introduction_form.html.erb
+++ b/app/views/collections/_collection_introduction_form.html.erb
@@ -1,1 +1,1 @@
-<%= f.input :description, input_html: { class: 'honeycomb_redactor'  } %>
+<%= f.input :site_intro, input_html: { class: 'honeycomb_redactor'  } %>

--- a/app/views/collections/_collection_introduction_form.html.erb
+++ b/app/views/collections/_collection_introduction_form.html.erb
@@ -1,0 +1,1 @@
+<%= f.input :description, input_html: { class: 'honeycomb_redactor'  } %>

--- a/app/views/collections/_copyright_text_form.html.erb
+++ b/app/views/collections/_copyright_text_form.html.erb
@@ -1,0 +1,4 @@
+<%= f.input :copyright, input_html: { class: "honeycomb_redactor" } %>
+<h3>Copy and Paste Example</h3>
+<hr>
+<p><a href="http://www.nd.edu/copyright/">Copyright</a> <%= Date.today.year.to_s %> <a href="http://www.nd.edu">University of Notre Dame</a></p>

--- a/app/views/collections/_form.html.erb
+++ b/app/views/collections/_form.html.erb
@@ -2,5 +2,5 @@
 
 <%= f.input :name_line_1 %>
 <%= f.input :name_line_2 %>
-<%= f.input :description, as: :text, rows: 5 %>
 
+<h3>TODO: Add Search and Browse Here</h3>

--- a/app/views/collections/_form.html.erb
+++ b/app/views/collections/_form.html.erb
@@ -2,5 +2,4 @@
 
 <%= f.input :name_line_1 %>
 <%= f.input :name_line_2 %>
-
-<h3>TODO: Add Search and Browse Here</h3>
+<%= render partial: 'search_and_browse_form', locals: { f: f } %>

--- a/app/views/collections/_homepage_form.html.erb
+++ b/app/views/collections/_homepage_form.html.erb
@@ -1,0 +1,10 @@
+<%= display_errors(@collection) %>
+
+<%= f.input :short_intro, input_html: { class: 'honeycomb_redactor'  } %>
+
+<%= HoneypotThumbnail.display(f.object.honeypot_image) %>
+<%= f.input :uploaded_image, as: :file %>
+
+<%= f.input :show_page_title, as: :boolean, label: false, hint: "Select this box if your homepage image has your site title already embedded in it" do %>
+  <label><%= f.check_box :hide_title_on_home_page %> Do not overlay site title on homepage image.</label>
+<% end %>

--- a/app/views/collections/_search_and_browse_form.html.erb
+++ b/app/views/collections/_search_and_browse_form.html.erb
@@ -2,5 +2,5 @@
 <label><%= f.check_box :enable_search %> Enable Site Search</label>
 <% end %>
 <%= f.input :enable_browse, as: :boolean, label: false, hint: "This will enable a browse page with all items listed." do %>
-  <label><%= f.check_box :enable_search %> Enable Item Browse</label>
+  <label><%= f.check_box :enable_browse %> Enable Item Browse</label>
 <% end %>

--- a/app/views/collections/_search_and_browse_form.html.erb
+++ b/app/views/collections/_search_and_browse_form.html.erb
@@ -1,8 +1,6 @@
-<h3>Search and Browse</h3>
-<%= f.input :enable_search, as: :boolean, label: false, hint: "Select this box to enable search on the site." do %>
-  <label><%= f.check_box :enable_search %> Enable Site Search</label>
+<%= f.input :enable_search, as: :boolean, label: false, hint: "Select this box to enable search for this collection" do %>
+<label><%= f.check_box :enable_search %> Enable Site Search</label>
 <% end %>
-
 <%= f.input :enable_browse, as: :boolean, label: false, hint: "This will enable a browse page with all items listed." do %>
   <label><%= f.check_box :enable_search %> Enable Item Browse</label>
 <% end %>

--- a/app/views/collections/_search_and_browse_form.html.erb
+++ b/app/views/collections/_search_and_browse_form.html.erb
@@ -1,0 +1,8 @@
+<h3>Search and Browse</h3>
+<%= f.input :enable_search, as: :boolean, label: false, hint: "Select this box to enable search on the site." do %>
+  <label><%= f.check_box :enable_search %> Enable Site Search</label>
+<% end %>
+
+<%= f.input :enable_browse, as: :boolean, label: false, hint: "This will enable a browse page with all items listed." do %>
+  <label><%= f.check_box :enable_search %> Enable Item Browse</label>
+<% end %>

--- a/app/views/collections/_side_nav.html.erb
+++ b/app/views/collections/_side_nav.html.erb
@@ -1,0 +1,7 @@
+<% side_nav = CollectionsSideNav.new(collection: collection, form: form) %>
+<h4>Site Content</h4>
+<ul class="nav nav-pills nav-stacked">
+  <li class="<%= side_nav.active_tab_class(tab: "homepage") %>"><%= side_nav.homepage_link %></li>
+  <li class="<%= side_nav.active_tab_class(tab: "collection_introduction") %>"><%= side_nav.collection_introduction_link %></li>
+  <li class="<%= side_nav.active_tab_class(tab: "about_text") %>"><%= side_nav.about_text_link %></li>
+</ul>

--- a/app/views/collections/site_setup.html.erb
+++ b/app/views/collections/site_setup.html.erb
@@ -1,11 +1,9 @@
 <% page_title(@collection.name) %>
 <%= collection_nav(@collection, :website) %>
 
-<%= back_action_bar(edit_exhibit_path(@collection.id), '#' ) %>
-
 <div class="row">
   <div class="col-md-10">
-    <%= simple_form_for @collection do |f| %>
+    <%= simple_form_for @collection, :url => site_setup_update_form_collection_path(@collection, form: (params[:form] ? "#{params[:form]}" : 'homepage')) do |f| %>
       <%= display_errors(f.object) %>
 
       <div class="panel panel-default">

--- a/app/views/collections/site_setup.html.erb
+++ b/app/views/collections/site_setup.html.erb
@@ -1,0 +1,27 @@
+<% page_title(@collection.name) %>
+<%= collection_nav(@collection, :website) %>
+
+<%= back_action_bar(edit_exhibit_path(@collection.id), '#' ) %>
+
+<div class="row">
+  <div class="col-md-10">
+    <%= simple_form_for @collection do |f| %>
+      <%= display_errors(f.object) %>
+
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          <h3 class="panel-title">Site Setup</h3>
+        </div>
+        <div class="panel-body">
+          <%= render partial: (params[:form] ? "#{params[:form]}_form" : 'homepage_form'), locals: { f: f } %>
+        </div>
+        <div class="panel-footer">
+          <%= f.button :submit, "Save", class: 'btn btn-primary'%>
+        </div>
+      </div>
+    <% end %>
+  </div>
+  <div class="col-md-2">
+    <%= render "side_nav", collection: @collection, form: params[:form] %>
+  </div>
+</div>

--- a/app/views/shared/_collection_left_nav.html.erb
+++ b/app/views/shared/_collection_left_nav.html.erb
@@ -1,7 +1,7 @@
 <div class="nav-panel ">
   <ul class="well">
     <li class="<%= nav.active_section_css(:items) %>"><a href="<%= collection_items_path(nav.collection) %>"><i class="glyphicon glyphicon-picture"></i> <%= t('collection_left_nav.items') %></a></li>
-    <li class="<%= nav.active_section_css(:showcases) %>"><a href="<%= collection_exhibit_path(nav.collection) %>"><i class="glyphicon glyphicon-film"></i> <%= t('collection_left_nav.showcases') %></a></li>
+    <li class="<%= nav.active_section_css(:showcases) %>"><a href="<%= collection_showcases_path(nav.collection) %>"><i class="glyphicon glyphicon-film"></i> <%= t('collection_left_nav.showcases') %></a></li>
     <li class="<%= nav.active_section_css(:website) %>"><a href="<%= site_setup_collection_path(nav.collection) %>"><i class="glyphicon mdi-av-web"></i> <%= t('collection_left_nav.website') %></a></li>
     <li role="presentation" class="divider"></li>
     <li class="<%= nav.active_section_css(:settings) %>"><a href="<%= edit_collection_path(nav.collection) %>"><i class="glyphicon glyphicon-list-alt"></i> <%= t('collection_left_nav.settings') %></a></li>

--- a/app/views/shared/_collection_left_nav.html.erb
+++ b/app/views/shared/_collection_left_nav.html.erb
@@ -5,7 +5,6 @@
     <li class="<%= nav.active_section_css(:website) %>"><a href="<%= site_setup_collection_path(nav.collection) %>"><i class="glyphicon mdi-av-web"></i> <%= t('collection_left_nav.website') %></a></li>
     <li role="presentation" class="divider"></li>
     <li class="<%= nav.active_section_css(:settings) %>"><a href="<%= edit_collection_path(nav.collection) %>"><i class="glyphicon glyphicon-list-alt"></i> <%= t('collection_left_nav.settings') %></a></li>
-    <li class="<%= nav.active_section_css(:editors) %>"><a href="<%= collection_editors_path(nav.collection) %>"><i class="glyphicon glyphicon-user"></i> <%= t('collection_left_nav.editors') %></a></li>
     <li role="presentation" class="divider"></li>
 
     <li className="header" role="presentation">Publish Site</li>

--- a/app/views/shared/_collection_left_nav.html.erb
+++ b/app/views/shared/_collection_left_nav.html.erb
@@ -4,8 +4,8 @@
     <li class="<%= nav.active_section_css(:showcases) %>"><a href="<%= collection_exhibit_path(nav.collection) %>"><i class="glyphicon glyphicon-film"></i> <%= t('collection_left_nav.showcases') %></a></li>
     <li class="<%= nav.active_section_css(:website) %>"><a href="<%= site_setup_collection_path(nav.collection) %>"><i class="glyphicon mdi-av-web"></i> <%= t('collection_left_nav.website') %></a></li>
     <li role="presentation" class="divider"></li>
-    <li class="<%= nav.active_section_css(:editors) %>"><a href="<%= collection_editors_path(nav.collection) %>"><i class="glyphicon glyphicon-user"></i> <%= t('collection_left_nav.editors') %></a></li>
     <li class="<%= nav.active_section_css(:settings) %>"><a href="<%= edit_collection_path(nav.collection) %>"><i class="glyphicon glyphicon-list-alt"></i> <%= t('collection_left_nav.settings') %></a></li>
+    <li class="<%= nav.active_section_css(:editors) %>"><a href="<%= collection_editors_path(nav.collection) %>"><i class="glyphicon glyphicon-user"></i> <%= t('collection_left_nav.editors') %></a></li>
     <li role="presentation" class="divider"></li>
 
     <li className="header" role="presentation">Publish Site</li>

--- a/app/views/shared/_collection_left_nav.html.erb
+++ b/app/views/shared/_collection_left_nav.html.erb
@@ -1,12 +1,9 @@
 <div class="nav-panel ">
   <ul class="well">
-    <li class="header" role="presentation"><%= nav.collection.name_line_1 %></li>
-
     <li class="<%= nav.active_section_css(:items) %>"><a href="<%= collection_items_path(nav.collection) %>"><i class="glyphicon glyphicon-picture"></i> <%= t('collection_left_nav.items') %></a></li>
     <li class="<%= nav.active_section_css(:showcases) %>"><a href="<%= collection_exhibit_path(nav.collection) %>"><i class="glyphicon glyphicon-film"></i> <%= t('collection_left_nav.showcases') %></a></li>
+    <li class="<%= nav.active_section_css(:website) %>"><a href="<%= site_setup_collection_path(nav.collection) %>"><i class="glyphicon mdi-av-web"></i> <%= t('collection_left_nav.website') %></a></li>
     <li role="presentation" class="divider"></li>
-    <li class="header" role="presentation">Settings</li>
-    <li class="<%= nav.active_section_css(:website) %>"><a href="<%= edit_exhibit_path(nav.collection.exhibit) %>"><i class="glyphicon mdi-av-web"></i> <%= t('collection_left_nav.website') %></a></li>
     <li class="<%= nav.active_section_css(:editors) %>"><a href="<%= collection_editors_path(nav.collection) %>"><i class="glyphicon glyphicon-user"></i> <%= t('collection_left_nav.editors') %></a></li>
     <li class="<%= nav.active_section_css(:settings) %>"><a href="<%= edit_collection_path(nav.collection) %>"><i class="glyphicon glyphicon-list-alt"></i> <%= t('collection_left_nav.settings') %></a></li>
     <li role="presentation" class="divider"></li>

--- a/app/views/shared/_collection_left_nav.html.erb
+++ b/app/views/shared/_collection_left_nav.html.erb
@@ -4,6 +4,7 @@
     <li class="<%= nav.active_section_css(:showcases) %>"><a href="<%= collection_showcases_path(nav.collection) %>"><i class="glyphicon glyphicon-film"></i> <%= t('collection_left_nav.showcases') %></a></li>
     <li class="<%= nav.active_section_css(:website) %>"><a href="<%= site_setup_collection_path(nav.collection) %>"><i class="glyphicon mdi-av-web"></i> <%= t('collection_left_nav.website') %></a></li>
     <li role="presentation" class="divider"></li>
+    <li class="<%= nav.active_section_css(:editors) %>"><a href="<%= collection_editors_path(nav.collection) %>"><i class="glyphicon glyphicon-user"></i> <%= t('collection_left_nav.editors') %></a></li>
     <li class="<%= nav.active_section_css(:settings) %>"><a href="<%= edit_collection_path(nav.collection) %>"><i class="glyphicon glyphicon-list-alt"></i> <%= t('collection_left_nav.settings') %></a></li>
     <li role="presentation" class="divider"></li>
 

--- a/app/views/showcases/_action_bar.html.erb
+++ b/app/views/showcases/_action_bar.html.erb
@@ -1,7 +1,7 @@
 <div class="menu-bar default pull-left">
   <div class="btn-group">
     <%= link_to raw("<i class=\"glyphicon glyphicon-plus\"></i> #{t('.new', :default => t("Add Showcase"))}"),
-          new_exhibit_showcase_path(exhibit),
+          new_collection_showcase_path(collection),
           :class => 'btn btn-primary' %>
   </div>
 

--- a/app/views/showcases/_edit_action_bar.html.erb
+++ b/app/views/showcases/_edit_action_bar.html.erb
@@ -1,6 +1,6 @@
 <div class="menu-bar default">
   <div class="btn-group">
-    <%= back_button(exhibit_showcases_path(@showcase.exhibit)) %>
+    <%= back_button(collection_showcases_path(@showcase.collection)) %>
 
   </div>
       <%= link_to("PREVIEW", @showcase.beehive_url, class: "btn btn-large btn-hollow", :target => "_blank") %>

--- a/app/views/showcases/edit.html.erb
+++ b/app/views/showcases/edit.html.erb
@@ -4,7 +4,7 @@
 <%= render partial: 'edit_action_bar' %>
 
 <%= react_component 'ShowcaseEditor', {
-      itemsJSONPath: @showcase.exhibit.items_json_url,
+      itemsJSONPath: @showcase.collection.items_json_url,
       sectionsCreatePath: showcase_sections_path(@showcase, :json),
       showcaseJSONPath: showcase_path(@showcase.id, :json),
     },

--- a/app/views/showcases/index.html.erb
+++ b/app/views/showcases/index.html.erb
@@ -1,6 +1,6 @@
-<% page_title(t('.title'), @exhibit.collection) %>
-<%= collection_nav(@exhibit.collection, :showcases) %>
+<% page_title(t('.title'), @collection) %>
+<%= collection_nav(@collection, :showcases) %>
 
-<%= render partial: 'action_bar', locals: { exhibit: @exhibit } %>
+<%= render partial: 'action_bar', locals: { collection: @collection } %>
 
 <%= render partial: 'list', locals: { showcases: @showcases } %>

--- a/app/views/showcases/new.html.erb
+++ b/app/views/showcases/new.html.erb
@@ -1,7 +1,7 @@
-<% page_title(t('.title'), @exhibit.collection) %>
-<%= collection_nav(@exhibit.collection, :showcases) %>
+<% page_title(t('.title'), @collection) %>
+<%= collection_nav(@collection, :showcases) %>
 
-<%= simple_form_for [@showcase.exhibit, @showcase], :html => { :class => 'form-horizontal' } do |f| %>
+<%= simple_form_for [@showcase.collection, @showcase], :html => { :class => 'form-horizontal' } do |f| %>
   <div class="panel panel-default">
     <div class="panel-heading">
       <h3 class="panel-title">New Showcase</h3>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -71,7 +71,7 @@ en:
   collection_left_nav:
     items: 'Items'
     showcases: 'Showcases'
-    settings: 'Settings'
+    settings: 'Collection Settings'
     website: 'Site Setup'
     editors: 'Editors'
     live_site: 'Live Site'
@@ -93,7 +93,7 @@ en:
     new:
       title: 'New Collection'
     edit:
-      title: 'Settings'
+      title: 'Collection Settings'
     create:
       success: 'Collection created'
     update:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -74,7 +74,7 @@ en:
   collection_left_nav:
     items: 'Items'
     showcases: 'Showcases'
-    settings: 'Collection Settings'
+    settings: 'Settings'
     website: 'Site Setup'
     editors: 'Editors'
     live_site: 'Live Site'
@@ -96,7 +96,7 @@ en:
     new:
       title: 'New Collection'
     edit:
-      title: 'Collection Settings'
+      title: 'Settings'
     create:
       success: 'Collection created'
     update:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -71,7 +71,7 @@ en:
   collection_left_nav:
     items: 'Items'
     showcases: 'Showcases'
-    settings: 'Collection'
+    settings: 'Settings'
     website: 'Site Setup'
     editors: 'Editors'
     live_site: 'Live Site'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -215,3 +215,13 @@ en:
     attributes:
       item:
         manuscript_url: "Digitized Manuscript URL"
+  admin:
+    external_collections:
+      create:
+        success: 'Collection created'
+      update:
+        success: 'Collection updated'
+      site_setup_update:
+        success: 'Collection updated'
+      destroy:
+        success: 'Collection deleted'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -47,6 +47,8 @@ en:
       collection:
         name_line_1: 'Name Line 1'
         name_line_2: 'Name Line 2'
+        site_intro: 'Site Introduction'
+        short_intro: 'Short Introduction'
       exhibit:
         edit:
           description: "Collection/Exhibit Introduction"
@@ -64,7 +66,8 @@ en:
           description: "A more extensive description of this exhibit which will appear on the introduction page"
     placeholders:
       collection:
-        description: "Description should be a short description of what the collection is.  (100 Words)"
+        site_intro: "Create an introduction page to your site."
+        short_intro: "Create a short introduction. Try to limit this to around 200 characters."
       exhibit:
         edit:
           description: "Around 200 characters"
@@ -97,6 +100,8 @@ en:
     create:
       success: 'Collection created'
     update:
+      success: 'Collection updated'
+    site_setup_update:
       success: 'Collection updated'
     destroy:
       success: "Collection deleted"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,10 +23,13 @@ Rails.application.routes.draw do
     end
 
     member do
-      get "edit/:form", to: "collections#site_setup", as: :edit_collection_form, constraints: { form: /collection_introduction|about_text/ }
+      get "edit/:form", to: "collections#site_setup", as: :site_setup_form, constraints: { form: /homepage|collection_introduction|about_text|copyright_text/ }
+      patch "edit/:form", to: "collections#site_setup_update", as: :site_setup_update_form, constraints: { form: /homepage|collection_introduction|about_text|copyright_text/ }
       put :publish
       put :unpublish
       get :site_setup
+      patch :site_setup_update
+      put :site_setup_update
       post :get_google_import_authorization_uri, controller: "import"
       post :get_google_export_authorization_uri, controller: "export"
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,8 +23,9 @@ Rails.application.routes.draw do
     end
 
     member do
-      get "edit/:form", to: "collections#site_setup", as: :site_setup_form, constraints: { form: /homepage|collection_introduction|about_text|copyright_text/ }
-      patch "edit/:form", to: "collections#site_setup_update", as: :site_setup_update_form, constraints: { form: /homepage|collection_introduction|about_text|copyright_text/ }
+      site_setup_constraints = { form: /homepage|collection_introduction|about_text|copyright_text/ }
+      get "edit/:form", to: "collections#site_setup", as: :site_setup_form, constraints: site_setup_constraints
+      patch "edit/:form", to: "collections#site_setup_update", as: :site_setup_update_form, constraints: site_setup_constraints
       put :publish
       put :unpublish
       get :site_setup

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,8 +23,10 @@ Rails.application.routes.draw do
     end
 
     member do
+      get "edit/:form", to: "collections#site_setup", as: :edit_collection_form, constraints: { form: /collection_introduction|about_text/ }
       put :publish
       put :unpublish
+      get :site_setup
       post :get_google_import_authorization_uri, controller: "import"
       post :get_google_export_authorization_uri, controller: "export"
     end

--- a/db/migrate/20151103154957_drop_fkc_for_collection_exhibit.rb
+++ b/db/migrate/20151103154957_drop_fkc_for_collection_exhibit.rb
@@ -1,0 +1,21 @@
+class DropFkcForCollectionExhibit < ActiveRecord::Migration
+  # Asserts that the given query results are empty
+  def empty!(query:, error_message:)
+    result = execute query
+    if result.count > 0
+      raise "Unable to add foreign keys. #{error_message}"
+    end
+  end
+
+  def up
+    remove_foreign_key :exhibits, :collections
+  end
+
+  def down
+    empty!(query: "SELECT * FROM exhibits WHERE
+                     exhibits.collection_id IS NULL OR exhibits.collection_id NOT IN (SELECT id FROM collections);",
+           error_message: "Cannot re-add exhibit->collection constraint. An exhibit was found that had no associated collection.")
+
+    add_foreign_key :exhibits, :collections
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151015142141) do
+ActiveRecord::Schema.define(version: 20151103154957) do
 
   create_table "collection_users", force: :cascade do |t|
     t.integer  "user_id",       limit: 4, null: false
@@ -201,7 +201,6 @@ ActiveRecord::Schema.define(version: 20151015142141) do
 
   add_foreign_key "collection_users", "collections"
   add_foreign_key "collection_users", "users"
-  add_foreign_key "exhibits", "collections"
   add_foreign_key "items", "collections"
   add_foreign_key "items", "items", column: "parent_id"
   add_foreign_key "sections", "items"

--- a/spec/controllers/admin/external_collections_controller_spec.rb
+++ b/spec/controllers/admin/external_collections_controller_spec.rb
@@ -2,8 +2,16 @@ require "rails_helper"
 require "cache_spec_helper"
 
 RSpec.describe Admin::ExternalCollectionsController, type: :controller do
-  let(:collection) { instance_double(Collection, id: 1, name_line_1: "COLLECTION", destroy!: true, collection_users: [], showcases: [], items: [], honeypot_image: nil) }
-
+  let(:collection) do
+    instance_double(Collection,
+                    id: 1,
+                    name_line_1: "COLLECTION",
+                    destroy!: true,
+                    collection_users: [],
+                    showcases: [],
+                    items: [],
+                    honeypot_image: nil)
+  end
   let(:create_params) { { external_collection: { name_line_1: "TITLE!!" } } }
   let(:update_params) { { id: "1", published: true, external_collection: { name_line_1: "TITLE!!" } } }
 

--- a/spec/controllers/admin/external_collections_controller_spec.rb
+++ b/spec/controllers/admin/external_collections_controller_spec.rb
@@ -1,0 +1,177 @@
+require "rails_helper"
+require "cache_spec_helper"
+
+RSpec.describe Admin::ExternalCollectionsController, type: :controller do
+  let(:collection) { instance_double(Collection, id: 1, name_line_1: "COLLECTION", destroy!: true, collection_users: [], showcases: [], items: [], honeypot_image: nil) }
+
+  let(:create_params) { { external_collection: { name_line_1: "TITLE!!" } } }
+  let(:update_params) { { id: "1", published: true, external_collection: { name_line_1: "TITLE!!" } } }
+
+  before(:each) do
+    @user = sign_in_admin
+  end
+
+  describe "index" do
+    subject { get :index }
+
+    it "checks the admin permissions" do
+      expect_any_instance_of(described_class).to receive(:check_admin_or_admin_masquerading_permission!)
+      subject
+    end
+
+    it "uses the query object" do
+      expect_any_instance_of(CollectionQuery).to receive(:all_external)
+      subject
+    end
+
+    it "is a success" do
+      subject
+
+      expect(response).to be_success
+      expect(response).to render_template("index")
+    end
+  end
+
+  describe "new" do
+    it "checks the admin permissions" do
+      expect_any_instance_of(described_class).to receive(:check_admin_or_admin_masquerading_permission!)
+      get :new
+    end
+
+    it "calls CollectionQuery to get the collection" do
+      expect_any_instance_of(CollectionQuery).to receive(:build).and_return(Collection.new)
+      get :new
+    end
+
+    it "loads a new collection" do
+      get :new
+      assigns(:external_collection)
+      expect(assigns(:external_collection)).to be_a(Collection)
+    end
+
+    it "is a success" do
+      get :new
+      expect(response).to be_success
+    end
+  end
+
+  describe "create" do
+    before(:each) do
+      allow_any_instance_of(CollectionQuery).to receive(:build).and_return(collection)
+      allow(SaveCollection).to receive(:call).and_return(true)
+    end
+
+    it "checks the admin permissions" do
+      expect_any_instance_of(described_class).to receive(:check_admin_or_admin_masquerading_permission!)
+      post :create, create_params
+    end
+
+    it "calls the save service" do
+      expect(SaveCollection).to receive(:call)
+      post :create, create_params
+    end
+
+    it "assigns a collection" do
+      post :create, create_params
+
+      assigns(:external_collection)
+      expect(assigns(:external_collection)).to eq(collection)
+    end
+
+    it "redirects on success" do
+      post :create, create_params
+      expect(response).to be_redirect
+    end
+
+    it "renders new on failure" do
+      allow(SaveCollection).to receive(:call).and_return(false)
+
+      post :create, create_params
+      expect(response).to render_template(:new)
+    end
+  end
+
+  describe "edit" do
+    before(:each) do
+      allow_any_instance_of(CollectionQuery).to receive(:find).and_return(collection)
+    end
+
+    it "checks the admin permissions" do
+      expect_any_instance_of(described_class).to receive(:check_admin_or_admin_masquerading_permission!)
+      get :edit, id: 1
+    end
+
+    it "uses collection query to get the colletion" do
+      expect_any_instance_of(CollectionQuery).to receive(:find).with("1").and_return(collection)
+      get :edit, id: 1
+    end
+
+    it "is a success" do
+      get :edit, id: 1
+      expect(response).to be_success
+    end
+  end
+
+  describe "update" do
+    before(:each) do
+      allow_any_instance_of(CollectionQuery).to receive(:find).and_return(collection)
+      allow(SaveCollection).to receive(:call).and_return(true)
+    end
+
+    it "checks the admin permissions" do
+      expect_any_instance_of(described_class).to receive(:check_admin_or_admin_masquerading_permission!)
+      put :update, update_params
+    end
+
+    it "uses collection query to get the colletion" do
+      expect_any_instance_of(CollectionQuery).to receive(:find).with("1").and_return(collection)
+      put :update, update_params
+    end
+
+    it "assigns a collection" do
+      put :update, update_params
+
+      assigns(:external_collection)
+      expect(assigns(:external_collection)).to eq(collection)
+    end
+
+    it "redirects on success" do
+      put :update, update_params
+      expect(response).to be_redirect
+    end
+
+    it "renders edit on failure" do
+      allow(SaveCollection).to receive(:call).and_return(false)
+
+      put :update, update_params
+      expect(response).to render_template(:edit)
+    end
+  end
+
+  describe "destroy" do
+    before(:each) do
+      allow_any_instance_of(CollectionQuery).to receive(:find).and_return(collection)
+    end
+
+    it "checks admin permissions" do
+      expect_any_instance_of(described_class).to receive(:check_admin_or_admin_masquerading_permission!)
+
+      delete :destroy, id: "1"
+    end
+
+    it "uses collection query to get the colletion" do
+      expect_any_instance_of(CollectionQuery).to receive(:find).with("1").and_return(collection)
+      delete :destroy, id: "1"
+    end
+
+    it "redirects on success " do
+      delete :destroy, id: "1"
+      expect(response).to be_redirect
+    end
+
+    it "uses the Destroy::Collection.cascade! method" do
+      expect_any_instance_of(Destroy::Collection).to receive(:cascade!)
+      delete :destroy, id: "1"
+    end
+  end
+end

--- a/spec/controllers/sections_controller_spec.rb
+++ b/spec/controllers/sections_controller_spec.rb
@@ -2,8 +2,7 @@ require "rails_helper"
 require "cache_spec_helper"
 
 RSpec.describe SectionsController, type: :controller do
-  let(:showcase) { double(Showcase, id: 1, name: "name", sections: relation, exhibit: exhibit) }
-  let(:exhibit) { double(Exhibit, id: 1, name: "name", showcases: relation, collection: collection) }
+  let(:showcase) { double(Showcase, id: 1, name: "name", sections: relation, collection: collection) }
   let(:collection) { instance_double(Collection, id: 1, name_line_1: "name_line_1") }
   let(:section) { double(Section, id: 1, destroy!: true, showcase: showcase, :order= => true, order: 1, collection: collection) }
   let(:relation) { Section.all }

--- a/spec/decorators/collections_side_nav_spec.rb
+++ b/spec/decorators/collections_side_nav_spec.rb
@@ -1,0 +1,99 @@
+require "rails_helper"
+
+RSpec.describe CollectionsSideNav do
+  let(:collection) { double(Collection, id: 1) }
+
+  describe "#homepage_link" do
+    let(:context) { double("context", site_setup_form_collection_path: "path", link_to: "link") }
+    let(:subject) { described_class.new(collection: collection, form: nil) }
+
+    before(:each) do
+      allow(subject).to receive(:h).and_return(context)
+    end
+
+    it "returns a link to the homepage_form" do
+      expect(subject.homepage_link).to eq("link")
+    end
+
+    it "calls the correct path method" do
+      expect(context).to receive(:site_setup_form_collection_path).with(collection, form: "homepage")
+      subject.homepage_link
+    end
+  end
+
+  describe "#collection_introduction_link" do
+    let(:context) { double("context", site_setup_form_collection_path: "path", link_to: "link") }
+    let(:subject) { described_class.new(collection: collection, form: nil) }
+
+    before(:each) do
+      allow(subject).to receive(:h).and_return(context)
+    end
+
+    it "returns a link to the collection_introduction_form" do
+      expect(subject.collection_introduction_link).to eq("link")
+    end
+
+    it "calls the correct path method" do
+      expect(context).to receive(:site_setup_form_collection_path).with(collection, form: "collection_introduction")
+      subject.collection_introduction_link
+    end
+  end
+
+  describe "#about_text_link" do
+    let(:context) { double("context", site_setup_form_collection_path: "path", link_to: "link") }
+    let(:subject) { described_class.new(collection: collection, form: nil) }
+
+    before(:each) do
+      allow(subject).to receive(:h).and_return(context)
+    end
+
+    it "returns a link to the about_text_form" do
+      expect(subject.about_text_link).to eq("link")
+    end
+
+    it "calls the correct path method" do
+      expect(context).to receive(:site_setup_form_collection_path).with(collection, form: "about_text")
+      subject.about_text_link
+    end
+  end
+
+  describe "#copyright_text_link" do
+    let(:context) { double("context", site_setup_form_collection_path: "path", link_to: "link") }
+    let(:subject) { described_class.new(collection: collection, form: nil) }
+
+    before(:each) do
+      allow(subject).to receive(:h).and_return(context)
+    end
+
+    it "returns a link to the copyright_text_link" do
+      expect(subject.copyright_text_link).to eq("link")
+    end
+
+    it "calls the correct path method" do
+      expect(context).to receive(:site_setup_form_collection_path).with(collection, form: "copyright_text")
+      subject.copyright_text_link
+    end
+  end
+
+  describe "#active_tab_class" do
+    let(:context) { double("context") }
+    let(:subject) { described_class.new(collection: collection, form: "form") }
+
+    before(:each) do
+      allow(subject).to receive(:h).and_return(context)
+    end
+
+    it "returns active when the tab == the form " do
+      expect(subject.active_tab_class(tab: "form")).to eq("active")
+    end
+
+    it "returns empty string when the tab != form " do
+      expect(subject.active_tab_class(tab: "not_the_form")).to eq("")
+    end
+
+    it "returns active if the form is nil and the tab == edit " do
+      subject = described_class.new(collection: collection, form: nil)
+      expect(subject.active_tab_class(tab: "edit")).to eq("active")
+    end
+  end
+end

--- a/spec/decorators/showcase_list_spec.rb
+++ b/spec/decorators/showcase_list_spec.rb
@@ -4,8 +4,8 @@ describe ShowcaseList do
   subject { described_class.new(showcase) }
 
   let(:sections) { %w(section1 section2) }
-  let(:showcase) { double(Showcase, exhibit: exhibit, id: 1, sections: sections) }
-  let(:exhibit) { double(Exhibit, id: 1) }
+  let(:showcase) { double(Showcase, collection: collection, id: 1, sections: sections) }
+  let(:collection) { double(Collection, id: 1) }
 
   describe "sections" do
     before(:each) do
@@ -27,7 +27,7 @@ describe ShowcaseList do
     expect(subject.showcase).to be(showcase)
   end
 
-  it "returns the exhibit" do
-    expect(subject.exhibit).to be(exhibit)
+  it "returns the collection" do
+    expect(subject.collection).to be(collection)
   end
 end

--- a/spec/form/section_form_spec.rb
+++ b/spec/form/section_form_spec.rb
@@ -2,8 +2,7 @@ require "rails_helper"
 
 describe SectionForm do
   let(:collection) { double(Collection, id: 1) }
-  let(:exhibit) { double(Exhibit, id: 1, collection: collection) }
-  let(:showcase) { double(Showcase, id: 1, exhibit: exhibit, sections: sections) }
+  let(:showcase) { double(Showcase, id: 1, collection: collection, sections: sections) }
   let(:section) { double(Section, id: 1, order: 1, item_id: 1, showcase: showcase, "order=" => true, name: "the section") }
   let(:sections) { double(build: true) }
 

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -67,10 +67,14 @@ RSpec.describe Collection do
         expect { subject.destroy }.to raise_error
       end
 
-      it "fails if a Exhibit references it" do
-        subject = FactoryGirl.create(:collection)
-        FactoryGirl.create(:exhibit)
-        expect { subject.destroy }.to raise_error
+      context "foreign key constraints" do
+        describe "#destroy" do
+          it "fails if a Showcase references it" do
+            subject = FactoryGirl.create(:collection)
+            FactoryGirl.create(:showcase)
+            expect { subject.destroy }.to raise_error
+          end
+        end
       end
 
       it "fails if an Item references it" do

--- a/spec/services/save_honeypot_image_spec.rb
+++ b/spec/services/save_honeypot_image_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe SaveHoneypotImage do
   end
 
   let(:honeypot_image) { HoneypotImage.new(item_id: 1) }
-  let(:collection) { double(Collection, id: 1) }
-  let(:item) { double(Item, id: 1, collection: collection, image: image, honeypot_image: honeypot_image, save: true) }
+  let(:collection) { double(Collection, id: 100, image: image, honeypot_image: honeypot_image, save: true) }
+  let(:item) { double(Item, id: 10, collection: collection, image: image, honeypot_image: honeypot_image, save: true) }
   let(:image) { double(path: Rails.root.join("spec/fixtures/test.jpg").to_s, content_type: "image/jpeg") }
   let(:faraday_response) { double(success?: true, body: honeypot_json) }
 
@@ -33,7 +33,7 @@ RSpec.describe SaveHoneypotImage do
     end
 
     it "sends a request to the json api" do
-      expect(connection).to receive(:post).with("/api/images", application_id: "honeycomb", group_id: 1, item_id: 1, image: kind_of(Faraday::UploadIO)).and_return(faraday_response)
+      expect(connection).to receive(:post).with("/api/images", application_id: "honeycomb", group_id: 100, item_id: 10, image: kind_of(Faraday::UploadIO)).and_return(faraday_response)
 
       subject.save!
     end
@@ -110,6 +110,18 @@ RSpec.describe SaveHoneypotImage do
   describe "#api_url" do
     it "returns a url to the honeypot application" do
       expect(subject.send(:api_url)).to eq("http://localhost:3019")
+    end
+  end
+
+  context "group id" do
+    it "uses the collection id as the group id when the object is a collection" do
+      subject = described_class.new(object: collection)
+      expect(subject.send(:group_id)).to eq(collection.id)
+    end
+
+    it "uses the collection id as the group id when the object has a collection method" do
+      subject = described_class.new(object: item)
+      expect(subject.send(:group_id)).to eq(collection.id)
     end
   end
 end

--- a/spec/services/save_honeypot_image_spec.rb
+++ b/spec/services/save_honeypot_image_spec.rb
@@ -33,7 +33,12 @@ RSpec.describe SaveHoneypotImage do
     end
 
     it "sends a request to the json api" do
-      expect(connection).to receive(:post).with("/api/images", application_id: "honeycomb", group_id: 100, item_id: 10, image: kind_of(Faraday::UploadIO)).and_return(faraday_response)
+      expect(connection).to receive(:post).with("/api/images",
+                                                application_id: "honeycomb",
+                                                group_id: 100,
+                                                item_id: 10,
+                                                image: kind_of(Faraday::UploadIO)).
+        and_return(faraday_response)
 
       subject.save!
     end

--- a/spec/values/cache_keys/custom/collections_spec.rb
+++ b/spec/values/cache_keys/custom/collections_spec.rb
@@ -28,4 +28,18 @@ RSpec.describe CacheKeys::Custom::Collections do
       subject.edit(collection: collection)
     end
   end
+
+  context "site_setup" do
+    let(:collection) { instance_double(Collection) }
+
+    it "uses CacheKeys::ActiveRecord" do
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate)
+      subject.site_setup(collection: collection)
+    end
+
+    it "uses the correct data" do
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with(record: collection)
+      subject.site_setup(collection: collection)
+    end
+  end
 end


### PR DESCRIPTION
All of the data layer changes have been made. These changes are needed to fix the controllers and views to work with those data changes. I also made changes to the behavior of the site setup form. On save, it will now redirect back to the current form for editing. This was taking the user back to the top form, which meant the user would have to click on the form again to see the changes that they made.