### PR TITLE
Dec 739 create collection metadata config

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -5,6 +5,7 @@ class Collection < ActiveRecord::Base
   has_many :showcases
   has_many :pages
   has_one :honeypot_image
+  has_one :collection_configuration
 
   has_attached_file :image,
                     restricted_characters: /[&$+,\/:;=?@<>\[\]{}\|\\^~%#]/

--- a/app/models/collection_configuration.rb
+++ b/app/models/collection_configuration.rb
@@ -1,0 +1,4 @@
+class CollectionConfiguration < ActiveRecord::Base
+  belongs_to :collection
+
+end

--- a/app/models/collection_configuration.rb
+++ b/app/models/collection_configuration.rb
@@ -1,4 +1,3 @@
 class CollectionConfiguration < ActiveRecord::Base
   belongs_to :collection
-
 end

--- a/app/services/create_collection_configuration.rb
+++ b/app/services/create_collection_configuration.rb
@@ -1,0 +1,28 @@
+class CreateCollectionConfiguration
+  attr_reader :collection
+
+  def self.call(collection)
+    new(collection).create
+  end
+
+  def initialize(collection)
+    @collection = collection
+  end
+
+  def create
+    return collection.collection_configuration if collection.collection_configuration
+
+    collection.create_collection_configuration(
+      metadata: base_config[:fields],
+      sorts: base_config[:sorts],
+      facets: base_config[:facets],
+    )
+  end
+
+  private
+
+  def base_config
+    @base_config ||= YAML.load_file(Rails.root.join("config/metadata/", "item.yml"))
+  end
+
+end

--- a/app/services/create_collection_configuration.rb
+++ b/app/services/create_collection_configuration.rb
@@ -24,5 +24,4 @@ class CreateCollectionConfiguration
   def base_config
     @base_config ||= YAML.load_file(Rails.root.join("config/metadata/", "item.yml"))
   end
-
 end

--- a/app/services/save_collection.rb
+++ b/app/services/save_collection.rb
@@ -16,6 +16,7 @@ class SaveCollection
     collection.attributes = params
     check_unique_id
     if collection.save && process_uploaded_image
+      ensure_configuration_setup
       true
     else
       false
@@ -45,5 +46,9 @@ class SaveCollection
     else
       true
     end
+  end
+
+  def ensure_configuration_setup
+    CreateCollectionConfiguration.call(collection)
   end
 end

--- a/db/migrate/20160121193224_create_metadata_configurations.rb
+++ b/db/migrate/20160121193224_create_metadata_configurations.rb
@@ -1,6 +1,6 @@
 class CreateMetadataConfigurations < ActiveRecord::Migration
   def change
-    create_table :configurations do |t|
+    create_table :collection_configurations do |t|
       t.integer :collection_id, null: false
       t.jsonb :metadata, null: false, default: "{}"
       t.jsonb :sorts, null: false, default: "{}"
@@ -8,6 +8,6 @@ class CreateMetadataConfigurations < ActiveRecord::Migration
       t.timestamps
     end
 
-    add_foreign_key :configurations, :collections
+    add_foreign_key :collection_configurations, :collections
   end
 end

--- a/db/migrate/20160121193224_create_metadata_configurations.rb
+++ b/db/migrate/20160121193224_create_metadata_configurations.rb
@@ -1,0 +1,13 @@
+class CreateMetadataConfigurations < ActiveRecord::Migration
+  def change
+    create_table :configurations do |t|
+      t.integer :collection_id, null: false
+      t.jsonb :metadata, null: false, default: "{}"
+      t.jsonb :sorts, null: false, default: "{}"
+      t.jsonb :facets, null: false, default: "{}"
+      t.timestamps
+    end
+
+    add_foreign_key :configurations, :collections
+  end
+end

--- a/db/migrate/20160122191511_update_collection_configuration.rb
+++ b/db/migrate/20160122191511_update_collection_configuration.rb
@@ -1,0 +1,7 @@
+class UpdateCollectionConfiguration < ActiveRecord::Migration
+  def change
+    Collection.all.each do | collection |
+      CreateCollectionConfiguration.call(collection)
+    end
+  end
+end

--- a/db/migrate/20160122191511_update_collection_configuration.rb
+++ b/db/migrate/20160122191511_update_collection_configuration.rb
@@ -1,6 +1,6 @@
 class UpdateCollectionConfiguration < ActiveRecord::Migration
   def change
-    Collection.all.each do | collection |
+    Collection.all.each do |collection|
       CreateCollectionConfiguration.call(collection)
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,6 +16,15 @@ ActiveRecord::Schema.define(version: 20160121193224) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
+  create_table "collection_configurations", force: :cascade do |t|
+    t.integer  "collection_id",              null: false
+    t.jsonb    "metadata",      default: {}, null: false
+    t.jsonb    "sorts",         default: {}, null: false
+    t.jsonb    "facets",        default: {}, null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
   create_table "collection_users", force: :cascade do |t|
     t.integer  "user_id",       null: false
     t.integer  "collection_id", null: false
@@ -57,15 +66,6 @@ ActiveRecord::Schema.define(version: 20160121193224) do
   add_index "collections", ["preview_mode"], name: "index_collections_on_preview_mode", using: :btree
   add_index "collections", ["published"], name: "index_collections_on_published", using: :btree
   add_index "collections", ["unique_id"], name: "index_collections_on_unique_id", using: :btree
-
-  create_table "configurations", force: :cascade do |t|
-    t.integer  "collection_id",              null: false
-    t.jsonb    "metadata",      default: {}, null: false
-    t.jsonb    "sorts",         default: {}, null: false
-    t.jsonb    "facets",        default: {}, null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
 
   create_table "exhibits", force: :cascade do |t|
     t.text     "name"
@@ -229,9 +229,9 @@ ActiveRecord::Schema.define(version: 20160121193224) do
 
   add_index "versions", ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id", using: :btree
 
+  add_foreign_key "collection_configurations", "collections"
   add_foreign_key "collection_users", "collections"
   add_foreign_key "collection_users", "users"
-  add_foreign_key "configurations", "collections"
   add_foreign_key "items", "collections"
   add_foreign_key "items", "items", column: "parent_id"
   add_foreign_key "pages", "collections"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151117161736) do
