### PR TITLE
DEC-652: Build pages api

### DIFF
--- a/app/controllers/v1/pages_controller.rb
+++ b/app/controllers/v1/pages_controller.rb
@@ -1,0 +1,23 @@
+module V1
+  class PagesController < APIController
+    def index
+      collection = CollectionQuery.new.public_find(params[:collection_id])
+      @collection = CollectionJSONDecorator.new(collection)
+
+      cache_key = CacheKeys::Generator.new(key_generator: CacheKeys::Custom::V1Pages,
+                                           action: "index",
+                                           collection: collection)
+      fresh_when(etag: cache_key.generate)
+    end
+
+    def show
+      page = PageQuery.new.public_find(params[:id])
+      @page = PageJSONDecorator.new(page)
+
+      cache_key = CacheKeys::Generator.new(key_generator: CacheKeys::Custom::V1Pages,
+                                           action: "show",
+                                           page: @page)
+      fresh_when(etag: cache_key.generate)
+    end
+  end
+end

--- a/app/decorators/v1/collection_json_decorator.rb
+++ b/app/decorators/v1/collection_json_decorator.rb
@@ -80,6 +80,10 @@ module V1
       @showcases ||= ShowcaseQuery.new(object.showcases).public_api_list
     end
 
+    def pages
+      @pages ||= PageQuery.new(object.pages).ordered
+    end
+
     def image
       if object.honeypot_image
         object.honeypot_image.json_response
@@ -88,6 +92,6 @@ module V1
 
     def display(json, _includes = {})
       json.partial! "/v1/collections/collection", collection_object: self
-end
+    end
   end
 end

--- a/app/decorators/v1/page_json_decorator.rb
+++ b/app/decorators/v1/page_json_decorator.rb
@@ -1,0 +1,40 @@
+
+module V1
+  class PageJSONDecorator < Draper::Decorator
+    delegate :id, :collection, :unique_id, :updated_at, :name, :content
+
+    def self.display(showcase, json)
+      new(showcase).display(json)
+    end
+
+    def at_id
+      h.v1_page_url(object.unique_id)
+    end
+
+    def collection_url
+      h.v1_collection_url(object.collection.unique_id)
+    end
+
+    def slug
+      CreateURLSlug.call(object.slug)
+    end
+
+    def additional_type
+      "https://github.com/ndlib/honeycomb/wiki/Page"
+    end
+
+    def next
+      SiteObjectsQuery.new.next(collection_object: object)
+    end
+
+    def previous
+      SiteObjectsQuery.new.previous(collection_object: object)
+    end
+
+    def display(json)
+      if object.present?
+        json.partial! "/v1/pages/page", page_object: self
+      end
+    end
+  end
+end

--- a/app/decorators/v1/section_json_decorator.rb
+++ b/app/decorators/v1/section_json_decorator.rb
@@ -7,6 +7,10 @@ module V1
       new(section).display(json)
     end
 
+    def additional_type
+      "https://github.com/ndlib/honeycomb/wiki/Section"
+    end
+
     def name
       SectionName.call(object)
     end

--- a/app/decorators/v1/site_objects_json_decorator.rb
+++ b/app/decorators/v1/site_objects_json_decorator.rb
@@ -8,7 +8,7 @@ module V1
       when "Item"
         V1::ItemJSONDecorator.display(site_object, json)
       when "Page"
-        nil
+        V1::PageJSONDecorator.display(site_object, json)
       else
         raise "Unsupported object type #{site_object.class.name}"
       end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -5,4 +5,8 @@ class Page < ActiveRecord::Base
   validates :collection, presence: true
 
   has_paper_trail
+
+  def slug
+    name
+  end
 end

--- a/app/values/cache_keys/custom/pages.rb
+++ b/app/values/cache_keys/custom/pages.rb
@@ -1,6 +1,6 @@
 module CacheKeys
   module Custom
-    # Generator for sections_controller
+    # Generator for pages_controller
     class Pages
       def index(collection:)
         CacheKeys::ActiveRecord.new.generate(record: [collection, collection.pages])

