### PR TITLE
Dec 738 migrate metadata to jsonb

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,10 @@ cache:
   bundler: true
   directories:
   - node_modules
+addons:
+  postgresql: "9.4"
+services:
+  - postgresql  
 notifications:
   hipchat:
     on_success: change

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,19 +1,17 @@
 class Item < ActiveRecord::Base
-  store :metadata,
-        accessors: [
-          :creator,
-          :contributor,
-          :publisher,
-          :alternate_name,
-          :rights,
-          :call_number,
-          :provenance,
-          :subject,
-          :original_language,
-          :date_created,
-          :date_published,
-          :date_modified
-        ], coder: JSON
+  store_accessor :metadata,
+    :creator,
+    :contributor,
+    :publisher,
+    :alternate_name,
+    :rights,
+    :call_number,
+    :provenance,
+    :subject,
+    :original_language,
+    :date_created,
+    :date_published,
+    :date_modified
 
   has_paper_trail
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,17 +1,17 @@
 class Item < ActiveRecord::Base
   store_accessor :metadata,
-    :creator,
-    :contributor,
-    :publisher,
-    :alternate_name,
-    :rights,
-    :call_number,
-    :provenance,
-    :subject,
-    :original_language,
-    :date_created,
-    :date_published,
-    :date_modified
+                 :creator,
+                 :contributor,
+                 :publisher,
+                 :alternate_name,
+                 :rights,
+                 :call_number,
+                 :provenance,
+                 :subject,
+                 :original_language,
+                 :date_created,
+                 :date_published,
+                 :date_modified
 
   has_paper_trail
 

--- a/db/migrate/20160121133856_migrate_item_metadata_to_jsonb.rb
+++ b/db/migrate/20160121133856_migrate_item_metadata_to_jsonb.rb
@@ -1,0 +1,11 @@
+class MigrateItemMetadataToJsonb < ActiveRecord::Migration
+  def change
+    add_column :items, :metadata_jsonb, :jsonb, default: "{}"
+    execute "UPDATE items SET metadata_jsonb = metadata::jsonb"
+    execute "update items set metadata_jsonb = '{}' where metadata_jsonb is null"
+
+    change_column :items, :metadata_jsonb, :jsonb, null: false
+    rename_column :items, :metadata, :metadata_json
+    rename_column :items, :metadata_jsonb, :metadata
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151117161736) do
+ActiveRecord::Schema.define(version: 20160121133856) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -128,9 +128,10 @@ ActiveRecord::Schema.define(version: 20151117161736) do
     t.string   "uploaded_image_content_type"
     t.integer  "uploaded_image_file_size"
     t.datetime "uploaded_image_updated_at"
-    t.text     "metadata"
+    t.text     "metadata_json"
     t.integer  "image_status",                default: 0
-    t.string   "user_defined_id",                         null: false
+    t.string   "user_defined_id",                          null: false
+    t.jsonb    "metadata",                    default: {}, null: false
   end
 
   add_index "items", ["collection_id", "user_defined_id"], name: "index_items_on_collection_id_and_user_defined_id", unique: true, using: :btree


### PR DESCRIPTION
why: now that the we have jsonb. we need to migration of the old json store of metadata values to the new and flashy jsonb fields. 

what: added a migration to convert the field and converted the class.  