+ActiveRecord::Schema.define(version: 20160121193224) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -57,6 +57,15 @@ ActiveRecord::Schema.define(version: 20151117161736) do
   add_index "collections", ["preview_mode"], name: "index_collections_on_preview_mode", using: :btree
   add_index "collections", ["published"], name: "index_collections_on_published", using: :btree
   add_index "collections", ["unique_id"], name: "index_collections_on_unique_id", using: :btree
+
+  create_table "configurations", force: :cascade do |t|
+    t.integer  "collection_id",              null: false
+    t.jsonb    "metadata",      default: {}, null: false
+    t.jsonb    "sorts",         default: {}, null: false
+    t.jsonb    "facets",        default: {}, null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
 
   create_table "exhibits", force: :cascade do |t|
     t.text     "name"
@@ -128,9 +137,10 @@ ActiveRecord::Schema.define(version: 20151117161736) do
     t.string   "uploaded_image_content_type"
     t.integer  "uploaded_image_file_size"
     t.datetime "uploaded_image_updated_at"
-    t.text     "metadata"
+    t.text     "metadata_json"
     t.integer  "image_status",                default: 0
-    t.string   "user_defined_id",                         null: false
+    t.string   "user_defined_id",                          null: false
+    t.jsonb    "metadata",                    default: {}, null: false
   end
 
   add_index "items", ["collection_id", "user_defined_id"], name: "index_items_on_collection_id_and_user_defined_id", unique: true, using: :btree
@@ -221,6 +231,7 @@ ActiveRecord::Schema.define(version: 20151117161736) do
 
   add_foreign_key "collection_users", "collections"
   add_foreign_key "collection_users", "users"
+  add_foreign_key "configurations", "collections"
   add_foreign_key "items", "collections"
   add_foreign_key "items", "items", column: "parent_id"
   add_foreign_key "pages", "collections"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,8 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
-ActiveRecord::Schema.define(version: 20160121193224) do
+ActiveRecord::Schema.define(version: 20160122191511) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/factories/item.rb
+++ b/spec/factories/item.rb
@@ -10,15 +10,4 @@ FactoryGirl.define do
     image_content_type "image/jpeg"
     image_file_size 1.megabyte
   end
