### PR TITLE
DEC-639: Add pages

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -25,12 +25,6 @@ class PagesController < ApplicationController
     end
   end
 
-  def show
-    @page = PageQuery.new.find(params[:id])
-    check_user_edits!(page.collection)
-    redirect_to edit_page_path(page.id)
-  end
-
   def edit
     @page = PageQuery.new.find(params[:id])
     check_user_edits!(@page.collection)
@@ -46,7 +40,7 @@ class PagesController < ApplicationController
 
     if SavePage.call(@page, save_params)
       flash[:notice] = t(".success")
-      redirect_to page_path(@page)
+      redirect_to edit_page_path(@page)
     else
       render :edit
     end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,0 +1,80 @@
+class PagesController < ApplicationController
+  def index
+    check_user_edits!(collection)
+    @pages = PageQuery.new(collection.pages).ordered
+    cache_key = CacheKeys::Generator.new(key_generator: CacheKeys::Custom::Pages,
+                                         action: "index",
+                                         collection: collection)
+    fresh_when(etag: cache_key.generate)
+  end
+
+  def new
+    check_user_edits!(collection)
+    @page = PageQuery.new(collection.pages).build
+  end
+
+  def create
+    check_user_edits!(collection)
+    @page = PageQuery.new(collection.pages).build(save_params)
+
+    if SavePage.call(@page, save_params)
+      flash[:notice] = t(".success")
+      redirect_to page_path(@page)
+    else
+      render :new
+    end
+  end
+
+  def show
+    @page = PageQuery.new.find(params[:id])
+    check_user_edits!(page.collection)
+    redirect_to edit_page_path(page.id)
+  end
+
+  def edit
+    @page = PageQuery.new.find(params[:id])
+    check_user_edits!(@page.collection)
+    cache_key = CacheKeys::Generator.new(key_generator: CacheKeys::Custom::Pages,
+                                         action: "edit",
+                                         page: @page)
+    fresh_when(etag: cache_key.generate)
+  end
+
+  def update
+    @page = PageQuery.new.find(params[:id])
+    check_user_edits!(@page.collection)
+
+    if SavePage.call(@page, save_params)
+      flash[:notice] = t(".success")
+      redirect_to page_path(@page)
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    @page = PageQuery.new.find(params[:id])
+    check_user_edits!(@page.collection)
+    Destroy::Page.new.cascade!(page: @page)
+
+    flash[:notice] = t(".success")
+    redirect_to collection_pages_path(@page.collection)
+  end
+
+  protected
+
+  def save_params
+    params.require(:page).permit([
+      :name,
+      :content
+    ])
+  end
+
+  def page
+    @page ||= PageQuery.new.find(params[:id])
+  end
+
+  def collection
+    @collection ||= CollectionQuery.new.find(params[:collection_id])
+  end
+end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -13,7 +13,7 @@ class PagesController < ApplicationController
     @page = PageQuery.new(collection.pages).build
   end
 
-  def create
+  def create # rubocop:disable Metrics/AbcSize
     check_user_edits!(collection)
     @page = PageQuery.new(collection.pages).build(save_params)
 

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -3,6 +3,7 @@ class Collection < ActiveRecord::Base
   has_many :collection_users
   has_many :users, through: :collection_users
   has_many :showcases
+  has_many :pages
   has_one :honeypot_image
 
   has_attached_file :image,

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -1,0 +1,7 @@
+class Page < ActiveRecord::Base
+  belongs_to :collection
+
+  validates :collection, presence: true
+
+  has_paper_trail
+end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -1,6 +1,7 @@
 class Page < ActiveRecord::Base
   belongs_to :collection
 
+  validates :name, presence: true
   validates :collection, presence: true
 
   has_paper_trail

--- a/app/queries/page_query.rb
+++ b/app/queries/page_query.rb
@@ -1,0 +1,29 @@
+class PageQuery
+  attr_reader :relation
+
+  def initialize(relation = Page.all)
+    @relation = relation
+  end
+
+  def all
+    relation
+  end
+
+  def ordered
+    relation.order(:name)
+  end
+
+  delegate :find, to: :relation
+
+  def build(args = {})
+    relation.build(args)
+  end
+
+  def public_find(id)
+    relation.find_by!(unique_id: id)
+  end
+
+  def can_delete?
+    true
+  end
+end

--- a/app/services/destroy/collection.rb
+++ b/app/services/destroy/collection.rb
@@ -2,10 +2,11 @@ module Destroy
   class Collection
 
     # Allow injecting destroy objects to use when cascading
-    def initialize(destroy_collection_user: nil, destroy_showcase: nil, destroy_item: nil)
+    def initialize(destroy_collection_user: nil, destroy_showcase: nil, destroy_item: nil, destroy_page: nil)
       @destroy_collection_user = destroy_collection_user || Destroy::CollectionUser.new
       @destroy_showcase = destroy_showcase || Destroy::Showcase.new
       @destroy_item = destroy_item || Destroy::Item.new
+      @destroy_page = destroy_page || Destroy::Page.new
     end
 
     # Destroy the object only
