### PR TITLE
DEC-685: Showcase order default

### DIFF
--- a/app/queries/showcase_query.rb
+++ b/app/queries/showcase_query.rb
@@ -20,6 +20,7 @@ class ShowcaseQuery
   delegate :find, to: :relation
 
   def build(args = {})
+    args[:order] = relation.maximum(:order).to_i + 1
     relation.build(args)
   end
 

--- a/spec/queries/showcase_query_spec.rb
+++ b/spec/queries/showcase_query_spec.rb
@@ -48,6 +48,18 @@ describe ShowcaseQuery do
       item = subject.build(exhibit_id: 1)
       expect(item.exhibit_id).to eq(1)
     end
+
+    it "gives the next order as a default order" do
+      allow(relation).to receive(:maximum).with(:order).and_return 10
+      item = subject.build(exhibit_id: 1)
+      expect(item.order).to eq(11)
+    end
+
+    it "gives an order of 1 if there are no showcases with an order" do
+      allow(relation).to receive(:maximum).with(:order).and_return nil
+      item = subject.build(exhibit_id: 1)
+      expect(item.order).to eq(1)
+    end
   end
 
   describe "public_find" do


### PR DESCRIPTION
ShowcaseQuery will now add a default value for order that is based on the existing showcase orders when calling the build method. This should effectively append any new showcases to the end of the exhibit's list of showcases. Since it's done in the build method, the user has the ability to change it before saving the new showcase.