--- a/app/values/cache_keys/custom/v1_pages.rb
+++ b/app/values/cache_keys/custom/v1_pages.rb
@@ -1,0 +1,16 @@
+module CacheKeys
+  module Custom
+    # Generator for v1/pages_controller
+    class V1Pages
+      def index(collection:)
+        CacheKeys::ActiveRecord.new.generate(record: [collection, collection.pages])
+      end
+
+      def show(page:)
+        CacheKeys::ActiveRecord.new.generate(record: [page.object,
+                                                      page.collection,
+                                                      page.next])
+      end
+    end
+  end
+end

--- a/app/views/v1/items/_item.json.jbuilder
+++ b/app/views/v1/items/_item.json.jbuilder
@@ -2,6 +2,7 @@ json.set! "@context", "http://schema.org"
 json.set! "@type", "CreativeWork"
 json.set! "@id", item_object.at_id
 json.set! "isPartOf/collection", item_object.collection_url
+json.set! "additionalType", item_object.additional_type
 json.id item_object.unique_id
 json.slug item_object.slug
 json.name item_object.name

--- a/app/views/v1/pages/_page.json.jbuilder
+++ b/app/views/v1/pages/_page.json.jbuilder
@@ -1,0 +1,10 @@
+json.set! "@context", "http://schema.org"
+json.set! "@type", "CreativeWork"
+json.set! "@id", page_object.at_id
+json.set! "isPartOf/collection", page_object.collection_url
+json.set! "additionalType", page_object.additional_type
+json.id page_object.unique_id
+json.slug page_object.slug
+json.name page_object.name
+json.content page_object.content
+json.last_updated page_object.updated_at

--- a/app/views/v1/pages/index.json.jbuilder
+++ b/app/views/v1/pages/index.json.jbuilder
@@ -1,0 +1,6 @@
+@collection.display(json)
+json.set! :pages do
+  json.array! @collection.pages do |page|
+    V1::PageJSONDecorator.display(page, json)
+  end
+end

--- a/app/views/v1/pages/show.json.jbuilder
+++ b/app/views/v1/pages/show.json.jbuilder
@@ -1,0 +1,10 @@
+V1::CollectionJSONDecorator.display(@page.collection, json)
+json.set! :pages do
+  @page.display(json)
+  json.set! :nextObject do
+    V1::SiteObjectsJSONDecorator.display(@page.next, json) if @page.next.present?
+  end
+  json.set! :previousObject do
+    V1::SiteObjectsJSONDecorator.display(@page.previous, json) if @page.previous.present?
+  end
+end

--- a/app/views/v1/sections/_section.json.jbuilder
+++ b/app/views/v1/sections/_section.json.jbuilder
@@ -3,6 +3,7 @@ json.set! "@type", "CreativeWork"
 json.set! "@id", section_object.at_id
 json.set! "isPartOf/showcase", section_object.showcase_url
 json.set! "isPartOf/collection", section_object.collection_url
+json.set! "additionalType", section_object.additional_type
 json.id section_object.unique_id
 json.slug section_object.slug
 json.name section_object.name

--- a/app/views/v1/showcases/show.json.jbuilder
+++ b/app/views/v1/showcases/show.json.jbuilder
@@ -1,11 +1,11 @@
 V1::CollectionJSONDecorator.display(@showcase.collection, json)
 json.set! :showcases do
   @showcase.display(json)
-  json.set! :nextShowcase do
-    V1::ShowcaseJSONDecorator.display(@showcase.next, json)
+  json.set! :nextObject do
+    V1::SiteObjectsJSONDecorator.display(@showcase.next, json) if @showcase.next.present?
   end
-  json.set! :previousShowcase do
-    V1::ShowcaseJSONDecorator.display(@showcase.previous, json)
+  json.set! :previousObject do
+    V1::SiteObjectsJSONDecorator.display(@showcase.previous, json) if @showcase.previous.present?
   end
   json.set! :sections do
     json.array! @showcase.sections do |section|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,6 +76,7 @@ Rails.application.routes.draw do
       resources :search, only: [:index], defaults: { format: :json }
       resources :items, only: [:index], defaults: { format: :json }
       resources :showcases, only: [:index], defaults: { format: :json }
+      resources :pages, only: [:index], defaults: { format: :json }
     end
     resources :items,
               only: [:show, :update],
@@ -83,6 +84,7 @@ Rails.application.routes.draw do
       get :showcases, defaults: { format: :json }
     end
     resources :showcases, only: [:show], defaults: { format: :json }