@@ -24,6 +25,9 @@ module Destroy
         end
         collection.items.each do |child|
           destroy_item.cascade!(item: child)
+        end
+        collection.pages.each do |child|
+          @destroy_page.cascade!(page: child)
         end
         collection.destroy!
       end

--- a/app/services/destroy/page.rb
+++ b/app/services/destroy/page.rb
@@ -1,0 +1,14 @@
+module Destroy
+  class Page
+    # Destroy the object only
+    def destroy!(page:)
+      page.destroy!
+    end
+
+    # There are no additional cascades for Pages,
+    # so destroys the object only
+    def cascade!(page:)
+      page.destroy!
+    end
+  end
+end

--- a/app/services/save_page.rb
+++ b/app/services/save_page.rb
@@ -1,0 +1,29 @@
+class SavePage
+  attr_reader :page, :params
+
+  def self.call(page, params)
+    new(page, params).save
+  end
+
+  def initialize(page, params)
+    @page = page
+    @params = params
+  end
+
+  def save
+    page.attributes = params
+
+    check_unique_id
+    if page.save
+      page
+    else
+      false
+    end
+  end
+
+  private
+
+  def check_unique_id
+    CreateUniqueId.call(page)
+  end
+end

--- a/app/values/cache_keys/custom/pages.rb
+++ b/app/values/cache_keys/custom/pages.rb
@@ -1,0 +1,14 @@
+module CacheKeys
+  module Custom
+    # Generator for sections_controller
+    class Pages
+      def index(collection:)
+        CacheKeys::ActiveRecord.new.generate(record: [collection, collection.pages])
+      end
+
+      def edit(page:)
+        CacheKeys::ActiveRecord.new.generate(record: [page, page.collection])
+      end
+    end
+  end
+end

--- a/app/views/pages/_action_bar.html.erb
+++ b/app/views/pages/_action_bar.html.erb
@@ -1,0 +1,13 @@
+<div class="menu-bar default pull-left">
+  <div class="btn-group">
+    <%= link_to raw("<i class=\"glyphicon glyphicon-plus\"></i> #{t('.new', :default => t("Add Page"))}"),
+          new_collection_page_path(collection),
+          :class => 'btn btn-primary' %>
+  </div>
+
+</div>
+<div class="pull-right">
+  <div class="btn-group">
+    <%= learn_more_button('#') %>
+  </div>
+</div>

--- a/app/views/pages/_edit_action_bar.html.erb
+++ b/app/views/pages/_edit_action_bar.html.erb
@@ -1,0 +1,11 @@
+<div class="menu-bar default">
+  <div class="btn-group">
+    <%= back_button(collection_pages_path(@page.collection)) %>
+  </div>
+
+  <div class="pull-right">
+    <div class="btn-group">
+      <%= learn_more_button('#') %>
+    </div>
+  </div>
+</div>

--- a/app/views/pages/_form.html.erb
+++ b/app/views/pages/_form.html.erb
@@ -1,0 +1,4 @@
+<%= display_errors(@page) %>
+
+<%= f.input :name, as: :string %>
+<%= f.input :content, input_html: { class: 'honeycomb_redactor'  } %>

--- a/app/views/pages/_list.html.erb
+++ b/app/views/pages/_list.html.erb
@@ -1,0 +1,24 @@
+<table class="table table-striped item-list">
+  <thead>
+    <tr>
+      <th><%= t('.name') %></th>
+      <th><%= t('.content') %></th>
+      <th><%= t('.updated_at') %></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% pages.each do |page| %>
+      <tr>
+        <td>
+          <h4 class="media-heading"><%= h link_to page.name, page_path(page) %></h4>
+        </td>
+        <td>
+          <%= truncate(strip_tags(page.content), length: 200, omission: '...') %>
+        </th>
+        <td>
+           <%= ListTime.display(page.updated_at) %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/pages/_list.html.erb
+++ b/app/views/pages/_list.html.erb
@@ -10,7 +10,7 @@
     <% pages.each do |page| %>
       <tr>
         <td>
-          <h4 class="media-heading"><%= h link_to page.name, page_path(page) %></h4>
+          <h4 class="media-heading"><%= h link_to page.name, edit_page_path(page) %></h4>
         </td>
         <td>
           <%= truncate(strip_tags(page.content), length: 200, omission: '...') %>

--- a/app/views/pages/edit.html.erb
+++ b/app/views/pages/edit.html.erb
@@ -1,0 +1,19 @@
+<% page_title(@page.name, @page.collection) %>
+<%= collection_nav(@page.collection, :pages) %>
+
+<%= render partial: 'edit_action_bar' %>
+
+<%= simple_form_for @page, :html => { :class => 'form-horizontal' } do |f| %>
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      <h3 class="panel-title"><%= @page.name %></h3>
+    </div>
+    <div class="panel-body">
+      <%= render partial: 'form', locals: { f: f } %>
+    </div>
+    <div class="panel-footer">
+      <%= f.button :submit, "Save", class: 'btn btn-primary'%>
+    </div>
+  </div>
+<% end %>
+    <%= DeletePanel.new(@page).display(PageQuery.new(@page)) %>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -1,0 +1,6 @@
+<% page_title(t('.title'), @collection) %>
+<%= collection_nav(@collection, :pages) %>
+
+<%= render partial: 'action_bar', locals: { collection: @collection } %>
+
+<%= render partial: 'list', locals: { pages: @pages } %>