-
-  factory :no_metadata_item, class: Item do |i|
-    i.id { 1 }
-    i.name { "one" }
-    i.collection_id { 1 }
-    i.user_defined_id { "one" }
-    i.unique_id { "one" }
-    image_file_name "one.jpg"
-    image_content_type "image/jpeg"
-    image_file_size 1.megabyte
-  end
 end

--- a/spec/factories/item.rb
+++ b/spec/factories/item.rb
@@ -5,6 +5,18 @@ FactoryGirl.define do
     i.collection_id { 1 }
     i.user_defined_id { "one" }
     i.unique_id { "one" }
+    i.metadata { {} }
+    image_file_name "one.jpg"
+    image_content_type "image/jpeg"
+    image_file_size 1.megabyte
+  end
+
+  factory :no_metadata_item, class: Item do |i|
+    i.id { 1 }
+    i.name { "one" }
+    i.collection_id { 1 }
+    i.user_defined_id { "one" }
+    i.unique_id { "one" }
     image_file_name "one.jpg"
     image_content_type "image/jpeg"
     image_file_size 1.megabyte

--- a/spec/models/collection_configuration_spec.rb
+++ b/spec/models/collection_configuration_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.describe CollectionConfiguration do
+  subject { CollectionConfiguration.new }
+  [
+    :collection,
+    :metadata,
+    :facets,
+    :sorts
+  ].each do |field|
+    it "has field, #{field}" do
+      expect(subject).to respond_to(field)
+      expect(subject).to respond_to("#{field}=")
+    end
+  end
+end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Collection do
   [:name_line_1, :name_line_2, :items, :unique_id, :showcases,
    :collection_users, :published, :preview_mode, :users, :updated_at, :created_at,
    :site_intro, :short_intro, :showcases, :hide_title_on_home_page, :about, :copyright,
-   :enable_search, :enable_browse, :image, :uploaded_image, :pages].each do |field|
+   :enable_search, :enable_browse, :image, :uploaded_image, :pages, :collection_configuration].each do |field|
     it "has field, #{field}" do
       expect(subject).to respond_to(field)
       expect(subject).to respond_to("#{field}=")

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -127,6 +127,12 @@ RSpec.describe Item do
     end
   end
 
+  context "null constraints" do
+    it "does not allow metadata to be nil " do
+      expect { FactoryGirl.create(:no_metadata_item, collection: FactoryGirl.create(:collection)) }.to raise_error ActiveRecord::StatementInvalid
+    end
+  end
+
   context "foreign key constraints" do
     describe "#destroy" do
       it "fails if a section references it" do

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -127,12 +127,6 @@ RSpec.describe Item do
     end
   end
 
-  context "null constraints" do
-    it "does not allow metadata to be nil " do
-      expect { FactoryGirl.create(:no_metadata_item, collection: FactoryGirl.create(:collection)) }.to raise_error ActiveRecord::StatementInvalid
-    end
-  end
-
   context "foreign key constraints" do
     describe "#destroy" do
       it "fails if a section references it" do

--- a/spec/services/create_collection_configuration_spec.rb
+++ b/spec/services/create_collection_configuration_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe CreateCollectionConfiguration do
   end
 
   context "no existing configuration" do
