### PR TITLE
Fix api url

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -61,7 +61,7 @@ Rails.application.configure do
   # config.action_mailer.raise_delivery_errors = false
 
   default_url_options = {
-    host: "collections.library.nd.edu",
+    host: "honeycomb.library.nd.edu",
     protocol: "https"
   }
   config.action_mailer.default_url_options = default_url_options


### PR DESCRIPTION
API is currently using collections.library.nd.edu for things like showcases/items parts of collections, should be using honeycomb.library.nd.edu

Note: Previous PR was to fix 2.0