--- a/app/views/pages/new.html.erb
+++ b/app/views/pages/new.html.erb
@@ -1,0 +1,16 @@
+<% page_title(t('.title'), @collection) %>
+<%= collection_nav(@collection, :pages) %>
+
+<%= simple_form_for [@page.collection, @page], :html => { :class => 'form-horizontal' } do |f| %>
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      <h3 class="panel-title">New Page</h3>
+    </div>
+    <div class="panel-body">
+      <%= render partial: 'form', locals: { f: f } %>
+    </div>
+    <div class="panel-footer">
+      <%= f.button :submit, "Save", class: 'btn btn-primary'%>
+    </div>
+  </div>
+<% end %>

--- a/app/views/shared/_collection_left_nav.html.erb
+++ b/app/views/shared/_collection_left_nav.html.erb
@@ -2,6 +2,7 @@
   <ul class="well">
     <li class="<%= nav.active_section_css(:items) %>"><a href="<%= collection_items_path(nav.collection) %>"><i class="glyphicon glyphicon-picture"></i> <%= t('collection_left_nav.items') %></a></li>
     <li class="<%= nav.active_section_css(:showcases) %>"><a href="<%= collection_showcases_path(nav.collection) %>"><i class="glyphicon glyphicon-film"></i> <%= t('collection_left_nav.showcases') %></a></li>
+    <li class="<%= nav.active_section_css(:pages) %>"><a href="<%= collection_pages_path(nav.collection) %>"><i class="glyphicon glyphicon-duplicate"></i> <%= t('collection_left_nav.pages') %></a></li>
     <li class="<%= nav.active_section_css(:website) %>"><a href="<%= site_setup_collection_path(nav.collection) %>"><i class="glyphicon mdi-av-web"></i> <%= t('collection_left_nav.website') %></a></li>
     <li role="presentation" class="divider"></li>
     <li class="<%= nav.active_section_css(:editors) %>"><a href="<%= collection_editors_path(nav.collection) %>"><i class="glyphicon glyphicon-user"></i> <%= t('collection_left_nav.editors') %></a></li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -64,6 +64,7 @@ en:
   collection_left_nav:
     items: 'Items'
     showcases: 'Showcases'
+    pages: 'Pages'
     settings: 'Settings'
     website: 'Site Setup'
     editors: 'Editors'
@@ -212,3 +213,19 @@ en:
         success: 'Collection updated'
       destroy:
         success: 'Collection deleted'
+  pages:
+    index:
+      title: "Pages"
+    create:
+      success: "Page created"
+    new:
+      title: "New Page"
+    list:
+      name: "Page"
+      content: "Content"
+      updated_at: 'Last Modified At'
+    update:
+      success: "Page updated"
+    destroy:
+      success: "Page deleted"
+      failure: "There was a problem deleting this page"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,7 +60,7 @@ Rails.application.routes.draw do
     resources :sections, only: [:index, :new, :create]
   end
 
-  resources :pages, only: [:show, :edit, :update, :destroy]
+  resources :pages, only: [:edit, :update, :destroy]
 
   resources :sections, only: [:edit, :update, :destroy]
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,7 @@ Rails.application.routes.draw do
 
     resources :items, only: [:index, :new, :create]
     resources :showcases, only: [:index, :new, :create]
+    resources :pages, only: [:index, :new, :create]
 
     resources :editors, only: [:index, :create, :destroy] do
       collection do
@@ -58,6 +59,8 @@ Rails.application.routes.draw do
     end
     resources :sections, only: [:index, :new, :create]
   end
+
+  resources :pages, only: [:show, :edit, :update, :destroy]
 
   resources :sections, only: [:edit, :update, :destroy]
 

--- a/db/migrate/20151106195018_create_pages.rb
+++ b/db/migrate/20151106195018_create_pages.rb
@@ -1,0 +1,13 @@
+class CreatePages < ActiveRecord::Migration
+  def change
+    create_table :pages do |t|
+      t.string :unique_id
+      t.string :name
+      t.text :content
+      t.integer :collection_id, null: false
+      t.integer :image_id
+      t.timestamps null: false
+    end
+    add_foreign_key :pages, :collections
+  end
+end

--- a/db/migrate/20151106195018_create_pages.rb
+++ b/db/migrate/20151106195018_create_pages.rb
@@ -5,7 +5,6 @@ class CreatePages < ActiveRecord::Migration
       t.string :name
       t.text :content
       t.integer :collection_id, null: false