-    let(:collection) { double(collection_configuration: nil, create_collection_configuration: double()) }
+    let(:collection) { double(collection_configuration: nil, create_collection_configuration: double }
 
     it "builds a new configuration if there is not one" do
       expect(collection).to receive(:create_collection_configuration).and_return("CONFIGURATION")

--- a/spec/services/create_collection_configuration_spec.rb
+++ b/spec/services/create_collection_configuration_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe CreateCollectionConfiguration do
+  subject { described_class.call(collection) }
+
+  context "exhisting configuration" do
+    let(:collection) { double(collection_configuration: "CONFIGURATION") }
+
+    it "returns the current configuration if there is a configuration" do
+      expect(subject).to eq("CONFIGURATION")
+    end
+  end
+
+  context "no existing configuration" do
+    let(:collection) { double(collection_configuration: nil, create_collection_configuration: double ) }
+
+    it "builds a new configuration if there is not one" do
+      expect(collection).to receive(:create_collection_configuration).and_return("CONFIGURATION")
+      subject
+    end
+
+    it "returns the newly generted configuration" do
+      allow(collection).to receive(:create_collection_configuration).and_return("CONFIGURATION")
+      expect(subject).to eq("CONFIGURATION")
+    end
+
+    it "loads configuration from a yml file when there is no configuration" do
+      expect(YAML).to receive(:load_file).with(Rails.root.join("config/metadata/", "item.yml")).and_return(fields: [])
+      subject
+    end
+
+    it "passes the metadata, facets, and sorts from the config file to the create command" do
+      allow(YAML).to receive(:load_file).with(Rails.root.join("config/metadata/", "item.yml")).and_return(fields: "fields", facets: "facets", sorts: "sorts")
+      expect(collection).to receive(:create_collection_configuration).with({metadata: "fields", sorts: "sorts", facets: "facets"})
+      subject
+    end
+  end
+end

--- a/spec/services/create_collection_configuration_spec.rb
+++ b/spec/services/create_collection_configuration_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe CreateCollectionConfiguration do
   end
 
   context "no existing configuration" do
-    let(:collection) { double(collection_configuration: nil, create_collection_configuration: double ) }
+    let(:collection) { double(collection_configuration: nil, create_collection_configuration: double()) }
 
     it "builds a new configuration if there is not one" do
       expect(collection).to receive(:create_collection_configuration).and_return("CONFIGURATION")

--- a/spec/services/create_collection_configuration_spec.rb
+++ b/spec/services/create_collection_configuration_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe CreateCollectionConfiguration do
   end
 
   context "no existing configuration" do
-    let(:collection) { double(collection_configuration: nil, create_collection_configuration: double }
+    let(:collection) { double(collection_configuration: nil, create_collection_configuration: double) }
 
     it "builds a new configuration if there is not one" do
       expect(collection).to receive(:create_collection_configuration).and_return("CONFIGURATION")

--- a/spec/services/create_collection_configuration_spec.rb
+++ b/spec/services/create_collection_configuration_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe CreateCollectionConfiguration do
 
     it "passes the metadata, facets, and sorts from the config file to the create command" do
       allow(YAML).to receive(:load_file).with(Rails.root.join("config/metadata/", "item.yml")).and_return(fields: "fields", facets: "facets", sorts: "sorts")
-      expect(collection).to receive(:create_collection_configuration).with({metadata: "fields", sorts: "sorts", facets: "facets"})
+      expect(collection).to receive(:create_collection_configuration).with(metadata: "fields", sorts: "sorts", facets: "facets")
       subject
     end
   end

--- a/spec/services/save_collection_spec.rb
+++ b/spec/services/save_collection_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe SaveCollection, type: :model do
   subject { described_class.call(collection, params) }
-  let(:collection) { double(Collection, id: "id", "attributes=" => true, save: true, url: nil) }
+  let(:collection) { double(Collection, id: "id", "attributes=" => true, save: true, url: nil, collection_configuration: double) }
   let(:params) { { name_line_1: "name_line_1" } }
   let(:upload_image) { Rack::Test::UploadedFile.new(Rails.root.join("spec/fixtures/test.jpg"), "image/jpeg") }
 
@@ -83,6 +83,19 @@ RSpec.describe SaveCollection, type: :model do
     it "does add http if http is given but misspelled" do
       params[:url] = "htp://www.nowhere.nil"
       expect(collection).to receive(:attributes=).with(include(url: "http://htp://www.nowhere.nil"))
+      subject
+    end
+  end
+
+  describe "collection_configuration" do
+    it "calls CreateCollectionConfiguration after a success save" do
+      expect(CreateCollectionConfiguration).to receive(:call)
+      subject
+    end
+
+    it "does not call CreateCollectionConfiguration after a failure" do
+      allow(collection).to receive(:save).and_return(false)
+      expect(CreateCollectionConfiguration).to_not receive(:call)
       subject
     end
   end


### PR DESCRIPTION
Why:  Config needs to be stored in the database.  

What:  Updated to auto generate the configuration when a collection is created and to store it in the database.  

