### PR TITLE
BugFix: Search and Browse Stretched Images

### DIFF
--- a/app/models/waggle/item.rb
+++ b/app/models/waggle/item.rb
@@ -62,7 +62,7 @@ module Waggle
 
     def thumbnail
       if image
-        image["thumbnail/small"]
+        image["thumbnail/medium"]
       end
     end
   end

--- a/spec/models/waggle/adapters/solr/index/item_spec.rb
+++ b/spec/models/waggle/adapters/solr/index/item_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Waggle::Adapters::Solr::Index::Item do
         unique_id_s: "pig-in-mud",
         collection_id_s: "animals",
         type_s: "Item",
-        thumbnail_url_s: "http://localhost:3019/images/honeycomb/000/001/000/013/small/pig-in-mud.jpg",
+        thumbnail_url_s: "http://localhost:3019/images/honeycomb/000/001/000/013/medium/pig-in-mud.jpg",
         last_updated_dt: "2015-08-04T12:47:17Z",
         title_t: ["pig-in-mud"],
       )

--- a/spec/models/waggle/item_spec.rb
+++ b/spec/models/waggle/item_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Waggle::Item do
   describe "thumbnail_url" do
     it "is the correct value" do
       expect(subject.thumbnail_url).to be_present
-      expect(subject.thumbnail_url).to eq(data["image"]["thumbnail/small"]["contentUrl"])
+      expect(subject.thumbnail_url).to eq(data["image"]["thumbnail/medium"]["contentUrl"])
     end
   end
 


### PR DESCRIPTION
Why: Related to https://docs.google.com/document/d/1yzEkvolhxhzUDvHD4y92hOvj-g4yx5lcgO7MeFJu0wU/edit#bookmark=id.8t3ocag3vsri
How: Beehive requires the medium url for search hits. Changed the waggle item. This change will require reindexing all items so that the new url is returned in search results.

Note: This PR is for a bug fix on 2.0. Ticket https://jira.library.nd.edu/browse/DEC-688 should address the problem in master.