-      t.integer :image_id
       t.timestamps null: false
     end
     add_foreign_key :pages, :collections

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -66,11 +66,11 @@ ActiveRecord::Schema.define(version: 20151106195018) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.text     "about",                       limit: 65535
-    t.text     "copyright",                   limit: 65535
     t.string   "uploaded_image_file_name",    limit: 255
     t.string   "uploaded_image_content_type", limit: 255
     t.integer  "uploaded_image_file_size",    limit: 4
     t.datetime "uploaded_image_updated_at"
+    t.text     "copyright",                   limit: 65535
     t.boolean  "hide_title_on_home_page"
     t.string   "url",                         limit: 255
     t.boolean  "enable_search"
@@ -128,7 +128,6 @@ ActiveRecord::Schema.define(version: 20151106195018) do
     t.string   "name",          limit: 255
     t.text     "content",       limit: 65535
     t.integer  "collection_id", limit: 4,     null: false
-    t.integer  "image_id",      limit: 4
     t.datetime "created_at",                  null: false
     t.datetime "updated_at",                  null: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151104211754) do
+ActiveRecord::Schema.define(version: 20151106195018) do
 
   create_table "collection_users", force: :cascade do |t|
     t.integer  "user_id",       limit: 4, null: false
@@ -66,11 +66,11 @@ ActiveRecord::Schema.define(version: 20151104211754) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.text     "about",                       limit: 65535
+    t.text     "copyright",                   limit: 65535
     t.string   "uploaded_image_file_name",    limit: 255
     t.string   "uploaded_image_content_type", limit: 255
     t.integer  "uploaded_image_file_size",    limit: 4
     t.datetime "uploaded_image_updated_at"
-    t.text     "copyright",                   limit: 65535
     t.boolean  "hide_title_on_home_page"
     t.string   "url",                         limit: 255
     t.boolean  "enable_search"
@@ -122,6 +122,18 @@ ActiveRecord::Schema.define(version: 20151104211754) do
   add_index "items", ["parent_id"], name: "index_items_on_parent_id", using: :btree
   add_index "items", ["published"], name: "index_items_on_published", using: :btree
   add_index "items", ["unique_id"], name: "index_items_on_unique_id", using: :btree
+
+  create_table "pages", force: :cascade do |t|
+    t.string   "unique_id",     limit: 255
+    t.string   "name",          limit: 255
+    t.text     "content",       limit: 65535
+    t.integer  "collection_id", limit: 4,     null: false
+    t.integer  "image_id",      limit: 4
+    t.datetime "created_at",                  null: false
+    t.datetime "updated_at",                  null: false
+  end
+
+  add_index "pages", ["collection_id"], name: "fk_rails_b9e6c17b8e", using: :btree
 
   create_table "sections", force: :cascade do |t|
     t.string   "name",        limit: 255
@@ -202,6 +214,7 @@ ActiveRecord::Schema.define(version: 20151104211754) do
   add_foreign_key "collection_users", "users"
   add_foreign_key "items", "collections"
   add_foreign_key "items", "items", column: "parent_id"
+  add_foreign_key "pages", "collections"
   add_foreign_key "sections", "items"
   add_foreign_key "sections", "showcases"
   add_foreign_key "showcases", "collections"

--- a/spec/controllers/admin/external_collections_controller_spec.rb
+++ b/spec/controllers/admin/external_collections_controller_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Admin::ExternalCollectionsController, type: :controller do
                     destroy!: true,
                     collection_users: [],
                     showcases: [],
+                    pages: [],
                     items: [],
                     honeypot_image: nil)
   end

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 require "cache_spec_helper"
 
 RSpec.describe CollectionsController, type: :controller do
-  let(:collection) { instance_double(Collection, id: 1, name_line_1: "COLLECTION", destroy!: true, collection_users: [], showcases: [], items: []) }
+  let(:collection) { instance_double(Collection, id: 1, name_line_1: "COLLECTION", destroy!: true, collection_users: [], showcases: [], pages: [], items: []) }
 
   let(:create_params) { { collection: { name_line_1: "TITLE!!" } } }
   let(:update_params) { { id: "1", published: true, collection: { name_line_1: "TITLE!!" } } }

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -160,32 +160,6 @@ RSpec.describe PagesController, type: :controller do
     it_behaves_like "a private content-based etag cacher"
   end
 