+    resources :pages, only: [:show], defaults: { format: :json }
     resources :sections, only: [:show], defaults: { format: :json }
   end
 

--- a/spec/controllers/v1/pages_controller_spec.rb
+++ b/spec/controllers/v1/pages_controller_spec.rb
@@ -1,0 +1,79 @@
+require "rails_helper"
+require "cache_spec_helper"
+
+RSpec.describe V1::PagesController, type: :controller do
+  let(:collection) { instance_double(Collection, id: "1", updated_at: nil, pages: nil) }
+  let(:page) { instance_double(Page, id: "1", updated_at: nil, collection: nil) }
+
+  before(:each) do
+    allow_any_instance_of(PageQuery).to receive(:public_find).and_return(page)
+    allow_any_instance_of(CollectionQuery).to receive(:public_find).and_return(collection)
+  end
+
+  describe "#index" do
+    subject { get :index, collection_id: collection.id, format: :json }
+    it "calls CollectionQuery" do
+      expect_any_instance_of(CollectionQuery).to receive(:public_find).with(collection.id).and_return(collection)
+
+      subject
+    end
+
+    it "is successful" do
+      subject
+      expect(response).to be_success
+    end
+
+    it "assigns collection" do
+      subject
+      expect(assigns(:collection)).to be_present
+    end
+
+    it "renders the correct view" do
+      subject
+      expect(subject).to render_template("v1/pages/index")
+    end
+
+    it_behaves_like "a private basic custom etag cacher"
+
+    it "uses the V1Pages#index to generate the cache key" do
+      expect_any_instance_of(CacheKeys::Custom::V1Pages).to receive(:index)
+      subject
+    end
+  end
+
+  describe "#show" do
+    subject { get :show, id: "id", format: :json }
+
+    before(:each) do
+      allow_any_instance_of(V1::PageJSONDecorator).to receive(:next).and_return(nil)
+    end
+
+    it "calls PageQuery" do
+      expect_any_instance_of(PageQuery).to receive(:public_find).with("id").and_return(page)
+
+      subject
+    end
+
+    it "is successful" do
+      subject
+      expect(response).to be_success
+    end
+
+    it "assigns page" do
+      subject
+      expect(assigns(:page)).to be_present
+    end
+
+    it "renders the correct view" do
+      subject
+      expect(subject).to render_template("v1/pages/show")
+    end
+
+    it_behaves_like "a private basic custom etag cacher"
+
+    it "uses the V1Pages#show to generate the cache key" do
+      expect_any_instance_of(CacheKeys::Custom::V1Pages).to receive(:show)
+      subject
+    end
+  end
+end

--- a/spec/decorators/v1/collection_json_decorator_spec.rb
+++ b/spec/decorators/v1/collection_json_decorator_spec.rb
@@ -223,6 +223,15 @@ RSpec.describe V1::CollectionJSONDecorator do
     end
   end
 
+  describe "#pages" do
+    let(:collection) { double(Collection, pages: []) }
+
+    it "queries for ordered list of pages" do
+      expect_any_instance_of(PageQuery).to receive(:ordered)
+      subject.pages
+    end
+  end
+
   describe "#image" do
     let(:collection) { double(Collection, honeypot_image: honeypot_image) }
     let(:honeypot_image) { double(HoneypotImage, json_response: "json_response") }

