### PR TITLE
DEC-674: Migrate developers to postgres

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,9 @@ before_install:
 script:
   - bundle exec rspec spec
 before_script:
-  - cp config/secrets.example.yml config/secrets.yml  
-  - mysql -e 'create database honeycomb_test'
+  - cp config/secrets.example.yml config/secrets.yml
+  - psql -c 'create database honeycomb_test' -U postgres
+  - psql -c 'create role root superuser createdb createrole inherit login replication' -U postgres
   - RAILS_ENV=test bundle exec rake --trace db:migrate test
 cache:
   bundler: true

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem "responders", "~> 2.0"
 # gem "therubyracer",  platforms: :ruby
 
 gem "mysql2"
+gem "pg"
 
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem "jbuilder", "~> 2.0"

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,6 @@ gem "responders", "~> 2.0"
 # See https://github.com/sstephenson/execjs#readme for more supported runtimes
 # gem "therubyracer",  platforms: :ruby
 
-gem "mysql2"
 gem "pg"
 
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -275,7 +275,6 @@ GEM
     multi_json (1.11.2)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
-    mysql2 (0.3.17)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (2.9.2)
@@ -543,7 +542,6 @@ DEPENDENCIES
   jquery-rails (= 3.1.2)
   jquery-ui-rails (= 5.0.2)
   mime-types (~> 2.6.1)
-  mysql2
   newrelic_rpm
   paper_trail (~> 4.0.0.beta2)
   paperclip

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -305,6 +305,7 @@ GEM
       paperclip (>= 3.0.2, < 5.0)
     parser (2.2.2.6)
       ast (>= 1.1, < 3.0)
+    pg (0.18.4)
     powerpack (0.1.1)
     pry (0.10.1)
       coderay (~> 1.1.0)
@@ -547,6 +548,7 @@ DEPENDENCIES
   paper_trail (~> 4.0.0.beta2)
   paperclip
   paperclip-meta
+  pg
   pry
   pry-nav
   quiet_assets

--- a/app/queries/collection_query.rb
+++ b/app/queries/collection_query.rb
@@ -19,7 +19,7 @@ class CollectionQuery
   end
 
   def public_collections
-    relation.where("published = ?", true)
+    relation.where("published = ?", true).order(created_at: :asc)
   end
 
   def public_find(id)

--- a/app/queries/section_query.rb
+++ b/app/queries/section_query.rb
@@ -20,10 +20,12 @@ class SectionQuery
   end
 
   def next(section)
-    relation.where(showcase_id: section.showcase_id).where("`#{relation.table_name}`.order > ?", section.order).order(:order).first
+    order_field = Section.arel_table[:order]
+    relation.where(showcase_id: section.showcase_id).where(order_field.gt(section.order)).order(order: :asc).first
   end
 
   def previous(section)
-    relation.where(showcase_id: section.showcase_id).where("`#{relation.table_name}`.order < ?", section.order).order(order: :desc).first
+    order_field = Section.arel_table[:order]
+    relation.where(showcase_id: section.showcase_id).where(order_field.lt(section.order)).order(order: :desc).first
   end
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -10,8 +10,14 @@ mysql_settings: &mysql_settings
   reconnect: true
   pool:      5
 
+pg_settings: &pg_settings
+  adapter: postgresql
+  encoding: utf8
+  reconnect: true
+  pool: 5
+
 local_user: &local_user
-  <<: *mysql_settings
+  <<: *pg_settings
   username: root
   password:
   host:     localhost

--- a/db/dec_json_comparator.rb
+++ b/db/dec_json_comparator.rb
@@ -1,0 +1,39 @@
+# Compares two json files for differences using HashDiff. Order of arrays does not matter.
+# No output will be given if no differences were found.
+require 'json'
+require 'hashdiff'
+
+# Deep sorts jsons by id's
+def sort!(json)
+  if(json.respond_to?("sort!"))
+    json.sort! { |x, y| x["id"] <=> y["id"] }
+    json.each { |h| sort!(h) }
+  end
+  if(json.respond_to?("each_pair"))
+    json.each_pair { |k, v| sort!(json[k]) }
+  end
+end
+
+file1_path = ARGV[0]
+file2_path = ARGV[1]
+unless File.exist?(file1_path)
+  fail "'#{file1_path}' not found."
+end
+
+unless File.exist?(file2_path)
+  fail "'#{file2_path}' not found."
+end
+
+file1 = File.read(file1_path)
+json1 = JSON.parse(file1)
+sort!(json1)
+file2 = File.read(file2_path)
+json2 = JSON.parse(file2)
+sort!(json2)
+
+diff = HashDiff.diff(json1, json2)
+if diff.any?
+  print "HashDiff of '#{file1_path}' and '#{file2_path}':\n"
+  print HashDiff.diff(json1, json2)
+  print "\n"
+end

