### PR TITLE
DEC-662: Update beehive work with site_path

### DIFF
--- a/app/assets/javascripts/components/forms/SitePath.jsx
+++ b/app/assets/javascripts/components/forms/SitePath.jsx
@@ -59,7 +59,7 @@ var SitePath = React.createClass({
     $.get(this.props.sitePathURL, function(result) {
       if (this.isMounted()) {
         this.setState({
-          sitePathObjects: result.site_objects
+          sitePathObjects: result.site_path
         }, this.requestAvailable);
       }
     }.bind(this));
@@ -99,7 +99,7 @@ var SitePath = React.createClass({
       url: this.props.sitePathUpdateURL,
       dataType: "json",
       data: {
-        site_objects: JSON.stringify(json)
+        site_path: JSON.stringify(json)
       },
       method: "PUT",
       success: (function() {

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -124,6 +124,6 @@ class CollectionsController < ApplicationController
       :uploaded_image,
       :about,
       :copyright,
-      :site_objects)
+      :site_path)
   end
 end

--- a/app/controllers/v1/collections_controller.rb
+++ b/app/controllers/v1/collections_controller.rb
@@ -65,23 +65,23 @@ module V1
       end
     end
 
-    def site_objects
+    def site_path
       collection = CollectionQuery.new.any_find(params[:collection_id])
       @collection = CollectionJSONDecorator.new(collection)
-      @site_objects = SiteObjectsQuery.new.all(collection: collection)
+      @site_path = SiteObjectsQuery.new.all(collection: collection)
       cache_key = CacheKeys::Generator.new(key_generator: CacheKeys::Custom::V1Collections,
-                                           action: "site_objects",
-                                           collection: collection, site_objects: @site_objects)
+                                           action: "site_path",
+                                           collection: collection, site_path: @site_path)
       fresh_when(etag: cache_key.generate)
     end
 
-    def site_objects_update
+    def site_path_update
       @collection = CollectionQuery.new.any_find(params[:collection_id])
 
       return if rendered_forbidden?(@collection)
 
-      site_objects = SiteObjectsQuery.new.public_to_private_json(json_string: params[:site_objects])
-      @return_value = SaveCollection.call(@collection, site_objects: site_objects)
+      site_path = SiteObjectsQuery.new.public_to_private_json(json_string: params[:site_path])
+      @return_value = SaveCollection.call(@collection, site_path: site_path)
 
       respond_to do |format|
         format.json { render json: { status: @return_value }.to_json }

--- a/app/decorators/v1/page_json_decorator.rb
+++ b/app/decorators/v1/page_json_decorator.rb
@@ -32,7 +32,9 @@ module V1
     end
 
     def image
-      V1::ImageJSONDecorator.new(object.image).to_hash
+      if object.image
+        V1::ImageJSONDecorator.new(object.image).to_hash
+      end
     end
 
     def display(json)

--- a/app/queries/site_objects_query.rb
+++ b/app/queries/site_objects_query.rb
@@ -1,16 +1,16 @@
 class SiteObjectsQuery
-  # Gets an array of all of the objects referenced by site_objects
+  # Gets an array of all of the objects referenced by site_path
   def all(collection:)
-    site_objects_json(collection_id: collection.id).map do |site_object|
+    site_path_json(collection_id: collection.id).map do |site_object|
       get_object(site_object: site_object)
     end
   end
 
-  # Determines if an object exists in site_objects for its collection
+  # Determines if an object exists in site_path for its collection
   def exists?(collection_object:)
     type = collection_object.class.name
     id = collection_object.id
-    site_objects_json(collection_id: collection_object.collection_id).detect do |site_object|
+    site_path_json(collection_id: collection_object.collection_id).detect do |site_object|
       if site_object[:type] == type && site_object[:id] == id
         return true
       end
@@ -24,8 +24,8 @@ class SiteObjectsQuery
   # will become
   #   [{ type: "Showcase", id: 1 },{ type: "Showcase", id: 2 }]
   def public_to_private_json(json_string:)
-    site_objects = JSON.parse(json_string, symbolize_names: true)
-    site_objects.map do |site_object|
+    site_path = JSON.parse(json_string, symbolize_names: true)
+    site_path.map do |site_object|
       object = get_object_public(site_object: site_object)
       { type: object.class.name, id: object.id }
     end.to_json
@@ -35,7 +35,7 @@ class SiteObjectsQuery
   def next(collection_object:)
     type = collection_object.class.name
     id = collection_object.id
-    site_objects_json(collection_id: collection_object.collection_id).each_cons(2) do |site_object, next_site_object|
+    site_path_json(collection_id: collection_object.collection_id).each_cons(2) do |site_object, next_site_object|
       if site_object[:type] == type && site_object[:id] == id
         return get_object(site_object: next_site_object)
       end
@@ -48,7 +48,7 @@ class SiteObjectsQuery
     previous = nil
     type = collection_object.class.name
     id = collection_object.id
-    site_objects_json(collection_id: collection_object.collection_id).each do |site_object|
+    site_path_json(collection_id: collection_object.collection_id).each do |site_object|
       if site_object[:type] == type && site_object[:id] == id
         return previous.nil? ? nil : get_object(site_object: previous)
       end
@@ -63,12 +63,12 @@ class SiteObjectsQuery
 
   # Returns an array of hashes of the form { :type, :id }
   # Ex: [{type: "showcase", id: 3},{ type: "showcase", id:1 }]
-  def site_objects_json(collection_id:)
+  def site_path_json(collection_id:)
     collection = Collection.find(collection_id)
-    if collection.nil? || collection.site_objects.blank?
+    if collection.nil? || collection.site_path.blank?
       []
     else
-      JSON.parse(collection.site_objects, symbolize_names: true)
+      JSON.parse(collection.site_path, symbolize_names: true)
     end
   end
 

--- a/app/values/cache_keys/custom/v1_collections.rb
+++ b/app/values/cache_keys/custom/v1_collections.rb
@@ -10,8 +10,8 @@ module CacheKeys
         CacheKeys::ActiveRecord.new.generate(record: collection)
       end
 
-      def site_objects(collection:, site_objects:)
-        CacheKeys::ActiveRecord.new.generate(record: [collection, site_objects])
+      def site_path(collection:, site_path:)
+        CacheKeys::ActiveRecord.new.generate(record: [collection, site_path])
       end
     end
   end

--- a/app/views/collections/_site_path_form.html.erb
+++ b/app/views/collections/_site_path_form.html.erb
@@ -1,6 +1,6 @@
 <%= react_component("SitePath", {
-  sitePathURL: v1_collection_site_objects_path(@collection.unique_id),
-  sitePathUpdateURL: v1_collection_site_objects_path(@collection.unique_id),
+  sitePathURL: v1_collection_site_path_path(@collection.unique_id),
+  sitePathUpdateURL: v1_collection_site_path_path(@collection.unique_id),
   showcasesURL: v1_collection_showcases_path(@collection.unique_id),
   pagesURL: v1_collection_pages_path(@collection.unique_id)
 }) %>

--- a/app/views/v1/collections/site_path.json.jbuilder
+++ b/app/views/v1/collections/site_path.json.jbuilder
@@ -1,6 +1,6 @@
 @collection.display(json)
-json.set! :site_objects do
-  json.array! @site_objects do |site_object|
+json.set! :site_path do
+  json.array! @site_path do |site_object|
     V1::SiteObjectsJSONDecorator.display(site_object, json)
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,8 +76,8 @@ Rails.application.routes.draw do
       put :unpublish, defaults: { format: :json }
       put :preview_mode, defaults: { format: :json }
       get :metadata_configuration, defaults: { format: :json }
-      get :site_objects, defaults: { format: :json }
-      put :site_objects, to: "collections#site_objects_update", defaults: { format: :json }
+      get :site_path, defaults: { format: :json }
+      put :site_path, to: "collections#site_path_update", defaults: { format: :json }
       resources :search, only: [:index], defaults: { format: :json }
       resources :items, only: [:index, :create], defaults: { format: :json }
       resources :showcases, only: [:index], defaults: { format: :json }

--- a/db/dec_scraper.py
+++ b/db/dec_scraper.py
@@ -35,7 +35,7 @@ def main():
         collection = get_json_file(collection["@id"])
         items = get_json_file(collection["hasPart/items"])
         showcases = get_json_file(collection["hasPart/showcases"])
-        site_objects = get_json_file(collection["@id"] + "/site_objects")
+        site_path = get_json_file(collection["@id"] + "/site_path")
         for item in items["items"]:
             item = get_json_file(item["@id"])
             # for each child in item["children"]

--- a/db/migrate/20160208151649_rename_site_objects_to_site_path.rb
+++ b/db/migrate/20160208151649_rename_site_objects_to_site_path.rb
@@ -1,0 +1,5 @@
+class RenameSiteObjectsToSitePath < ActiveRecord::Migration
+  def change
+    rename_column :collections, :site_objects, :site_path
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160202150100) do
+ActiveRecord::Schema.define(version: 20160208151649) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -60,7 +60,7 @@ ActiveRecord::Schema.define(version: 20160202150100) do
     t.datetime "uploaded_image_updated_at"
     t.boolean  "enable_search"
     t.boolean  "hide_title_on_home_page"
-    t.text     "site_objects"
+    t.text     "site_path"
   end
 
   add_index "collections", ["preview_mode"], name: "index_collections_on_preview_mode", using: :btree

--- a/spec/controllers/v1/collections_controller_spec.rb
+++ b/spec/controllers/v1/collections_controller_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 require "cache_spec_helper"
 
 RSpec.describe V1::CollectionsController, type: :controller do
-  let(:collection) { instance_double(Collection, id: 1, published: false, site_objects: "[]") }
+  let(:collection) { instance_double(Collection, id: 1, published: false, site_path: "[]") }
   let(:collections) { [collection] }
 
   before(:each) do
@@ -151,8 +151,8 @@ RSpec.describe V1::CollectionsController, type: :controller do
     end
   end
 
-  describe "#site_objects" do
-    subject { get :site_objects, collection_id: collection.id, format: :json }
+  describe "#site_path" do
+    subject { get :site_path, collection_id: collection.id, format: :json }
 
     before(:each) do
       allow(Collection).to receive(:find).and_return(collection)
@@ -171,61 +171,34 @@ RSpec.describe V1::CollectionsController, type: :controller do
     it "assigns collection" do
       subject
       expect(assigns(:collection)).to be_present
-      expect(subject).to render_template("v1/collections/site_objects")
+      expect(subject).to render_template("v1/collections/site_path")
     end
 
     it "renders the correct template" do
       subject
-      expect(subject).to render_template("v1/collections/site_objects")
+      expect(subject).to render_template("v1/collections/site_path")
     end
 
     it_behaves_like "a private basic custom etag cacher"
 
-    it "uses the V1Collections#site_objects to generate the cache key" do
-      expect_any_instance_of(CacheKeys::Custom::V1Collections).to receive(:site_objects)
+    it "uses the V1Collections#site_path to generate the cache key" do
+      expect_any_instance_of(CacheKeys::Custom::V1Collections).to receive(:site_path)
       subject
     end
   end
 
-  describe "metadata_configuration" do
-    let(:collection) { Collection.new(id: 1) }
-    let(:collection_configuration) { double(CollectionConfiguration) }
-    subject { get :metadata_configuration, collection_id: 1, format: :json }
-
-    before(:each) do
-      allow_any_instance_of(CollectionQuery).to receive(:any_find).and_return(collection)
-      allow_any_instance_of(CollectionConfigurationQuery).to receive(:find).and_return(collection_configuration)
-      allow_any_instance_of(V1::MetadataConfigurationJSON).to receive(:to_json).and_return("JSON")
-    end
-
-    it "calls to json on the V1::MetadataConfigurationJSON" do
-      expect_any_instance_of(V1::MetadataConfigurationJSON).to receive(:to_json)
-      subject
-    end
-
-    it "queries for the collection" do
-      expect_any_instance_of(CollectionQuery).to receive(:any_find).and_return(collection)
-      subject
-    end
-
-    it "queries for the configuration" do
-      expect_any_instance_of(CollectionConfigurationQuery).to receive(:find).and_return(collection_configuration)
-      subject
-    end
-  end
-
-  describe "#site_objects_update" do
-    let(:collection) { instance_double(Collection, id: 1, site_objects: nil) }
-    let(:site_objects) { "site_objects" }
-    let(:site_objects_translated) { "site_objects_translated" }
-    let(:subject) { put :site_objects_update, collection_id: collection.id, site_objects: site_objects, format: :json }
+  describe "#site_path_update" do
+    let(:collection) { instance_double(Collection, id: 1, site_path: nil) }
+    let(:site_path) { "site_path" }
+    let(:site_path_translated) { "site_path_translated" }
+    let(:subject) { put :site_path_update, collection_id: collection.id, site_path: site_path, format: :json }
 
     before(:each) do
       sign_in_admin
       allow_any_instance_of(CollectionQuery).to receive(:any_find).and_return(collection)
       allow(Collection).to receive(:find).and_return(collection)
       allow(SaveCollection).to receive(:call).and_return(true)
-      allow_any_instance_of(SiteObjectsQuery).to receive(:public_to_private_json).and_return(site_objects_translated)
+      allow_any_instance_of(SiteObjectsQuery).to receive(:public_to_private_json).and_return(site_path_translated)
     end
 
     it "calls SiteObjectsQuery" do
@@ -233,8 +206,13 @@ RSpec.describe V1::CollectionsController, type: :controller do
       subject
     end
 
-    it "sets the site_objects for collection using the string translated by SiteObjectsQuery" do
-      expect(SaveCollection).to receive(:call).with(collection, site_objects: site_objects_translated).and_return(true)
+    it "sets the site_path for collection using the string translated by SiteObjectsQuery" do
+      expect(SaveCollection).to receive(:call).with(collection, site_path: site_path_translated).and_return(true)
+      subject
+    end
+
+    it "checks the editor permissions" do
+      expect_any_instance_of(described_class).to receive(:user_can_edit?).with(collection)
       subject
     end
   end

--- a/spec/decorators/v1/page_json_decorator_spec.rb
+++ b/spec/decorators/v1/page_json_decorator_spec.rb
@@ -104,8 +104,14 @@ RSpec.describe V1::PageJSONDecorator do
 
   describe "#image" do
     it "calls v1 image json decorator" do
+      allow(page).to receive(:image).and_return("image")
       expect(V1::ImageJSONDecorator).to receive(:new).and_return({})
       subject.image
+    end
+
+    it "returns nil if there is no image" do
+      allow(page).to receive(:image).and_return(nil)
+      expect(subject.image).to eq(nil)
     end
   end
 

--- a/spec/decorators/v1/showcase_json_decorator_spec.rb
+++ b/spec/decorators/v1/showcase_json_decorator_spec.rb
@@ -77,6 +77,11 @@ RSpec.describe V1::ShowcaseJSONDecorator do
       expect(showcase).to receive(:honeypot_image).and_return(honeypot_image)
       subject.image
     end
+
+    it "returns nil if there is no image" do
+      allow(showcase).to receive(:honeypot_image).and_return(nil)
+      expect(subject.image).to eq(nil)
+    end
   end
 
   describe "#sections" do

--- a/spec/queries/page_query_spec.rb
+++ b/spec/queries/page_query_spec.rb
@@ -54,12 +54,12 @@ describe PageQuery do
     end
   end
 
-  it "can be deleted if not included in a collection's site_objects" do
+  it "can be deleted if not included in a collection's site_path" do
     expect_any_instance_of(SiteObjectsQuery).to receive(:exists?).with(collection_object: relation).and_return(false)
     expect(subject.can_delete?).to eq(true)
   end
 
-  it "cannot be deleted if included in a collection's site_objects" do
+  it "cannot be deleted if included in a collection's site_path" do
     expect_any_instance_of(SiteObjectsQuery).to receive(:exists?).with(collection_object: relation).and_return(true)
     expect(subject.can_delete?).to eq(false)
   end

--- a/spec/queries/showcase_query_spec.rb
+++ b/spec/queries/showcase_query_spec.rb
@@ -61,12 +61,12 @@ describe ShowcaseQuery do
     end
   end
 
-  it "can be deleted if not included in a collection's site_objects" do
+  it "can be deleted if not included in a collection's site_path" do
     expect_any_instance_of(SiteObjectsQuery).to receive(:exists?).with(collection_object: relation).and_return(false)
     expect(subject.can_delete?).to eq(true)
   end
 
-  it "cannot be deleted if included in a collection's site_objects" do
+  it "cannot be deleted if included in a collection's site_path" do
     expect_any_instance_of(SiteObjectsQuery).to receive(:exists?).with(collection_object: relation).and_return(true)
     expect(subject.can_delete?).to eq(false)
   end

--- a/spec/queries/site_objects_query_spec.rb
+++ b/spec/queries/site_objects_query_spec.rb
@@ -23,9 +23,9 @@ describe SiteObjectsQuery do
       instance_double(User, id: 2, unique_id: "two", class: double(Object, name: "User"))
     ]
   end
-  let(:site_objects_string) { '[{ "type": "Showcase", "id": 0 }, { "type": "Page", "id": 2 }, { "type": "Showcase", "id": 2 }]' }
-  let(:site_objects) { [showcases[0], pages[2], showcases[2]] }
-  let(:collection) { instance_double(Collection, id: 1, site_objects: site_objects_string) }
+  let(:site_path_string) { '[{ "type": "Showcase", "id": 0 }, { "type": "Page", "id": 2 }, { "type": "Showcase", "id": 2 }]' }
+  let(:site_path) { [showcases[0], pages[2], showcases[2]] }
+  let(:collection) { instance_double(Collection, id: 1, site_path: site_path_string) }
 
   before(:each) do
     allow(Collection).to receive(:find).and_return(collection)
@@ -41,28 +41,28 @@ describe SiteObjectsQuery do
   end
 
   it "returns all site objects as a json" do
-    expect(subject.all(collection: collection)).to eq(site_objects)
+    expect(subject.all(collection: collection)).to eq(site_path)
   end
 
-  it "returns empty array if site_objects is nil" do
-    allow(collection).to receive(:site_objects).and_return(nil)
+  it "returns empty array if site_path is nil" do
+    allow(collection).to receive(:site_path).and_return(nil)
     expect(subject.all(collection: collection)).to eq([])
   end
 
-  it "returns empty array if site_objects is empty string" do
-    allow(collection).to receive(:site_objects).and_return("")
+  it "returns empty array if site_path is empty string" do
+    allow(collection).to receive(:site_path).and_return("")
     expect(subject.all(collection: collection)).to eq([])
   end
 
   # The json string will be formed by code, not by a user, so if something goes
   # wrong, we should know about it
-  it "throws an exception if the site_objects json is malformed" do
-    allow(collection).to receive(:site_objects).and_return("[")
+  it "throws an exception if the site_path json is malformed" do
+    allow(collection).to receive(:site_path).and_return("[")
     expect { subject.all(collection: collection) }.to raise_error
   end
 
   context "when asking if an object exists in the array" do
-    it "returns false if the object given is not in the site_objects array" do
+    it "returns false if the object given is not in the site_path array" do
       expect(subject.exists?(collection_object: showcases[1])).to eq(false)
     end
 
@@ -70,13 +70,13 @@ describe SiteObjectsQuery do
       expect(subject.exists?(collection_object: pages[2])).to eq(true)
     end
 
-    it "returns true if the object given is in the site_objects array" do
+    it "returns true if the object given is in the site_path array" do
       expect(subject.exists?(collection_object: showcases[0])).to eq(true)
     end
   end
 
   context "when finding previous" do
-    it "returns nil if the object given is not in the site_objects array" do
+    it "returns nil if the object given is not in the site_path array" do
       expect(subject.previous(collection_object: showcases[1])).to eq(nil)
     end
 
@@ -93,7 +93,7 @@ describe SiteObjectsQuery do
   end
 
   context "when finding next" do
-    it "returns nil if the object given is not in the site_objects array" do
+    it "returns nil if the object given is not in the site_path array" do
       expect(subject.next(collection_object: showcases[1])).to eq(nil)
     end
 
@@ -110,8 +110,8 @@ describe SiteObjectsQuery do
   end
 
   context "invalid object types" do
-    let(:site_objects_string) { '[{ "type": "Showcase", "id": 0 }, { "type": "User", "id": 2 }, { "type": "Showcase", "id": 2 }]' }
-    let(:site_objects) { [showcases[0], users[2], showcases[2]] }
+    let(:site_path_string) { '[{ "type": "Showcase", "id": 0 }, { "type": "User", "id": 2 }, { "type": "Showcase", "id": 2 }]' }
+    let(:site_path) { [showcases[0], users[2], showcases[2]] }
 
     it "raises an exception" do
       expect { subject.all(collection: collection) }.to raise_error
@@ -119,7 +119,7 @@ describe SiteObjectsQuery do
   end
 
   describe "public_to_private_json" do
-    let(:public_site_objects_string) do
+    let(:public_site_path_string) do
       '[{ "type": "Showcase", "unique_id": "zero" },
         { "type": "Page", "unique_id": "two" },
         { "type": "Showcase", "unique_id": "two" }]'
