### PR TITLE
DEC-653: Refactor site ordering

### DIFF
--- a/app/assets/javascripts/components/FlashMessage.jsx
+++ b/app/assets/javascripts/components/FlashMessage.jsx
@@ -3,6 +3,7 @@ var EventEmitter = require('../EventEmitter');
 var mui = require("material-ui");
 var Snackbar = mui.Snackbar;
 
+// Sends flash messages to the message center. To send html in the message, use flash[:html_safe]
 var FlashMessage = React.createClass({
   mixins: [MuiThemeMixin, DialogMixin],
   
@@ -16,7 +17,7 @@ var FlashMessage = React.createClass({
   componentDidMount: function () {
     Flash.transferFromCookies();
     for(var key in Flash.data) {
-      EventEmitter.emit("MessageCenterDisplay", key, Flash.data[key].toString().replace(/\+/g, ' '));
+      EventEmitter.emit("MessageCenterDisplay", key, Flash.data[key].toString().replace(/\+/g, ' '), key == "html_safe");
     }
   },
 

--- a/app/assets/javascripts/components/forms/FormMessageCenter.jsx
+++ b/app/assets/javascripts/components/forms/FormMessageCenter.jsx
@@ -9,16 +9,18 @@ var FormMessageCenter = React.createClass({
     return {
       messageType: "",
       messageText: "",
+      htmlSafe: false,
     };
   },
   componentWillMount: function() {
     EventEmitter.on("MessageCenterDisplay", this.receiveDisplay);
   },
 
-  receiveDisplay: function(messageType, messageText) {
+  receiveDisplay: function(messageType, messageText, htmlSafe) {
     this.setState({
       messageType: messageType,
       messageText: messageText,
+      htmlSafe: htmlSafe,
     });
     this.refs.errorDialog.show();
   },
@@ -27,12 +29,21 @@ var FormMessageCenter = React.createClass({
     this.refs.errorDialog.dismiss();
   },
 
+  messageSpan: function() {
+    if(this.state.htmlSafe) {
+      return (<span dangerouslySetInnerHTML={{ __html: this.state.messageText }}></span>);
+    } else {
+      return (<span>{ this.state.messageText }</span>);
+    }
+
+
+  },
 
   render: function () {
     return (
       <Snackbar
         ref = "errorDialog"
-        message={this.state.messageText}
+        message={ this.messageSpan() }
       >
       </Snackbar>
     );

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -123,6 +123,7 @@ class CollectionsController < ApplicationController
       :hide_title_on_home_page,
       :uploaded_image,
       :about,
-      :copyright)
+      :copyright,
+      :site_objects)
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -18,8 +18,8 @@ class PagesController < ApplicationController
     @page = PageQuery.new(collection.pages).build(save_params)
 
     if SavePage.call(@page, save_params)
-      flash[:notice] = t(".success")
-      redirect_to page_path(@page)
+      flash[:html_safe] = t(".success", href: view_context.link_to("Site Setup", site_setup_form_collection_path(collection, form: :homepage))).html_safe
+      redirect_to edit_page_path(@page)
     else
       render :new
     end

--- a/app/controllers/showcases_controller.rb
+++ b/app/controllers/showcases_controller.rb
@@ -18,7 +18,7 @@ class ShowcasesController < ApplicationController
     @showcase = ShowcaseQuery.new(collection.showcases).build(save_params)
 
     if SaveShowcase.call(@showcase, save_params)
-      flash[:notice] = t(".success")
+      flash[:html_safe] = t(".success", href: view_context.link_to("Site Setup", site_setup_form_collection_path(collection, form: :homepage))).html_safe
       redirect_to showcase_path(@showcase)
     else
       render :new

--- a/app/controllers/v1/collections_controller.rb
+++ b/app/controllers/v1/collections_controller.rb
@@ -62,5 +62,15 @@ module V1
         format.json { render json: @configuration.to_json }
       end
     end
+
+    def site_objects
+      collection = CollectionQuery.new.public_find(params[:collection_id])
+      @collection = CollectionJSONDecorator.new(collection)
+      @site_objects = SiteObjectsQuery.new.all(collection: collection)
+      cache_key = CacheKeys::Generator.new(key_generator: CacheKeys::Custom::V1Collections,
+                                           action: "site_objects",
+                                           collection: collection, site_objects: @site_objects)
+      fresh_when(etag: cache_key.generate)
+    end
   end
 end

--- a/app/decorators/v1/item_json_decorator.rb
+++ b/app/decorators/v1/item_json_decorator.rb
@@ -22,6 +22,10 @@ module V1
       object.description.to_s
     end
 
+    def additional_type
+      "https://github.com/ndlib/honeycomb/wiki/Item"
+    end
+
     def slug
       CreateURLSlug.call(object.name)
     end
@@ -63,6 +67,7 @@ module V1
       json.set! "@type", "CreativeWork"
       json.set! "@id", at_id
       json.set! "isPartOf/collection", collection_url
+      json.set! "additionalType", additional_type
       json.id unique_id
       json.collection_id collection_id
       json.slug slug

--- a/app/decorators/v1/showcase_json_decorator.rb
+++ b/app/decorators/v1/showcase_json_decorator.rb
@@ -23,12 +23,16 @@ module V1
       CreateURLSlug.call(object.slug)
     end
 
+    def additional_type
+      "https://github.com/ndlib/honeycomb/wiki/Showcase"
+    end
+
     def next
-      ShowcaseQuery.new.next(object)
+      SiteObjectsQuery.new.next(collection_object: object)
     end
 
     def previous
-      ShowcaseQuery.new.previous(object)
+      SiteObjectsQuery.new.previous(collection_object: object)
     end
 
     def sections

--- a/app/decorators/v1/site_objects_json_decorator.rb
+++ b/app/decorators/v1/site_objects_json_decorator.rb
@@ -1,0 +1,17 @@
+# Calls the appropriate decorator for the given site object
+module V1
+  class SiteObjectsJSONDecorator < Draper::Decorator
+    def self.display(site_object, json)
+      case site_object.class.name
+      when "Showcase"
+        V1::ShowcaseJSONDecorator.display(site_object, json)
+      when "Item"
+        V1::ItemJSONDecorator.display(site_object, json)
+      when "Page"
+        nil
+      else
+        raise "Unsupported object type #{site_object.class.name}"
+      end
+    end
+  end
+end

--- a/app/queries/page_query.rb
+++ b/app/queries/page_query.rb
@@ -24,6 +24,6 @@ class PageQuery
   end
 
   def can_delete?
-    true
+    !SiteObjectsQuery.new.exists?(collection_object: relation)
   end
 end

--- a/app/queries/showcase_query.rb
+++ b/app/queries/showcase_query.rb
@@ -10,11 +10,11 @@ class ShowcaseQuery
   end
 
   def admin_list
-    relation.order(:order, :name_line_1)
+    relation.order(:name_line_1)
   end
 
   def public_api_list
-    relation.order(:order, :name_line_1)
+    relation.order(:name_line_1)
   end
 
   delegate :find, to: :relation
@@ -25,21 +25,5 @@ class ShowcaseQuery
 
   def public_find(id)
     relation.find_by!(unique_id: id)
-  end
-
-  def next(showcase)
-    relation.
-      where(collection_id: showcase.collection_id).
-      where("`#{relation.table_name}`.order > ?", showcase.order).
-      order(:order).
-      first
-  end
-
-  def previous(showcase)
-    relation.
-      where(collection_id: showcase.collection_id).
-      where("`#{relation.table_name}`.order < ?", showcase.order).
-      order(order: :desc).
-      first
   end
 end

--- a/app/queries/showcase_query.rb
+++ b/app/queries/showcase_query.rb
@@ -26,4 +26,8 @@ class ShowcaseQuery
   def public_find(id)
     relation.find_by!(unique_id: id)
   end
+
+  def can_delete?
+    !SiteObjectsQuery.new.exists?(collection_object: relation)
+  end
 end

--- a/app/queries/site_objects_query.rb
+++ b/app/queries/site_objects_query.rb
@@ -5,16 +5,26 @@ class SiteObjectsQuery
     end
   end
 
+  # Determines if an object exists in site_objects for its collection
+  def exists?(collection_object:)
+    type = collection_object.class.name
+    id = collection_object.id
+    site_objects_json(collection_id: collection_object.collection_id).detect do |site_object|
+      if site_object[:type] == type && site_object[:id] == id
+        return true
+      end
+    end
+    false
+  end
+
   # Given an object within the collection, this will find the next one in the list
   def next(collection_object:)
-    previous = nil
     type = collection_object.class.name
     id = collection_object.id
     site_objects_json(collection_id: collection_object.collection_id).each_cons(2) do |site_object, next_site_object|
       if site_object[:type] == type && site_object[:id] == id
         return get_object(site_object: next_site_object)
       end
-      previous = site_object
     end
     nil
   end

--- a/app/queries/site_objects_query.rb
+++ b/app/queries/site_objects_query.rb
@@ -1,0 +1,62 @@
+class SiteObjectsQuery
+  def all(collection:)
+    site_objects_json(collection_id: collection.id).map do |site_object|
+      get_object(site_object: site_object)
+    end
+  end
+
+  # Given an object within the collection, this will find the next one in the list
+  def next(collection_object:)
+    previous = nil
+    type = collection_object.class.name
+    id = collection_object.id
+    site_objects_json(collection_id: collection_object.collection_id).each_cons(2) do |site_object, next_site_object|
+      if site_object[:type] == type && site_object[:id] == id
+        return get_object(site_object: next_site_object)
+      end
+      previous = site_object
+    end
+    nil
+  end
+
+  # Given an object within the collection, this will find the previous one in the list
+  def previous(collection_object:)
+    previous = nil
+    type = collection_object.class.name
+    id = collection_object.id
+    site_objects_json(collection_id: collection_object.collection_id).each do |site_object|
+      if site_object[:type] == type && site_object[:id] == id
+        return previous.nil? ? nil : get_object(site_object: previous)
+      end
+      previous = site_object
+    end
+    nil
+  end
+
+  private
+
+  attr_reader :collection
+
+  # Returns an array of hashes of the form { :type, :id }
+  # Ex: [{type: "showcase", id: 3},{ type: "showcase", id:1 }]
+  def site_objects_json(collection_id:)
+    collection = Collection.find(collection_id)
+    if collection.nil?
+      []
+    else
+      JSON.parse(collection.site_objects, symbolize_names: true)
+    end
+  end
+
+  def get_object(site_object:)
+    if supported_types.include?(site_object[:type])
+      site_object[:type].constantize.find(site_object[:id])
+    else
+      raise "Unsupported object type #{site_object[:type]}."
+    end
+  end
+
+  def supported_types
+    ["Showcase", "Page"]
+  end
+end

--- a/app/values/cache_keys/custom/v1_collections.rb
+++ b/app/values/cache_keys/custom/v1_collections.rb
@@ -9,6 +9,10 @@ module CacheKeys
       def show(collection:)
         CacheKeys::ActiveRecord.new.generate(record: collection)
       end
+
+      def site_objects(collection:, site_objects:)
+        CacheKeys::ActiveRecord.new.generate(record: [collection, site_objects])
+      end
     end
   end
 end

--- a/app/views/collections/_homepage_form.html.erb
+++ b/app/views/collections/_homepage_form.html.erb
@@ -1,6 +1,7 @@
 <%= display_errors(@collection) %>
 
 <%= f.input :short_intro, input_html: { class: 'honeycomb_redactor'  } %>
+<%= f.input :site_objects, as: :text %>
 
 <%= HoneypotThumbnail.display(f.object.honeypot_image) %>
 <%= f.input :uploaded_image, as: :file %>

--- a/app/views/showcases/_form.html.erb
+++ b/app/views/showcases/_form.html.erb
@@ -5,7 +5,5 @@
 
 <%= f.input :description, hint: 'Please keep the description as short as possible', as: :string %>
 
-<%= f.input :order %>
-
 <%= f.input :uploaded_image, as: :file, required: true %>
 <%= HoneypotThumbnail.display(f.object.honeypot_image) %>

--- a/app/views/showcases/title.html.erb
+++ b/app/views/showcases/title.html.erb
@@ -18,4 +18,4 @@
 <% end %>
 
 
-<%= DeletePanel.new(@showcase).display %>
+<%= DeletePanel.new(@showcase).display(ShowcaseQuery.new(@showcase)) %>

--- a/app/views/v1/collections/site_objects.json.jbuilder
+++ b/app/views/v1/collections/site_objects.json.jbuilder
@@ -1,0 +1,6 @@
+@collection.display(json)
+json.set! :site_objects do
+  json.array! @site_objects do |site_object|
+    V1::SiteObjectsJSONDecorator.display(site_object, json)
+  end
+end

--- a/app/views/v1/showcases/_showcase.json.jbuilder
+++ b/app/views/v1/showcases/_showcase.json.jbuilder
@@ -2,6 +2,7 @@ json.set! "@context", "http://schema.org"
 json.set! "@type", "CreativeWork"
 json.set! "@id", showcase_object.at_id
 json.set! "isPartOf/collection", showcase_object.collection_url
+json.set! "additionalType", showcase_object.additional_type
 json.id showcase_object.unique_id
 json.slug showcase_object.slug
 json.name showcase_object.name

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -179,7 +179,7 @@ en:
     index:
       title: "Showcases"
     create:
-      success: "Showcase created"
+      success: "Showcase created! Go to %{href} to add the showcase to your site."
     new:
       title: "New Showcase"
     list:
@@ -217,7 +217,7 @@ en:
     index:
       title: "Pages"
     create:
-      success: "Page created"
+      success: "Page created! Go to %{href} to add the page to your site."
     new:
       title: "New Page"
     list:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -193,6 +193,10 @@ en:
     destroy:
       success: "Showcase deleted"
       failure: "There was a problem deleting this showcase"
+    delete_panel:
+      heading: Delete this Showcase
+      message: "Proceed with caution. This will remove the Showcase and all associated data."
+      cannot_delete_message: "Deleting this Showcase is disabled due to its usage on the homepage."
   sections:
     new:
       title: "New Section"
@@ -229,3 +233,7 @@ en:
     destroy:
       success: "Page deleted"
       failure: "There was a problem deleting this page"
+    delete_panel:
+      heading: Delete this Page
+      message: "Proceed with caution. This will remove the Page and all associated data."
+      cannot_delete_message: "Deleting this Page is disabled due to its usage on the homepage."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,6 +72,7 @@ Rails.application.routes.draw do
       put :unpublish, defaults: { format: :json }
       put :preview_mode, defaults: { format: :json }
       get :metadata_configuration, defaults: { format: :json }
+      get :site_objects, defaults: { format: :json }
       resources :search, only: [:index], defaults: { format: :json }
       resources :items, only: [:index], defaults: { format: :json }
       resources :showcases, only: [:index], defaults: { format: :json }

--- a/db/migrate/20151109212812_add_site_objects_to_collections.rb
+++ b/db/migrate/20151109212812_add_site_objects_to_collections.rb
@@ -1,0 +1,5 @@
+class AddSiteObjectsToCollections < ActiveRecord::Migration
+  def change
+    add_column :collections, :site_objects, :text, limit: 4294967295
+  end
+end

--- a/db/migrate/20151109213406_copy_existing_showcases_to_site_objects.rb
+++ b/db/migrate/20151109213406_copy_existing_showcases_to_site_objects.rb
@@ -1,0 +1,30 @@
+class CopyExistingShowcasesToSiteObjects < ActiveRecord::Migration
+  class ShowcaseMigration < ActiveRecord::Base
+    self.table_name = "showcases"
+  end
+  class CollectionMigration < ActiveRecord::Base
+    self.table_name = "collections"
+  end
+
+  def up
+    # For each collection, get a list of showcases (in the order that the API currently retrieves them)
+    # and construct an array of hashes that are of the form { :type, :id }
+    # Ex: [{"type":"showcase","id":3},{"type":"showcase","id":1}]
+    CollectionMigration.find_each do |collection|
+      site_objects = []
+      ShowcaseMigration.where(collection_id: collection.id).order(:order, :name_line_1).each do |showcase|
+        site_objects << { type: "Showcase", id: showcase.id }
+      end
+      collection.site_objects = ActiveSupport::JSON.encode(site_objects)
+      collection.save
+    end
+
+    CollectionMigration.reset_column_information
+    ShowcaseMigration.reset_column_information
+  end
+
+  def down
+    CollectionMigration.reset_column_information
+    ShowcaseMigration.reset_column_information
+  end
+end

--- a/db/migrate/20151110211606_drop_showcase_order.rb
+++ b/db/migrate/20151110211606_drop_showcase_order.rb
@@ -1,0 +1,5 @@
+class DropShowcaseOrder < ActiveRecord::Migration
+  def change
+    remove_column :showcases, :order, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151106195018) do
+ActiveRecord::Schema.define(version: 20151110211606) do
 
   create_table "collection_users", force: :cascade do |t|
     t.integer  "user_id",       limit: 4, null: false
@@ -27,7 +27,7 @@ ActiveRecord::Schema.define(version: 20151106195018) do
     t.string   "name_line_1",                 limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "deleted",                                   default: false
+    t.boolean  "deleted",                                        default: false
     t.string   "unique_id",                   limit: 255
     t.boolean  "published"
     t.string   "name_line_2",                 limit: 255
@@ -48,6 +48,7 @@ ActiveRecord::Schema.define(version: 20151106195018) do
     t.datetime "uploaded_image_updated_at"
     t.boolean  "enable_search"
     t.boolean  "hide_title_on_home_page"
+    t.text     "site_objects",                limit: 4294967295
   end
 
   add_index "collections", ["preview_mode"], name: "index_collections_on_preview_mode", using: :btree
@@ -66,11 +67,11 @@ ActiveRecord::Schema.define(version: 20151106195018) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.text     "about",                       limit: 65535
+    t.text     "copyright",                   limit: 65535
     t.string   "uploaded_image_file_name",    limit: 255
     t.string   "uploaded_image_content_type", limit: 255
     t.integer  "uploaded_image_file_size",    limit: 4
     t.datetime "uploaded_image_updated_at"
-    t.text     "copyright",                   limit: 65535
     t.boolean  "hide_title_on_home_page"
     t.string   "url",                         limit: 255
     t.boolean  "enable_search"
@@ -164,7 +165,6 @@ ActiveRecord::Schema.define(version: 20151106195018) do
     t.datetime "created_at"
     t.boolean  "published"
     t.string   "unique_id",                   limit: 255
-    t.integer  "order",                       limit: 4
     t.string   "name_line_2",                 limit: 255
     t.string   "uploaded_image_file_name",    limit: 255
     t.string   "uploaded_image_content_type", limit: 255
@@ -175,7 +175,6 @@ ActiveRecord::Schema.define(version: 20151106195018) do
 
   add_index "showcases", ["collection_id"], name: "index_showcases_on_collection_id", using: :btree
   add_index "showcases", ["exhibit_id"], name: "fk_rails_ee93a134d7", using: :btree
-  add_index "showcases", ["order"], name: "index_showcases_on_order", using: :btree
   add_index "showcases", ["published"], name: "index_showcases_on_published", using: :btree
   add_index "showcases", ["unique_id"], name: "index_showcases_on_unique_id", using: :btree
 

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -93,9 +93,9 @@ RSpec.describe PagesController, type: :controller do
       expect(response).to be_redirect
     end
 
-    it "flashes a notice" do
+    it "flashes an html_safe message" do
       subject
-      expect(flash[:notice]).to_not be_nil
+      expect(flash[:html_safe]).to_not be_nil
     end
 
     it "renders new on failure" do

--- a/spec/controllers/showcases_controller_spec.rb
+++ b/spec/controllers/showcases_controller_spec.rb
@@ -97,9 +97,12 @@ RSpec.describe ShowcasesController, type: :controller do
 
     it "redirects on success" do
       subject
-
       expect(response).to be_redirect
-      expect(flash[:notice]).to_not be_nil
+    end
+
+    it "flashes an html_safe message on success" do
+      subject
+      expect(flash[:html_safe]).to_not be_nil
     end
 
     it "renders new on failure" do

--- a/spec/decorators/v1/item_json_decorator_spec.rb
+++ b/spec/decorators/v1/item_json_decorator_spec.rb
@@ -84,6 +84,7 @@ RSpec.describe V1::ItemJSONDecorator do
         "@type",
         "@id",
         "isPartOf/collection",
+        "additionalType",
         "id",
         "slug",
         "name",
@@ -139,5 +140,9 @@ RSpec.describe V1::ItemJSONDecorator do
       expect(V1::MetadataJSON).to receive(:metadata).with(item).and_return("metadata")
       expect(subject.metadata).to eq("metadata")
     end
+  end
+
+  it "gives the correct additional_type" do
+    expect(subject.additional_type).to eq("https://github.com/ndlib/honeycomb/wiki/Item")
   end
 end

--- a/spec/decorators/v1/showcase_json_decorator_spec.rb
+++ b/spec/decorators/v1/showcase_json_decorator_spec.rb
@@ -92,16 +92,20 @@ RSpec.describe V1::ShowcaseJSONDecorator do
   end
 
   describe "#next" do
-    it "uses the showcase query to retrieve the next showcase" do
-      expect_any_instance_of(ShowcaseQuery).to receive(:next).with(showcase)
+    it "uses the site objects query to retrieve the next object" do
+      expect_any_instance_of(SiteObjectsQuery).to receive(:next).with(collection_object: showcase)
       subject.next
     end
   end
 
   describe "#previous" do
-    it "uses the showcase query to retrieve the previous showcase" do
-      expect_any_instance_of(ShowcaseQuery).to receive(:previous).with(showcase)
+    it "uses the site objects query to retrieve the previous object" do
+      expect_any_instance_of(SiteObjectsQuery).to receive(:previous).with(collection_object: showcase)
       subject.previous
     end
+  end
+
+  it "gives the correct additional_type" do
+    expect(subject.additional_type).to eq("https://github.com/ndlib/honeycomb/wiki/Showcase")
   end
 end

--- a/spec/decorators/v1/site_objects_json_decorator_spec.rb
+++ b/spec/decorators/v1/site_objects_json_decorator_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe V1::SiteObjectsJSONDecorator do
+  let(:showcase) { instance_double(Showcase, id: 0, collection_id: 1, class: double(Object, name: "Showcase")) }
+  let(:page) { instance_double(Page, id: 0, collection_id: 1, class: double(Object, name: "Page")) }
+  let(:item) { instance_double(Item, id: 0, collection_id: 1, class: double(Object, name: "Item")) }
+  let(:user) { instance_double(User, id: 0, class: double(Object, name: "User")) }
+
+  it "calls the correct decorator for a Showcase" do
+    expect(V1::ShowcaseJSONDecorator).to receive(:display)
+    described_class.display(showcase, nil)
+  end
+
+  it "calls the correct decorator for a Page"
+
+  it "calls the correct decorator for an Item" do
+    expect(V1::ItemJSONDecorator).to receive(:display)
+    described_class.display(item, nil)
+  end
+
+  it "raises an exception for other types" do
+    expect { described_class.display(user, nil) }.to raise_error
+  end
+end

--- a/spec/queries/page_query_spec.rb
+++ b/spec/queries/page_query_spec.rb
@@ -54,7 +54,13 @@ describe PageQuery do
     end
   end
 
-  it "can always be deleted" do
+  it "can be deleted if not included in a collection's site_objects" do
+    expect_any_instance_of(SiteObjectsQuery).to receive(:exists?).with(collection_object: relation).and_return(false)
     expect(subject.can_delete?).to eq(true)
+  end
+
+  it "cannot be deleted if included in a collection's site_objects" do
+    expect_any_instance_of(SiteObjectsQuery).to receive(:exists?).with(collection_object: relation).and_return(true)
+    expect(subject.can_delete?).to eq(false)
   end
 end

--- a/spec/queries/showcase_query_spec.rb
+++ b/spec/queries/showcase_query_spec.rb
@@ -60,4 +60,14 @@ describe ShowcaseQuery do
       expect { subject.public_find("asdf") }.to raise_error ActiveRecord::RecordNotFound
     end
   end
+
+  it "can be deleted if not included in a collection's site_objects" do
+    expect_any_instance_of(SiteObjectsQuery).to receive(:exists?).with(collection_object: relation).and_return(false)
+    expect(subject.can_delete?).to eq(true)
+  end
+
+  it "cannot be deleted if included in a collection's site_objects" do
+    expect_any_instance_of(SiteObjectsQuery).to receive(:exists?).with(collection_object: relation).and_return(true)
+    expect(subject.can_delete?).to eq(false)
+  end
 end

--- a/spec/queries/showcase_query_spec.rb
+++ b/spec/queries/showcase_query_spec.rb
@@ -19,14 +19,14 @@ describe ShowcaseQuery do
 
   describe "public_api_list" do
     it "orders the result" do
-      expect(relation).to receive(:order).with(:order, :name_line_1).and_return(relation)
+      expect(relation).to receive(:order).with(:name_line_1).and_return(relation)
       subject.public_api_list
     end
   end
 
   describe "admin_list" do
     it "orders the result" do
-      expect(relation).to receive(:order).with(:order, :name_line_1).and_return(relation)
+      expect(relation).to receive(:order).with(:name_line_1).and_return(relation)
       subject.admin_list
     end
   end
@@ -58,114 +58,6 @@ describe ShowcaseQuery do
 
     it "raises an error on not found" do
       expect { subject.public_find("asdf") }.to raise_error ActiveRecord::RecordNotFound
-    end
-  end
-
-  describe "next" do
-    before(:each) do
-      FactoryGirl.create(:collection)
-    end
-
-    it "finds the correct showcase when there is one" do
-      showcase1 = FactoryGirl.build(:showcase, id: 1, order: 1)
-      showcase2 = FactoryGirl.create(:showcase, id: 2, order: 2)
-      expect(subject.next(showcase1)).to eq(showcase2)
-    end
-
-    it "doesn't crash when there isn't one" do
-      showcase = FactoryGirl.build(:showcase, id: 1, order: 1)
-      expect { subject.next(showcase) }.to_not raise_error
-    end
-
-    it "returns nil when there isn't one" do
-      showcase = FactoryGirl.build(:showcase, id: 1, order: 1)
-      expect(subject.next(showcase)).to eq(nil)
-    end
-
-    it "doesn't find one if the orders are the same" do
-      showcase1 = FactoryGirl.build(:showcase, id: 1, order: 1)
-      FactoryGirl.create(:showcase, id: 2, order: 1)
-      expect(subject.next(showcase1)).to eq(nil)
-    end
-
-    it "doesn't find one if the next showcase's order is nil" do
-      showcase1 = FactoryGirl.build(:showcase, id: 1, order: 1)
-      FactoryGirl.create(:showcase, id: 2, order: nil)
-      expect(subject.next(showcase1)).to eq(nil)
-    end
-
-    it "doesn't find one if the current showcase's order is nil" do
-      showcase1 = FactoryGirl.build(:showcase, id: 1, order: nil)
-      FactoryGirl.create(:showcase, id: 2, order: 1)
-      expect(subject.next(showcase1)).to eq(nil)
-    end
-
-    context "searches based on order, not id" do
-      it "and does not find one when there is no showcase with a higher order, even though there is one with a higher id" do
-        showcase1 = FactoryGirl.build(:showcase, id: 1, order: 2)
-        FactoryGirl.create(:showcase, id: 2, order: 1)
-        expect(subject.next(showcase1)).to eq(nil)
-      end
-
-      it "and finds one when there is a showcase with a higher order, even though it has a lower id" do
-        showcase1 = FactoryGirl.create(:showcase, id: 1, order: 2)
-        showcase2 = FactoryGirl.build(:showcase, id: 2, order: 1)
-        expect(subject.next(showcase2)).to eq(showcase1)
-      end
-    end
-  end
-
-  describe "previous" do
-    before(:each) do
-      FactoryGirl.create(:collection)
-    end
-
-    it "finds the correct showcase when there is one" do
-      showcase1 = FactoryGirl.create(:showcase, id: 1, order: 1)
-      showcase2 = FactoryGirl.build(:showcase, id: 2, order: 2)
-      expect(subject.previous(showcase2)).to eq(showcase1)
-    end
-
-    it "doesn't crash when there isn't one" do
-      showcase = FactoryGirl.build(:showcase, id: 1, order: 1)
-      expect { subject.previous(showcase) }.to_not raise_error
-    end
-
-    it "returns nil when there isn't one" do
-      showcase = FactoryGirl.build(:showcase, id: 1, order: 1)
-      expect(subject.previous(showcase)).to eq(nil)
-    end
-
-    it "doesn't find one if the orders are the same" do
-      FactoryGirl.create(:showcase, id: 1, order: 1)
-      showcase2 = FactoryGirl.build(:showcase, id: 2, order: 1)
-      expect(subject.previous(showcase2)).to eq(nil)
-    end
-
-    it "doesn't find one if the previous showcase's order is nil" do
-      FactoryGirl.create(:showcase, id: 1, order: nil)
-      showcase2 = FactoryGirl.build(:showcase, id: 2, order: 1)
-      expect(subject.previous(showcase2)).to eq(nil)
-    end
-
-    it "doesn't find one if the current showcase's order is nil" do
-      FactoryGirl.create(:showcase, id: 1, order: 1)
-      showcase2 = FactoryGirl.build(:showcase, id: 2, order: nil)
-      expect(subject.previous(showcase2)).to eq(nil)
-    end
-
-    context "searches based on order, not id" do
-      it "and does not find one when there is no showcase with a lower order, even though there is one with a lower id" do
-        FactoryGirl.create(:showcase, id: 1, order: 2)
-        showcase2 = FactoryGirl.build(:showcase, id: 2, order: 1)
-        expect(subject.previous(showcase2)).to eq(nil)
-      end
-
-      it "and finds one when there is a showcase with a lower order, even though it has a higher id" do
-        showcase1 = FactoryGirl.build(:showcase, id: 1, order: 2)
-        showcase2 = FactoryGirl.create(:showcase, id: 2, order: 1)
-        expect(subject.previous(showcase1)).to eq(showcase2)
-      end
     end
   end
 end

--- a/spec/queries/site_objects_query_spec.rb
+++ b/spec/queries/site_objects_query_spec.rb
@@ -44,6 +44,20 @@ describe SiteObjectsQuery do
     expect(subject.all(collection: collection)).to eq(site_objects)
   end
 
+  context "when asking if an object exists in the array" do
+    it "returns false if the object given is not in the site_objects array" do
+      expect(subject.exists?(collection_object: showcases[1])).to eq(false)
+    end
+
+    it "finds the previous object" do
+      expect(subject.exists?(collection_object: pages[2])).to eq(true)
+    end
+
+    it "returns true if the object given is in the site_objects array" do
+      expect(subject.exists?(collection_object: showcases[0])).to eq(true)
+    end
+  end
+
   context "when finding previous" do
     it "returns nil if the object given is not in the site_objects array" do
       expect(subject.previous(collection_object: showcases[1])).to eq(nil)

--- a/spec/queries/site_objects_query_spec.rb
+++ b/spec/queries/site_objects_query_spec.rb
@@ -1,0 +1,89 @@
+require "rails"
+require "rails_helper"
+
+describe SiteObjectsQuery do
+  let(:showcases) do
+    [
+      instance_double(Showcase, id: 0, collection_id: 1, class: double(Object, name: "Showcase")),
+      instance_double(Showcase, id: 1, collection_id: 1, class: double(Object, name: "Showcase")),
+      instance_double(Showcase, id: 2, collection_id: 1, class: double(Object, name: "Showcase"))
+    ]
+  end
+  let(:pages) do
+    [
+      instance_double(Page, id: 0, collection_id: 1, class: double(Object, name: "Page")),
+      instance_double(Page, id: 1, collection_id: 1, class: double(Object, name: "Page")),
+      instance_double(Page, id: 2, collection_id: 1, class: double(Object, name: "Page"))
+    ]
+  end
+  let(:users) do
+    [
+      instance_double(User, id: 0, class: double(Object, name: "User")),
+      instance_double(User, id: 1, class: double(Object, name: "User")),
+      instance_double(User, id: 2, class: double(Object, name: "User"))
+    ]
+  end
+  let(:site_objects_string) { '[{ "type": "Showcase", "id": 0 }, { "type": "Page", "id": 2 }, { "type": "Showcase", "id": 2 }]' }
+  let(:site_objects) { [showcases[0], pages[2], showcases[2]] }
+  let(:collection) { instance_double(Collection, id: 1, site_objects: site_objects_string) }
+
+  before(:each) do
+    allow(Collection).to receive(:find).and_return(collection)
+    allow(Showcase).to receive(:find) do |id|
+      showcases[id]
+    end
+    allow(Page).to receive(:find) do |id|
+      pages[id]
+    end
+    allow(User).to receive(:find) do |id|
+      users[id]
+    end
+  end
+
+  it "returns all site objects as a json" do
+    expect(subject.all(collection: collection)).to eq(site_objects)
+  end
+
+  context "when finding previous" do
+    it "returns nil if the object given is not in the site_objects array" do
+      expect(subject.previous(collection_object: showcases[1])).to eq(nil)
+    end
+
+    it "finds the previous object" do
+      expect(subject.previous(collection_object: pages[2])).to eq(showcases[0])
+    end
+
+    it "returns nil if there is no previous object" do
+      # Since there are multiple paths to return nil, this first expectation is to ensure
+      # that it finds the object
+      expect(subject.next(collection_object: showcases[0])).to eq(pages[2])
+      expect(subject.previous(collection_object: showcases[0])).to eq(nil)
+    end
+  end
+
+  context "when finding next" do
+    it "returns nil if the object given is not in the site_objects array" do
+      expect(subject.next(collection_object: showcases[1])).to eq(nil)
+    end
+
+    it "finds the next object" do
+      expect(subject.next(collection_object: pages[2])).to eq(showcases[2])
+    end
+
+    it "returns nil if there is no next object" do
+      # Since there are multiple paths to return nil, this first expectation is to ensure
+      # that it finds the object
+      expect(subject.previous(collection_object: showcases[2])).to eq(pages[2])
+      expect(subject.next(collection_object: showcases[2])).to eq(nil)
+    end
+  end
+
+  context "invalid object types" do
+    let(:site_objects_string) { '[{ "type": "Showcase", "id": 0 }, { "type": "User", "id": 2 }, { "type": "Showcase", "id": 2 }]' }
+    let(:site_objects) { [showcases[0], users[2], showcases[2]] }
+
+    it "raises an exception" do
+      expect { subject.all(collection: collection) }.to raise_error
+    end
+  end
+end

--- a/spec/values/cache_keys/custom/v1_collections_spec.rb
+++ b/spec/values/cache_keys/custom/v1_collections_spec.rb
@@ -28,4 +28,18 @@ RSpec.describe CacheKeys::Custom::V1Collections do
       subject.show(collection: collection)
     end
   end
+
+  context "site_objects" do
+    let(:collection) { instance_double(Collection) }
+
+    it "uses CacheKeys::ActiveRecord" do
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate)
+      subject.site_objects(collection: collection, site_objects: ["one", "two"])
+    end
+
+    it "uses the correct data" do
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with(record: [collection, ["one", "two"]])
+      subject.site_objects(collection: collection, site_objects: ["one", "two"])
+    end
+  end
 end


### PR DESCRIPTION
Why: Collection home pages need to be able to show pages, showcases, and items. This can no longer be handled by Showcase order.
How: 
-Added migrations to add the site_objects field to Collections and copy the showcases for the collections into this field as an array of site objects of the format { type, id }
-Created a query object to make it easier to find all site objects for a collection and next/previous object for an object
-Dropped showcase.order
-Added a simple text input for the site_objects in the Site Setup for now until we get an editor created.
-Created a route v1/collections/id/site_objects to get all site objects for a Collection, where the JSON output is similar to v1/collections/id/showcases, but can now be expanded to contain other objects. 
-The previous behavior caused all new showcases to immediately appear on the site. That's no longer the case now that the user has to edit what objects will show on the site. To help with this, I changed the flash messages for page/showcase create to let them know where to go to make the new object show up.