--- a/db/dec_json_comparator.rb
+++ b/db/dec_json_comparator.rb
@@ -1,16 +1,16 @@
 # Compares two json files for differences using HashDiff. Order of arrays does not matter.
 # No output will be given if no differences were found.
-require 'json'
-require 'hashdiff'
+require "json"
+require "hashdiff"
 
 # Deep sorts jsons by id's
 def sort!(json)
-  if(json.respond_to?("sort!"))
+  if (json.respond_to?("sort!"))
     json.sort! { |x, y| x["id"] <=> y["id"] }
     json.each { |h| sort!(h) }
   end
-  if(json.respond_to?("each_pair"))
-    json.each_pair { |k, v| sort!(json[k]) }
+  if (json.respond_to?("each_pair"))
+    json.each_pair { |k, _v| sort!(json[k]) }
   end
 end
 

--- a/db/dec_json_comparator.rb
+++ b/db/dec_json_comparator.rb
@@ -5,11 +5,11 @@ require "hashdiff"
 
 # Deep sorts jsons by id's
 def sort!(json)
-  if (json.respond_to?("sort!"))
+  if json.respond_to?("sort!")
     json.sort! { |x, y| x["id"] <=> y["id"] }
     json.each { |h| sort!(h) }
   end
-  if (json.respond_to?("each_pair"))
+  if json.respond_to?("each_pair")
     json.each_pair { |k, _v| sort!(json[k]) }
   end
 end

--- a/db/dec_scraper.py
+++ b/db/dec_scraper.py
@@ -1,0 +1,46 @@
+import urllib
+import json
+import re
+
+host_url = "http://localhost:3017"
+
+# Gets the json data at the requested uri, writes it to a file named by the uri,
+# and returns the json data for further processing.
+# Ex: get_json_file("/v1/collections")
+#     will create v1_collections.json with the json data retrieved
+def get_json_file(uri):
+    url = host_url + uri
+    host_pattern = re.compile('^' + host_url)
+    if host_pattern.match(uri):
+        url = uri
+
+    response = urllib.urlopen(url)
+    file_name = url.replace(host_url + '/', '')
+    file_name = file_name.replace('/', '_')
+    f = open(file_name, "w")
+    data = {}
+    status = response.getcode()
+    # pretty sure urllib doesn't cache, but I'll check anyway...
+    if status == 200 or status == 304:
+        data = json.loads(response.read())
+        f.write(json.dumps(data))
+    else:
+        f.write(response.read())
+    f.close
+    return data
+
+def main():
+    collections = get_json_file("/v1/collections")
+    for collection in collections:
+        collection = get_json_file(collection["@id"])
+        items = get_json_file(collection["hasPart/items"])
+        showcases = get_json_file(collection["hasPart/showcases"])
+        site_objects = get_json_file(collection["@id"] + "/site_objects")
+        for item in items["items"]:
+            item = get_json_file(item["@id"])
+            # for each child in item["children"]
+        for showcase in showcases["showcases"]:
+            showcase = get_json_file(showcase["@id"])
+            for section in showcase["showcases"]["sections"]:
+                section = get_json_file(section["@id"])
+main()

--- a/db/migrate/20150604150434_add_metadata_to_items.rb
+++ b/db/migrate/20150604150434_add_metadata_to_items.rb
@@ -1,5 +1,10 @@
 class AddMetadataToItems < ActiveRecord::Migration
   def change
-    add_column :items, :metadata, :text, limit: 4294967295
+    case ActiveRecord::Base.connection.class.name
+    when /.*Mysql.*/
+      add_column :items, :metadata, :text, limit: 4294967295
+    else
+      add_column :items, :metadata, :text
+    end
   end
 end

--- a/db/migrate/20151014173751_copy_collection_id_to_showcase.rb
+++ b/db/migrate/20151014173751_copy_collection_id_to_showcase.rb
@@ -1,7 +1,12 @@
 class CopyCollectionIdToShowcase < ActiveRecord::Migration
   def up