--- a/spec/decorators/v1/page_json_decorator_spec.rb
+++ b/spec/decorators/v1/page_json_decorator_spec.rb
@@ -1,0 +1,68 @@
+require "rails_helper"
+
+RSpec.describe V1::PageJSONDecorator do
+  subject { described_class.new(page) }
+
+  let(:page) { double(Page) }
+
+  describe "generic fields" do
+    [:id, :unique_id, :collection, :updated_at, :name, :content].each do |field|
+      it "responds to #{field}" do
+        expect(subject).to respond_to(field)
+      end
+    end
+  end
+
+  describe "#at_id" do
+    let(:page) { double(Page, unique_id: "page_id") }
+
+    it "returns the path to the id" do
+      expect(subject.at_id).to eq("http://test.host/v1/pages/page_id")
+    end
+  end
+
+  describe "#collection_url" do
+    let(:collection) { double(Collection, unique_id: "collection_id") }
+    let(:page) { double(Page, collection: collection) }
+
+    it "returns the path to the items" do
+      expect(subject.collection_url).to eq("http://test.host/v1/collections/collection_id")
+    end
+  end
+
+  describe "#slug" do
+    let(:page) { double(Page, slug: "sluggish") }
+
+    it "calls the slug generator" do
+      expect(CreateURLSlug).to receive(:call).with(page.slug)
+      subject.slug
+    end
+  end
+
+  describe "#display" do
+    let(:json) { double }
+
+    it "calls the partial for the display" do
+      expect(json).to receive(:partial!).with("/v1/pages/page", page_object: page)
+      subject.display(json)
+    end
+  end
+
+  describe "#next" do
+    it "uses the site objects query to retrieve the next object" do
+      expect_any_instance_of(SiteObjectsQuery).to receive(:next).with(collection_object: page)
+      subject.next
+    end
+  end
+
+  describe "#previous" do
+    it "uses the site objects query to retrieve the previous object" do
+      expect_any_instance_of(SiteObjectsQuery).to receive(:previous).with(collection_object: page)
+      subject.previous
+    end
+  end
+
+  it "gives the correct additional_type" do
+    expect(subject.additional_type).to eq("https://github.com/ndlib/honeycomb/wiki/Page")
+  end
+end

--- a/spec/decorators/v1/section_json_decorator_spec.rb
+++ b/spec/decorators/v1/section_json_decorator_spec.rb
@@ -92,4 +92,8 @@ RSpec.describe V1::SectionJSONDecorator do
       subject.display(json)
     end
   end
+
+  it "gives the correct additional_type" do
+    expect(subject.additional_type).to eq("https://github.com/ndlib/honeycomb/wiki/Section")
+  end
 end

--- a/spec/decorators/v1/site_objects_json_decorator_spec.rb
+++ b/spec/decorators/v1/site_objects_json_decorator_spec.rb
@@ -11,7 +11,10 @@ RSpec.describe V1::SiteObjectsJSONDecorator do
     described_class.display(showcase, nil)
   end
 
-  it "calls the correct decorator for a Page"
+  it "calls the correct decorator for a Page" do
+    expect(V1::PageJSONDecorator).to receive(:display)
+    described_class.display(page, nil)
+  end
 
   it "calls the correct decorator for an Item" do
     expect(V1::ItemJSONDecorator).to receive(:display)

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -18,4 +18,9 @@ RSpec.describe Page do
     expect(subject).to respond_to(:paper_trail_enabled_for_model?)
     expect(subject.paper_trail_enabled_for_model?).to be(true)
   end
+
+  it "uses name for the slug" do
+    subject.name = "Slug"
+    expect(subject.slug).to eq(subject.name)
+  end
 end

--- a/spec/values/cache_keys/custom/v1_pages_spec.rb
+++ b/spec/values/cache_keys/custom/v1_pages_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe CacheKeys::Custom::V1Pages do
+  context "index" do
+    let(:collection) { instance_double(Collection, pages: "pages") }
+
+    it "uses CacheKeys::ActiveRecord" do
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate)
+      subject.index(collection: collection)
+    end
+
+    it "uses the correct data" do
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with(record: [collection, "pages"])
+      subject.index(collection: collection)
+    end
+  end
+
+  context "show" do
+    let(:page) { instance_double(Page, collection: "collection") }
+    let(:page_json) do
+      instance_double(V1::PageJSONDecorator,
+                      collection: "collection",
+                      next: "next",
+                      object: page)
+    end
+
+    it "uses CacheKeys::ActiveRecord" do
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate)
+      subject.show(page: page_json)
+    end
+
+    it "uses the correct data" do
+      expect_any_instance_of(CacheKeys::ActiveRecord).
+        to receive(:generate).
+        with(record: [page, page_json.collection, page_json.next])
+      subject.show(page: page_json)
+    end
+  end
+end


### PR DESCRIPTION
Why: Now that page models have been created, need a way to get page data via the api
How: 
-Added routes/controllers/views for v1 pages index and show
-Added cachekey generators for v1 pages index/show
-Changed showcases#show to use site objects for getting next/previous objects
-Added additionalType to item and section for consistency

Depends on https://github.com/ndlib/honeycomb/pull/291, will rebase when that's merged in.