-  describe "GET #show" do
-    subject { get :show, id: page.id }
-
-    it "checks the editor permissions" do
-      expect_any_instance_of(described_class).to receive(:check_user_edits!).with(collection)
-      subject
-    end
-
-    it "uses page query " do
-      expect_any_instance_of(PageQuery).to receive(:find).with("1").and_return(page)
-      subject
-    end
-
-    it "assigns a page decorator" do
-      subject
-      expect(assigns(:page)).to eq(page)
-    end
-
-    it "is a redirect" do
-      subject
-      expect(response).to be_redirect
-    end
-
-    it_behaves_like "a private content-based etag cacher"
-  end
-
   describe "GET #edit" do
     subject { get :edit, id: page.id }
 

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -1,0 +1,250 @@
+require "rails_helper"
+require "cache_spec_helper"
+
+RSpec.describe PagesController, type: :controller do
+  let(:page) { instance_double(Page, id: 1, name: "name", collection: collection, destroy!: true) }
+  let(:collection) { instance_double(Collection, id: 1, name_line_1: "name_line_1", pages: relation) }
+
+  let(:relation) { Page.all }
+  let(:create_params) { { collection_id: collection.id, page: { name: "name", content: "content" } } }
+  let(:update_params) { { id: page.id, page: { name: "name", content: "content" } } }
+
+  before(:each) do
+    sign_in_admin
+
+    allow_any_instance_of(CollectionQuery).to receive(:find).and_return(collection)
+    allow_any_instance_of(PageQuery).to receive(:find).and_return(page)
+    allow_any_instance_of(PageQuery).to receive(:build).and_return(page)
+    allow(SavePage).to receive(:call).and_return(true)
+  end
+
+  describe "GET #index" do
+    subject { get :index, collection_id: collection.id }
+
+    it "returns a 200" do
+      subject
+      expect(response).to be_success
+    end
+
+    it "checks the editor permissions" do
+      expect_any_instance_of(described_class).to receive(:check_user_edits!).with(collection)
+      subject
+    end
+
+    it "users the item query to get items" do
+      expect_any_instance_of(PageQuery).to receive(:ordered)
+      subject
+    end
+
+    it "assigns an item decorator to items" do
+      subject
+      expect(assigns(:pages)).to be_a(ActiveRecord::Relation)
+    end
+
+    it_behaves_like "a private basic custom etag cacher"
+
+    it "uses the Pages#index to generate the cache key" do
+      expect_any_instance_of(CacheKeys::Custom::Pages).to receive(:index)
+      subject
+    end
+  end
+
+  describe "GET #new" do
+    subject { get :new, collection_id: collection.id }
+
+    it "returns a 200" do
+      subject
+      expect(response).to be_success
+    end
+
+    it "checks the editor permissions" do
+      expect_any_instance_of(described_class).to receive(:check_user_edits!).with(collection)
+      subject
+    end
+
+    it "uses item query " do
+      expect_any_instance_of(PageQuery).to receive(:build).and_return(page)
+      subject
+    end
+
+    it "assigns and item and it is an item decorator" do
+      subject
+      expect(assigns(:page)).to eq(page)
+    end
+
+    it_behaves_like "a private content-based etag cacher"
+  end
+
+  describe "POST #create" do
+    subject { post :create, create_params }
+
+    it "checks the editor permissions" do
+      expect_any_instance_of(described_class).to receive(:check_user_edits!).with(collection)
+      subject
+    end
+
+    it "uses page query " do
+      expect_any_instance_of(PageQuery).to receive(:build).and_return(page)
+      subject
+    end
+
+    it "redirects on success" do
+      subject
+      expect(response).to be_redirect
+    end
+
+    it "flashes a notice" do
+      subject
+      expect(flash[:notice]).to_not be_nil
+    end
+
+    it "renders new on failure" do
+      allow(SavePage).to receive(:call).and_return(false)
+      subject
+      expect(response).to render_template("new")
+    end
+
+    it "assigns a page" do
+      subject
+      assigns(:page)
+      expect(assigns(:page)).to eq(page)
+    end
+
+    it "uses the save page service" do
+      expect(SavePage).to receive(:call).with(page, update_params[:page]).and_return(true)
+      subject
+    end
+
+    it_behaves_like "a private content-based etag cacher"
+  end
+
+  describe "PUT #update" do
+    subject { put :update, update_params }
+
+    it "checks the editor permissions" do
+      expect_any_instance_of(described_class).to receive(:check_user_edits!).with(collection)
+      subject
+    end
+
+    it "uses page query " do
+      expect_any_instance_of(PageQuery).to receive(:find).with("1").and_return(page)
+      subject
+    end
+
+    it "redirects on success" do
+      subject
+      expect(response).to be_redirect
+    end
+
+    it "flashes a notice" do
+      subject
+      expect(flash[:notice]).to_not be_nil
+    end
+
+    it "renders new on failure" do
+      allow(SavePage).to receive(:call).and_return(false)
+      subject
+      expect(response).to render_template("edit")
+    end
+
+    it "assigns a page" do
+      subject
+      expect(assigns(:page)).to eq(page)
+    end
+
+    it "uses the save page service" do
+      expect(SavePage).to receive(:call).with(page, update_params[:page]).and_return(true)
+      subject
+    end
+
+    it_behaves_like "a private content-based etag cacher"
+  end
+
+  describe "GET #show" do
+    subject { get :show, id: page.id }
+
+    it "checks the editor permissions" do
+      expect_any_instance_of(described_class).to receive(:check_user_edits!).with(collection)
+      subject
+    end
+
+    it "uses page query " do
+      expect_any_instance_of(PageQuery).to receive(:find).with("1").and_return(page)
+      subject
+    end
+
+    it "assigns a page decorator" do
+      subject
+      expect(assigns(:page)).to eq(page)
+    end
+
+    it "is a redirect" do
+      subject
+      expect(response).to be_redirect
+    end
+
+    it_behaves_like "a private content-based etag cacher"
+  end
+
+  describe "GET #edit" do
+    subject { get :edit, id: page.id }
+
+    it "checks the editor permissions" do
+      expect_any_instance_of(described_class).to receive(:check_user_edits!).with(collection)
+      subject
+    end
+
+    it "uses page query " do
+      expect_any_instance_of(PageQuery).to receive(:find).with("1").and_return(page)
+      subject
+    end
+
+    it "assigns a page" do
+      subject
+      expect(assigns(:page)).to eq(page)
+    end
+
+    it_behaves_like "a private basic custom etag cacher"
+
+    it "uses the Pages#default to generate the cache key" do
+      expect_any_instance_of(CacheKeys::Custom::Pages).to receive(:edit)
+      subject
+    end
+  end
+
+  describe "DELETE #destroy" do
+    subject { delete :destroy, id: page.id }
+
+    it "on success, redirects" do
+      subject
+      expect(response).to be_redirect
+    end
+
+    it "flashes a notice" do
+      subject
+      expect(flash[:notice]).to_not be_nil
+    end
+
+    it "assigns and item" do
+      subject
+      expect(assigns(:page)).to eq(page)
+    end
+
+    it "checks the editor permissions" do
+      expect_any_instance_of(described_class).to receive(:check_user_edits!).with(collection)
+      subject
+    end
+
+    it "uses page query " do
+      expect_any_instance_of(PageQuery).to receive(:find).with("1").and_return(page)
+      subject
+    end
+
+    it "uses the Destroy::Page.cascade method" do
+      expect_any_instance_of(Destroy::Page).to receive(:cascade!)
+      subject
+    end
+
+    it_behaves_like "a private content-based etag cacher"
+  end
+end