@@ -139,7 +139,7 @@ describe SiteObjectsQuery do
     end
 
     it "converts to the same json string using correct ids" do
-      expect(JSON.parse(subject.public_to_private_json(json_string: public_site_objects_string))).to eq(JSON.parse(site_objects_string))
+      expect(JSON.parse(subject.public_to_private_json(json_string: public_site_path_string))).to eq(JSON.parse(site_path_string))
     end
   end
 end

--- a/spec/values/cache_keys/custom/v1_collections_spec.rb
+++ b/spec/values/cache_keys/custom/v1_collections_spec.rb
@@ -29,17 +29,17 @@ RSpec.describe CacheKeys::Custom::V1Collections do
     end
   end
 
-  context "site_objects" do
+  context "site_path" do
     let(:collection) { instance_double(Collection) }
 
     it "uses CacheKeys::ActiveRecord" do
       expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate)
-      subject.site_objects(collection: collection, site_objects: ["one", "two"])
+      subject.site_path(collection: collection, site_path: ["one", "two"])
     end
 
     it "uses the correct data" do
       expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with(record: [collection, ["one", "two"]])
-      subject.site_objects(collection: collection, site_objects: ["one", "two"])
+      subject.site_path(collection: collection, site_path: ["one", "two"])
     end
   end
 end


### PR DESCRIPTION
Why: Before I can work on beehive, we need to change site_objects to site_path in honeycomb.
How: Migrated site_objects to site_path and updated all references to site_path.

Renamed branch from https://github.com/ndlib/honeycomb/pull/319