-    execute "UPDATE showcases INNER JOIN exhibits ON exhibits.id = showcases.exhibit_id
-             SET showcases.collection_id = exhibits.collection_id;"
+    case ActiveRecord::Base.connection.class.name
+    when /.*Mysql.*/
+      execute "UPDATE showcases INNER JOIN exhibits ON exhibits.id = showcases.exhibit_id
+               SET showcases.collection_id = exhibits.collection_id;"
+    else
+      execute "UPDATE showcases SET collection_id = exhibits.collection_id FROM exhibits WHERE exhibits.id = showcases.exhibit_id;"
+    end
   end
 
   def down

--- a/db/migrate/20151109212812_add_site_objects_to_collections.rb
+++ b/db/migrate/20151109212812_add_site_objects_to_collections.rb
@@ -1,5 +1,10 @@
 class AddSiteObjectsToCollections < ActiveRecord::Migration
   def change
-    add_column :collections, :site_objects, :text, limit: 4294967295
+    case ActiveRecord::Base.connection.class.name
+    when /.*Mysql.*/
+      add_column :collections, :site_objects, :text, limit: 4294967295
+    else
+      add_column :collections, :site_objects, :text
+    end
   end
 end

--- a/db/pgloader.lisp
+++ b/db/pgloader.lisp
@@ -1,0 +1,6 @@
+LOAD DATABASE
+FROM mysql://root@localhost/honeycomb_development
+INTO postgresql://root@localhost/honeycomb_development
+WITH data only
+SET session_replication_role = 'replica'
+EXCLUDING TABLE NAMES MATCHING 'schema_migrations';

--- a/db/recreate_constraints.sql
+++ b/db/recreate_constraints.sql
@@ -1,0 +1,15 @@
+\t
+\o drop_constraints.sql
+SELECT 'ALTER TABLE "'||nspname||'"."'||relname||'" DROP CONSTRAINT "'||conname||'";'
+ FROM pg_constraint
+ INNER JOIN pg_class ON conrelid=pg_class.oid
+ INNER JOIN pg_namespace ON pg_namespace.oid=pg_class.relnamespace
+ ORDER BY CASE WHEN contype='f' THEN 0 ELSE 1 END,contype,nspname,relname,conname;
+
+\o create_constraints.sql
+SELECT 'ALTER TABLE "'||nspname||'"."'||relname||'" ADD CONSTRAINT "'||conname||'" '||
+   pg_get_constraintdef(pg_constraint.oid)||';'
+ FROM pg_constraint
+ INNER JOIN pg_class ON conrelid=pg_class.oid
+ INNER JOIN pg_namespace ON pg_namespace.oid=pg_class.relnamespace
+ ORDER BY CASE WHEN contype='f' THEN 0 ELSE 1 END DESC,contype DESC,nspname DESC,relname DESC,conname DESC;

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,9 +13,12 @@
 
 ActiveRecord::Schema.define(version: 20151117161736) do
 
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
   create_table "collection_users", force: :cascade do |t|
-    t.integer  "user_id",       limit: 4, null: false
-    t.integer  "collection_id", limit: 4, null: false
+    t.integer  "user_id",       null: false
+    t.integer  "collection_id", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -24,31 +27,31 @@ ActiveRecord::Schema.define(version: 20151117161736) do
   add_index "collection_users", ["user_id"], name: "index_collection_users_on_user_id", using: :btree
 
   create_table "collections", force: :cascade do |t|
-    t.string   "name_line_1",                 limit: 255
+    t.string   "name_line_1"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "deleted",                                        default: false
-    t.string   "unique_id",                   limit: 255
+    t.boolean  "deleted",                     default: false
+    t.string   "unique_id"
     t.boolean  "published"
-    t.string   "name_line_2",                 limit: 255
+    t.string   "name_line_2"
     t.boolean  "preview_mode"
-    t.string   "url",                         limit: 255
-    t.text     "site_intro",                  limit: 65535
-    t.text     "short_intro",                 limit: 65535
-    t.text     "about",                       limit: 65535
-    t.text     "copyright",                   limit: 65535
+    t.string   "url"
+    t.text     "site_intro"
+    t.text     "short_intro"
+    t.text     "about"
+    t.text     "copyright"
     t.boolean  "enable_browse"
