### PR TITLE
DEC-695: Cannot insert items into page if collection is not published or preview enabled

### DIFF
--- a/app/controllers/v1/items_controller.rb
+++ b/app/controllers/v1/items_controller.rb
@@ -3,7 +3,7 @@ module V1
   class ItemsController < APIController
     # API controller for items
     def index
-      collection = CollectionQuery.new.public_find(params[:collection_id])
+      collection = CollectionQuery.new.any_find(params[:collection_id])
       @collection = CollectionJSONDecorator.new(collection)
 
       cache_key = CacheKeys::Generator.new(key_generator: CacheKeys::Custom::V1Items,

--- a/spec/controllers/v1/items_controller_spec.rb
+++ b/spec/controllers/v1/items_controller_spec.rb
@@ -12,8 +12,12 @@ RSpec.describe V1::ItemsController, type: :controller do
 
   describe "#index" do
     subject { get :index, collection_id: collection.id, format: :json }
+    before(:each) do
+      allow_any_instance_of(CollectionQuery).to receive(:any_find).and_return(collection)
+    end
+
     it "calls CollectionQuery" do
-      expect_any_instance_of(CollectionQuery).to receive(:public_find).with(collection.id).and_return(collection)
+      expect_any_instance_of(CollectionQuery).to receive(:any_find).with(collection.id).and_return(collection)
 
       subject
     end


### PR DESCRIPTION
Why: The page redactor allows the user to insert images that are in the collection, but this fails if the collection is not either in preview mode or is published.
How: Modified ItemsController#index to use any_find instead of public_find, so that we can get items for the collection even if it's not published/preview enabled.