### PR TITLE
DEC-684: Unable to save metadata

### DIFF
--- a/app/controllers/v1/items_controller.rb
+++ b/app/controllers/v1/items_controller.rb
@@ -60,28 +60,25 @@ module V1
 
     def save_params
       params.require(:item).permit(
+        :user_defined_id,
         :name,
         :description,
         :image,
         :manuscript_url,
         :transcription,
         :rights,
-        :subject,
-        :provenance,
-        :call_number,
-        :original_language,
         :uploaded_image,
-        :alternate_name,
-        :contributor,
-        :publisher,
-        :creator,
+        [:creator, creator: []], # both :creator, and creator: [] are required bc it can pass null or an array.
+        [:publisher, publisher: []], # both :publisher, and publisher: [] are required bc it can pass null or an array.
+        [:alternate_name, alternate_name: []], # both :alternate_name, and alternate_name: [] are required bc it can pass null or an array.
+        [:contributor, contributor: []], # both :contributor, and contributor: [] are required bc it can pass null or an array.
+        [:original_language, original_language: []],
+        [:subject, subject: []],
+        [:call_number, call_number: []],
+        [:provenance, provenance: []],
         date_created: [:value, :year, :month, :day, :bc, :display_text],
         date_modified: [:value, :year, :month, :day, :bc, :display_text],
         date_published: [:value, :year, :month, :day, :bc, :display_text],
-        creator: [], # both :creator, and creator: [] are required bc it can pass null or an array.
-        publisher: [], # both :publisher, and publisher: [] are required bc it can pass null or an array.
-        alternate_name: [], # both :alternate_name, and alternate_name: [] are required bc it can pass null or an array.
-        contributor: [], # both :contributor, and contributor: [] are required bc it can pass null or an array.
       )
     end
   end

--- a/spec/controllers/v1/items_controller_spec.rb
+++ b/spec/controllers/v1/items_controller_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe V1::ItemsController, type: :controller do
   describe "PUT #update" do
     let(:collection) { double(Collection, id: "1") }
     let(:item) { double(Item, id: 1, parent: nil, collection: collection) }
-    let(:update_params) { { format: :json, id: item.id, item: { title: "title" } } }
+    let(:update_params) { { format: :json, id: item.id, item: { name: "item" } } }
     subject { put :update, update_params }
 
     before(:each) do
@@ -107,6 +107,36 @@ RSpec.describe V1::ItemsController, type: :controller do
 
       assigns(:item)
       expect(assigns(:item)).to eq(item)
+    end
+
+    it "accepts an array for all metadata that allows multiples" do
+      Metadata::Configuration.item_configuration.fields.each do |field|
+        if field.multiple
+          update_params[:item][field.name] = []
+        end
+      end
+      expect(SaveItem).to receive(:call).with(item, update_params[:item])
+      subject
+    end
+
+    it "accepts a single value for all metadata that allows multiples" do
+      Metadata::Configuration.item_configuration.fields.each do |field|
+        if field.multiple
+          update_params[:item][field.name] = field.label
+        end
+      end
+      expect(SaveItem).to receive(:call).with(item, update_params[:item])
+      subject
+    end
+
+    it "accepts nil for all metadata that allows multiples" do
+      Metadata::Configuration.item_configuration.fields.each do |field|
+        if field.multiple
+          update_params[:item][field.name] = nil
+        end
+      end
+      expect(SaveItem).to receive(:call).with(item, update_params[:item])
+      subject
     end
 
     it "uses the save item service" do


### PR DESCRIPTION
Problem was due to the items controller not allowing arrays for some of the metadata fields that allow multiples. Fixed the items controller to allow arrays as params for all multiple fields. Also changed to permit user_defined_id to allow the user to change this if necessary.

Note: This bug affected 2.0 and master. https://github.com/ndlib/honeycomb/pull/295 was for fix to 2.0, this PR is to fix master.