-    t.string   "image_file_name",             limit: 255
-    t.string   "image_content_type",          limit: 255
-    t.integer  "image_file_size",             limit: 4
+    t.string   "image_file_name"
+    t.string   "image_content_type"
+    t.integer  "image_file_size"
     t.datetime "image_updated_at"
-    t.string   "uploaded_image_file_name",    limit: 255
-    t.string   "uploaded_image_content_type", limit: 255
-    t.integer  "uploaded_image_file_size",    limit: 4
+    t.string   "uploaded_image_file_name"
+    t.string   "uploaded_image_content_type"
+    t.integer  "uploaded_image_file_size"
     t.datetime "uploaded_image_updated_at"
     t.boolean  "enable_search"
     t.boolean  "hide_title_on_home_page"
-    t.text     "site_objects",                limit: 4294967295
+    t.text     "site_objects"
   end
 
   add_index "collections", ["preview_mode"], name: "index_collections_on_preview_mode", using: :btree
@@ -56,80 +59,78 @@ ActiveRecord::Schema.define(version: 20151117161736) do
   add_index "collections", ["unique_id"], name: "index_collections_on_unique_id", using: :btree
 
   create_table "exhibits", force: :cascade do |t|
-    t.text     "name",                        limit: 65535
-    t.text     "description",                 limit: 65535
-    t.integer  "collection_id",               limit: 4
-    t.string   "image_file_name",             limit: 255
-    t.string   "image_content_type",          limit: 255
-    t.integer  "image_file_size",             limit: 4
+    t.text     "name"
+    t.text     "description"
+    t.integer  "collection_id"
+    t.string   "image_file_name"
+    t.string   "image_content_type"
+    t.integer  "image_file_size"
     t.datetime "image_updated_at"
-    t.text     "short_description",           limit: 65535
+    t.text     "short_description"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.text     "about",                       limit: 65535
-    t.string   "uploaded_image_file_name",    limit: 255
-    t.string   "uploaded_image_content_type", limit: 255
-    t.integer  "uploaded_image_file_size",    limit: 4
+    t.text     "about"
+    t.string   "uploaded_image_file_name"
+    t.string   "uploaded_image_content_type"
+    t.integer  "uploaded_image_file_size"
     t.datetime "uploaded_image_updated_at"
-    t.text     "copyright",                   limit: 65535
+    t.text     "copyright"
     t.boolean  "hide_title_on_home_page"
-    t.string   "url",                         limit: 255
+    t.string   "url"
     t.boolean  "enable_search"
     t.boolean  "enable_browse"
   end
 
-  add_index "exhibits", ["collection_id"], name: "fk_rails_b56f41d7b6", using: :btree
-
   create_table "honeypot_images", force: :cascade do |t|
-    t.integer  "item_id",       limit: 4
-    t.string   "name",          limit: 255
-    t.text     "json_response", limit: 65535
+    t.integer  "item_id"
+    t.string   "name"
+    t.text     "json_response"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "showcase_id",   limit: 4
-    t.integer  "exhibit_id",    limit: 4
-    t.integer  "collection_id", limit: 4
+    t.integer  "showcase_id"
+    t.integer  "exhibit_id"
+    t.integer  "collection_id"
   end
 
   add_index "honeypot_images", ["item_id"], name: "index_honeypot_images_on_item_id", using: :btree
 
   create_table "images", force: :cascade do |t|
-    t.integer  "collection_id",      limit: 4,     null: false
-    t.string   "image_file_name",    limit: 255,   null: false
-    t.string   "image_content_type", limit: 255
-    t.integer  "image_file_size",    limit: 4
+    t.integer  "collection_id",      null: false
+    t.string   "image_file_name",    null: false
+    t.string   "image_content_type"
+    t.integer  "image_file_size"
     t.datetime "image_updated_at"
-    t.string   "image_fingerprint",  limit: 255,   null: false
-    t.text     "image_meta",         limit: 65535
-    t.datetime "created_at",                       null: false
-    t.datetime "updated_at",                       null: false
+    t.string   "image_fingerprint",  null: false
+    t.text     "image_meta"
+    t.datetime "created_at",         null: false
+    t.datetime "updated_at",         null: false
   end
 
   add_index "images", ["image_fingerprint"], name: "index_images_on_image_fingerprint", using: :btree
 
   create_table "items", force: :cascade do |t|
