### PR TITLE
Settings change for beehive alias

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -29,4 +29,4 @@ production:
   <<: *vm
   cas_base: https://login.nd.edu/cas
   honeypot_url: https://honeypot.library.nd.edu
-  beehive_url: https://beehive.library.nd.edu
+  beehive_url: https://collections.library.nd.edu


### PR DESCRIPTION
What: Changes settings to that honeycomb points to collections.library.nd.edu as the beehive alias