--- a/spec/factories/page.rb
+++ b/spec/factories/page.rb
@@ -1,0 +1,9 @@
+FactoryGirl.define do
+  factory :page do |s|
+    s.id { 1 }
+    s.name { "Page1" }
+    s.content { "<p>One</p>" }
+    s.collection_id { 1 }
+    s.image_id { 1 }
+  end
+end

--- a/spec/factories/page.rb
+++ b/spec/factories/page.rb
@@ -4,6 +4,5 @@ FactoryGirl.define do
     s.name { "Page1" }
     s.content { "<p>One</p>" }
     s.collection_id { 1 }
-    s.image_id { 1 }
   end
 end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Collection do
   [:name_line_1, :name_line_2, :items, :unique_id, :showcases,
    :collection_users, :published, :preview_mode, :users, :updated_at, :created_at,
    :site_intro, :short_intro, :showcases, :hide_title_on_home_page, :about, :copyright,
-   :enable_search, :enable_browse, :image, :uploaded_image].each do |field|
+   :enable_search, :enable_browse, :image, :uploaded_image, :pages].each do |field|
     it "has field, #{field}" do
       expect(subject).to respond_to(field)
       expect(subject).to respond_to("#{field}=")
@@ -82,6 +82,12 @@ RSpec.describe Collection do
       it "fails if an Item references it" do
         subject = FactoryGirl.create(:collection)
         FactoryGirl.create(:item)
+        expect { subject.destroy }.to raise_error
+      end
+
+      it "fails if a Page references it" do
+        subject = FactoryGirl.create(:collection)
+        FactoryGirl.create(:page)
         expect { subject.destroy }.to raise_error
       end
     end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe Page do
+  [:name, :content, :collection, :unique_id, :updated_at, :created_at].each do |field|
+    it "has the field #{field}" do
+      expect(subject).to respond_to(field)
+      expect(subject).to respond_to("#{field}=")
+    end
+  end
+
+  [:collection].each do |field|
+    it "requires the field, #{field}" do
+      expect(subject).to have(1).error_on(field)
+    end
+  end
+
+  it "has a papertrail" do
+    expect(subject).to respond_to(:paper_trail_enabled_for_model?)
+    expect(subject.paper_trail_enabled_for_model?).to be(true)
+  end
+end

--- a/spec/queries/page_query_spec.rb
+++ b/spec/queries/page_query_spec.rb
@@ -1,0 +1,60 @@
+require "rails"
+require "rails_helper"
+
+describe PageQuery do
+  subject { described_class.new(relation) }
+  let(:relation) { Page.all }
+
+  describe "#relation" do
+    it "returns the relation" do
+      expect(subject.relation).to eq(relation)
+    end
+  end
+
+  describe "all" do
+    it "returns all the pages" do
+      expect(subject.all).to eq(relation)
+    end
+  end
+
+  describe "ordered" do
+    it "orders the result" do
+      expect(relation).to receive(:order).with(:name).and_return(relation)
+      subject.ordered
+    end
+  end
+
+  describe "find" do
+    it "finds the object" do
+      expect(relation).to receive(:find).with(1)
+      subject.find(1)
+    end
+  end
+
+  describe "build" do
+    it "builds a object off of the relation" do
+      expect(relation).to receive(:build)
+      subject.build
+    end
+
+    it "accepts default arguments" do
+      item = subject.build(collection_id: 1)
+      expect(item.collection_id).to eq(1)
+    end
+  end
+
+  describe "public_find" do
+    it "calls public_find!" do
+      expect(relation).to receive(:find_by!).with(unique_id: "asdf")
+      subject.public_find("asdf")
+    end
+
+    it "raises an error on not found" do
+      expect { subject.public_find("asdf") }.to raise_error ActiveRecord::RecordNotFound
+    end
+  end
+
+  it "can always be deleted" do
+    expect(subject.can_delete?).to eq(true)
+  end
+end