-    t.text     "name",                        limit: 65535
-    t.text     "description",                 limit: 65535
+    t.text     "name"
+    t.text     "description"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "collection_id",               limit: 4
-    t.string   "image_file_name",             limit: 255
-    t.string   "image_content_type",          limit: 255
-    t.integer  "image_file_size",             limit: 4
+    t.integer  "collection_id"
+    t.string   "image_file_name"
+    t.string   "image_content_type"
+    t.integer  "image_file_size"
     t.datetime "image_updated_at"
-    t.text     "sortable_name",               limit: 65535
-    t.integer  "parent_id",                   limit: 4
-    t.string   "manuscript_url",              limit: 255
+    t.text     "sortable_name"
+    t.integer  "parent_id"
+    t.string   "manuscript_url"
     t.boolean  "published"
-    t.string   "unique_id",                   limit: 255
-    t.text     "transcription",               limit: 65535
-    t.string   "uploaded_image_file_name",    limit: 255
-    t.string   "uploaded_image_content_type", limit: 255
-    t.integer  "uploaded_image_file_size",    limit: 4
+    t.string   "unique_id"
+    t.text     "transcription"
+    t.string   "uploaded_image_file_name"
+    t.string   "uploaded_image_content_type"
+    t.integer  "uploaded_image_file_size"
     t.datetime "uploaded_image_updated_at"
-    t.text     "metadata",                    limit: 4294967295
-    t.integer  "image_status",                limit: 4,          default: 0
-    t.string   "user_defined_id",             limit: 255,                    null: false
+    t.text     "metadata"
+    t.integer  "image_status",                default: 0
+    t.string   "user_defined_id",                         null: false
   end
 
   add_index "items", ["collection_id", "user_defined_id"], name: "index_items_on_collection_id_and_user_defined_id", unique: true, using: :btree
@@ -139,72 +140,66 @@ ActiveRecord::Schema.define(version: 20151117161736) do
   add_index "items", ["unique_id"], name: "index_items_on_unique_id", using: :btree
 
   create_table "pages", force: :cascade do |t|
-    t.string   "unique_id",     limit: 255
-    t.string   "name",          limit: 255
-    t.text     "content",       limit: 65535
-    t.integer  "collection_id", limit: 4,     null: false
-    t.datetime "created_at",                  null: false
-    t.datetime "updated_at",                  null: false
-    t.integer  "image_id",      limit: 4
+    t.string   "unique_id"
+    t.string   "name"
+    t.text     "content"
+    t.integer  "collection_id", null: false
+    t.datetime "created_at",    null: false
+    t.datetime "updated_at",    null: false
+    t.integer  "image_id"
   end
 
-  add_index "pages", ["collection_id"], name: "fk_rails_b9e6c17b8e", using: :btree
-  add_index "pages", ["image_id"], name: "fk_rails_7484eb7907", using: :btree
-
   create_table "sections", force: :cascade do |t|
-    t.string   "name",        limit: 255
-    t.text     "description", limit: 65535
-    t.string   "image",       limit: 255
-    t.integer  "item_id",     limit: 4
-    t.integer  "order",       limit: 4
-    t.text     "caption",     limit: 65535
-    t.integer  "showcase_id", limit: 4
-    t.string   "unique_id",   limit: 255
+    t.string   "name"
+    t.text     "description"
+    t.string   "image"
+    t.integer  "item_id"
+    t.integer  "order"
+    t.text     "caption"
+    t.integer  "showcase_id"
+    t.string   "unique_id"
     t.datetime "updated_at"
     t.datetime "created_at"
     t.boolean  "has_spacer"
   end
 
-  add_index "sections", ["item_id"], name: "fk_rails_921f48e5e7", using: :btree
-  add_index "sections", ["showcase_id"], name: "fk_rails_9a3e59b41b", using: :btree
   add_index "sections", ["unique_id"], name: "index_sections_on_unique_id", using: :btree
 
   create_table "showcases", force: :cascade do |t|
-    t.text     "name_line_1",                 limit: 65535
-    t.text     "description",                 limit: 65535
-    t.integer  "exhibit_id",                  limit: 4
-    t.string   "image_file_name",             limit: 255
-    t.string   "image_content_type",          limit: 255
-    t.integer  "image_file_size",             limit: 4
+    t.text     "name_line_1"
+    t.text     "description"
+    t.integer  "exhibit_id"
+    t.string   "image_file_name"
+    t.string   "image_content_type"
+    t.integer  "image_file_size"
     t.datetime "image_updated_at"
     t.datetime "updated_at"
     t.datetime "created_at"
     t.boolean  "published"
