### PR TITLE
DEC-696: Page/Showcase edit fails to load when site objects is nil

### DIFF
--- a/app/queries/site_objects_query.rb
+++ b/app/queries/site_objects_query.rb
@@ -51,7 +51,7 @@ class SiteObjectsQuery
   # Ex: [{type: "showcase", id: 3},{ type: "showcase", id:1 }]
   def site_objects_json(collection_id:)
     collection = Collection.find(collection_id)
-    if collection.nil?
+    if collection.nil? || collection.site_objects.blank?
       []
     else
       JSON.parse(collection.site_objects, symbolize_names: true)

--- a/spec/queries/site_objects_query_spec.rb
+++ b/spec/queries/site_objects_query_spec.rb
@@ -44,6 +44,23 @@ describe SiteObjectsQuery do
     expect(subject.all(collection: collection)).to eq(site_objects)
   end
 
+  it "returns empty array if site_objects is nil" do
+    allow(collection).to receive(:site_objects).and_return(nil)
+    expect(subject.all(collection: collection)).to eq([])
+  end
+
+  it "returns empty array if site_objects is empty string" do
+    allow(collection).to receive(:site_objects).and_return("")
+    expect(subject.all(collection: collection)).to eq([])
+  end
+
+  # The json string will be formed by code, not by a user, so if something goes
+  # wrong, we should know about it
+  it "throws an exception if the site_objects json is malformed" do
+    allow(collection).to receive(:site_objects).and_return("[")
+    expect{subject.all(collection: collection)}.to raise_error
+  end
+
   context "when asking if an object exists in the array" do
     it "returns false if the object given is not in the site_objects array" do
       expect(subject.exists?(collection_object: showcases[1])).to eq(false)

--- a/spec/queries/site_objects_query_spec.rb
+++ b/spec/queries/site_objects_query_spec.rb
@@ -58,7 +58,7 @@ describe SiteObjectsQuery do
   # wrong, we should know about it
   it "throws an exception if the site_objects json is malformed" do
     allow(collection).to receive(:site_objects).and_return("[")
-    expect{subject.all(collection: collection)}.to raise_error
+    expect { subject.all(collection: collection) }.to raise_error
   end
 
   context "when asking if an object exists in the array" do


### PR DESCRIPTION
Why: Within Page/Showcase edit, the delete button tries to disable itself if the object is included in site_objects, as a way of enforcing referencial integrity at the app layer. This check fails when the field is nil.
How: Changed the site objects query object to return an empty array if the field is null or empty string.