--- a/spec/services/destroy/collection_spec.rb
+++ b/spec/services/destroy/collection_spec.rb
@@ -4,15 +4,23 @@ describe Destroy::Collection do
   describe "#cascade" do
     let(:destroy_item) { instance_double(Destroy::Item, cascade!: nil) }
     let(:destroy_showcase) { instance_double(Destroy::Showcase, cascade!: nil) }
+    let(:destroy_page) { instance_double(Destroy::Page, cascade!: nil) }
     let(:destroy_collection_user) { instance_double(Destroy::CollectionUser, cascade!: nil) }
-    let(:subject) { Destroy::Collection.new(destroy_collection_user: destroy_collection_user, destroy_item: destroy_item, destroy_showcase: destroy_showcase) }
+    let(:subject) do
+      Destroy::Collection.new(destroy_collection_user: destroy_collection_user,
+                              destroy_item: destroy_item,
+                              destroy_showcase: destroy_showcase,
+                              destroy_page: destroy_page)
+    end
     let(:showcase) { instance_double(Showcase, destroy!: true) }
     let(:item) { instance_double(Item, destroy!: true, sections: [], children: []) }
+    let(:page) { instance_double(Page, destroy!: true) }
     let(:collection) do
       instance_double(Collection,
                       collection_users: [collection_user, collection_user],
                       showcases: [showcase, showcase],
                       items: [item, item],
+                      pages: [page, page],
                       destroy!: true)
     end
     let(:collection_user) { instance_double(CollectionUser) }
@@ -24,6 +32,11 @@ describe Destroy::Collection do
 
     it "calls DestroyShowcase.cascade on all associated showcases" do
       expect(destroy_showcase).to receive(:cascade!).with(showcase: showcase).twice
+      subject.cascade!(collection: collection)
+    end
+
+    it "calls DestroyPage.cascade on all associated pages" do
+      expect(destroy_page).to receive(:cascade!).with(page: page).twice
       subject.cascade!(collection: collection)
     end
 
@@ -48,7 +61,13 @@ describe Destroy::Collection do
     let(:destroy_item) { Destroy::Item.new }
     let(:destroy_showcase) { Destroy::Showcase.new }
     let(:destroy_collection_user) { Destroy::CollectionUser.new }
-    let(:subject) { Destroy::Collection.new(destroy_collection_user: destroy_collection_user, destroy_item: destroy_item, destroy_showcase: destroy_showcase) }
+    let(:destroy_page) { Destroy::Page.new }
+    let(:subject) do
+      Destroy::Collection.new(destroy_collection_user: destroy_collection_user,
+                              destroy_item: destroy_item,
+                              destroy_showcase: destroy_showcase,
+                              destroy_page: destroy_page)
+    end
     let(:collection) { FactoryGirl.create(:collection) }
     let(:showcase) { FactoryGirl.create(:showcase, collection_id: collection.id) }
     let(:user) { FactoryGirl.create(:user) }
@@ -60,26 +79,46 @@ describe Destroy::Collection do
       [FactoryGirl.create(:item, id: 1, collection_id: collection.id, user_defined_id: "one"),
        FactoryGirl.create(:item, id: 2, collection_id: collection.id, user_defined_id: "two")]
     end
+    let(:pages) do
+      [FactoryGirl.create(:page, id: 1, collection_id: collection.id),
+       FactoryGirl.create(:page, id: 2, collection_id: collection.id)]
+    end
 
     before(:each) do
       user
       collection
       showcase
       items
+      pages
       collection_users
     end
 
     # Ensures all data that was created still exists
     # in the database
     def data_still_exists!
+      items_still_exist!
+      pages_still_exist!
+      collection_users_still_exist!
+      expect { showcase.reload }.not_to raise_error
+      expect { collection.reload }.not_to raise_error
+    end
+
+    def items_still_exist!
       items.each do |item|
         expect { item.reload }.not_to raise_error
       end
+    end
+
+    def pages_still_exist!
+      pages.each do |page|
+        expect { page.reload }.not_to raise_error
+      end
+    end
+
+    def collection_users_still_exist!
       collection_users.each do |collection_user|
         expect { collection_user.reload }.not_to raise_error
       end
-      expect { showcase.reload }.not_to raise_error
-      expect { collection.reload }.not_to raise_error
     end
 
     it "rolls back if an error occurs with Destroy::CollectionUser" do