-    t.string   "unique_id",                   limit: 255
-    t.string   "name_line_2",                 limit: 255
-    t.string   "uploaded_image_file_name",    limit: 255
-    t.string   "uploaded_image_content_type", limit: 255
-    t.integer  "uploaded_image_file_size",    limit: 4
+    t.string   "unique_id"
+    t.string   "name_line_2"
+    t.string   "uploaded_image_file_name"
+    t.string   "uploaded_image_content_type"
+    t.integer  "uploaded_image_file_size"
     t.datetime "uploaded_image_updated_at"
-    t.integer  "collection_id",               limit: 4
+    t.integer  "collection_id"
   end
 
   add_index "showcases", ["collection_id"], name: "index_showcases_on_collection_id", using: :btree
-  add_index "showcases", ["exhibit_id"], name: "fk_rails_ee93a134d7", using: :btree
   add_index "showcases", ["published"], name: "index_showcases_on_published", using: :btree
   add_index "showcases", ["unique_id"], name: "index_showcases_on_unique_id", using: :btree
 
   create_table "users", force: :cascade do |t|
-    t.string   "first_name",         limit: 255
-    t.string   "last_name",          limit: 255
-    t.string   "display_name",       limit: 255
-    t.string   "email",              limit: 255, default: "", null: false
-    t.integer  "sign_in_count",      limit: 4,   default: 0
+    t.string   "first_name"
+    t.string   "last_name"
+    t.string   "display_name"
+    t.string   "email",              default: "", null: false
+    t.integer  "sign_in_count",      default: 0
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
-    t.string   "current_sign_in_ip", limit: 255
-    t.string   "last_sign_in_ip",    limit: 255
-    t.string   "username",           limit: 255
+    t.string   "current_sign_in_ip"
+    t.string   "last_sign_in_ip"
+    t.string   "username"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.boolean  "admin"
@@ -214,11 +209,11 @@ ActiveRecord::Schema.define(version: 20151117161736) do
   add_index "users", ["username"], name: "index_users_on_username", unique: true, using: :btree
 
   create_table "versions", force: :cascade do |t|
-    t.string   "item_type",  limit: 255,   null: false
-    t.integer  "item_id",    limit: 4,     null: false
-    t.string   "event",      limit: 255,   null: false
-    t.string   "whodunnit",  limit: 255
-    t.text     "object",     limit: 65535
+    t.string   "item_type",  null: false
+    t.integer  "item_id",    null: false
+    t.string   "event",      null: false
+    t.string   "whodunnit"
+    t.text     "object"
     t.datetime "created_at"
   end
 

--- a/spec/queries/collection_query_spec.rb
+++ b/spec/queries/collection_query_spec.rb
@@ -30,7 +30,7 @@ describe CollectionQuery do
 
   describe "public_collections" do
     it "returns all published collections" do
-      expect(relation).to receive(:where).with("published = ?", true)
+      expect(relation).to receive(:where).with("published = ?", true).and_return(relation)
       subject.public_collections
     end
   end


### PR DESCRIPTION
Why: We are going to be working on some features such as dynamic metadata that will be easier to r/w with postgres
How:
-Added pg gem to support postgres
-Fixed migrations and queries that explicitly used sql since there are differences between mysql/pg
-Fixed text type definitions, the pg equivalent of mysql longtext is just text
-Fixed travis to work with pg
-Found a problem with the section query and changed to work a little more safely with both pg and mysql
-Found a problem with ordering differences between postgres and mysql. Changed the default order of collections to force it to match the way mysql collections were ordered.

Specific to server migration:
-Created a pgloader script to use to copy the data. Had to make it only copy data to avoid it writing the schema differently from rails. This means we'll need to use rails to create the db and load the schema, then run the pgloader script to handle data copy.
-Wrote a basic scraper in python to get api data and wrote a comparator to compare the json files. These will be used to perform a pre/post server migration comparison to make sure the output is the same.
-For server migration, will need to drop constraints, copy data, then recreate the constraints. Added a script that will generate a drop/create script that we can use during the migration.