### PR TITLE
DEC-773: Add metadata drop down doesn't appear

### DIFF
--- a/app/assets/javascripts/components/forms/ItemMetaDataForm.jsx
+++ b/app/assets/javascripts/components/forms/ItemMetaDataForm.jsx
@@ -222,7 +222,10 @@ var ItemMetaDataForm = React.createClass({
           <PanelHeading>{this.state.formValues.name} Meta Data</PanelHeading>
           <PanelBody>
             { this.dynamicFormFields() }
-          
+            <ItemMetaDataSelectAdditionalFields
+              displayedFields={this.state.displayedFields}
+              selectableFields={this.state.formFields}
+              onChangeHandler={this.changeAddField} />
           </PanelBody>
           <PanelFooter>
             <SubmitButton disabled={this.formDisabled()} handleClick={this.handleSave} />

--- a/app/assets/javascripts/components/forms/ItemMetaDataSelectAdditionalFields.jsx
+++ b/app/assets/javascripts/components/forms/ItemMetaDataSelectAdditionalFields.jsx
@@ -51,7 +51,7 @@ var ItemMetaDataSelectAdditionalFields = React.createClass({
       return <p>loading...</p>
     }
     var dropDownIconStyle = {
-      right: this.muiTheme.spacing.desktopGutterLess,
+      //right: this.muiTheme.spacing.desktopGutterLess,
     };
     var underlineStyle = {
       borderTop: "solid 2px rgb(44, 88, 130)",


### PR DESCRIPTION
Why: Drop down box for adding new metadata has disappeared from the item form.
How: Readded the ItemMetadataSelectAdditionalFields to the metadata form. Looks like it may have been removed by accident during the mui update.