@@ -100,6 +139,14 @@ describe Destroy::Collection do
 
     it "rolls back if an error occurs with Destroy::Showcase" do
       allow(destroy_showcase).to receive(:cascade!).with(showcase: showcase).and_raise("error")
+      expect { subject.cascade!(collection: collection) }.to raise_error("error")
+      data_still_exists!
+    end
+
+    it "rolls back if an error occurs with Destroy::Page" do
+      # Throw error on second object to allow first one to get deleted
+      allow(collection).to receive(:pages).and_return(pages)
+      allow(pages[1]).to receive(:destroy!).and_raise("error")
       expect { subject.cascade!(collection: collection) }.to raise_error("error")
       data_still_exists!
     end

--- a/spec/services/destroy/page_spec.rb
+++ b/spec/services/destroy/page_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+describe Destroy::Page do
+  let(:page) { instance_double(Page) }
+
+  describe "#destroy" do
+    it "destroys the Page" do
+      expect(page).to receive(:destroy!)
+      subject.destroy!(page: page)
+    end
+  end
+
+  describe "#cascade" do
+    it "destroys the Page" do
+      expect(page).to receive(:destroy!)
+      subject.cascade!(page: page)
+    end
+  end
+
+  context "cascade transaction" do
+    let(:collection) { FactoryGirl.create(:collection) }
+    let(:page) { FactoryGirl.create(:page) }
+
+    # Ensures all data that was created still exists
+    # in the database
+    def data_still_exists!
+      expect { page.reload }.not_to raise_error
+    end
+
+    it "rolls back if an error occurs with Section.destroy!" do
+      collection
+      page
+      allow(page).to receive(:destroy!).and_raise("error")
+      expect { subject.cascade!(page: page) }.to raise_error("error")
+      data_still_exists!
+    end
+  end
+end

--- a/spec/services/destroy/page_spec.rb
+++ b/spec/services/destroy/page_spec.rb
@@ -27,7 +27,7 @@ describe Destroy::Page do
       expect { page.reload }.not_to raise_error
     end
 
-    it "rolls back if an error occurs with Section.destroy!" do
+    it "rolls back if an error occurs with Page.destroy!" do
       collection
       page
       allow(page).to receive(:destroy!).and_raise("error")

--- a/spec/services/save_page_spec.rb
+++ b/spec/services/save_page_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+describe SavePage do
+  subject { described_class.call(page, params) }
+
+  let(:page) { instance_double(Page, id: "1", "attributes=" => true, save: true, collection: collection) }
+  let(:collection) { instance_double(Collection, id: 1) }
+  let(:params) { "params" }
+
+  before(:each) do
+    allow(CreateUniqueId).to receive(:call).and_return(true)
+  end
+
+  context "successful save" do
+    it "sets the attributes" do
+      expect(page).to receive("attributes=").with(params)
+      subject
+    end
+
+    it "returns the section when it is successful" do
+      expect(subject).to be(page)
+    end
+
+    it "calls save" do
+      expect(page).to receive(:save).and_return(true)
+      subject
+    end
+  end
+
+  context "unsuccessful save" do
+    before(:each) do
+      allow(page).to receive(:save).and_return(false)
+    end
+
+    it "returns the false when it is unsuccessful" do
+      expect(subject).to be(false)
+    end
+
+    it "calls save" do
+      expect(page).to receive(:save).and_return(false)
+      subject
+    end
+  end
+
+  describe "unique_id" do
+    it "uses the class to generate the id" do
+      expect(CreateUniqueId).to receive(:call).with(page)
+      subject
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -77,7 +77,8 @@ RSpec.configure do |config|
       User,
       CollectionUser,
       Showcase,
-      Section
+      Section,
+      Page
     ].each do |database_model|
       instance = database_model.new
       # The first attribute is id, which does not cause the methods to be built on the class

--- a/spec/values/cache_keys/custom/pages_spec.rb
+++ b/spec/values/cache_keys/custom/pages_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe CacheKeys::Custom::Pages do
+  context "index" do
+    let(:collection) { instance_double(Collection, pages: "pages") }
+
+    it "uses CacheKeys::ActiveRecord" do
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate)
+      subject.index(collection: collection)
+    end
+
+    it "uses the correct data" do
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with(record: [collection, collection.pages])
+      subject.index(collection: collection)
+    end
+  end
+
+  context "edit" do
+    let(:page) { instance_double(Page, collection: "collection") }
+
+    it "uses CacheKeys::ActiveRecord" do
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate)
+      subject.edit(page: page)
+    end
+
+    it "uses the correct data" do
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with(record: [page, page.collection])
+      subject.edit(page: page)
+    end
+  end
+end


### PR DESCRIPTION
Why: We need to add the models and CRUD ops for Pages before we can add to the API/Beehive. 
How: Added a Pages model, controller, routes, views, and all of our typical service class objects such as save, delete, cache key generation, etc. This PR will only give the basics. Extending the API and the redactor to allow for adding images from the collection are part of a different ticket.