### PR TITLE
Dec 766 allow metaconfig to be created

### DIFF
--- a/app/assets/javascripts/actions/MetaDataConfigurationActions.js
+++ b/app/assets/javascripts/actions/MetaDataConfigurationActions.js
@@ -6,7 +6,7 @@ var APIResponseMixin = require("../mixins/APIResponseMixin");
 var update = require("react-addons-update");
 
 class MetaDataConfigurationActions extends NodeEventEmitter {
-  changeField(fieldName, fieldValues, pushToUrl) {
+  changeField(fieldName, fieldValues, pushToUrl, update) {
     // Clone values in order to revert the store if the change fails
     const previousValues = update(MetaDataConfigurationStore.fields[fieldName], {});
     // Optimistically change the store

--- a/app/assets/javascripts/actions/MetaDataConfigurationActions.js
+++ b/app/assets/javascripts/actions/MetaDataConfigurationActions.js
@@ -6,7 +6,7 @@ var APIResponseMixin = require("../mixins/APIResponseMixin");
 var update = require("react-addons-update");
 
 class MetaDataConfigurationActions extends NodeEventEmitter {
-  changeField(fieldName, fieldValues, pushToUrl, update) {
+  changeField(fieldName, fieldValues, pushToUrl, create) {
     // Clone values in order to revert the store if the change fails
     const previousValues = update(MetaDataConfigurationStore.fields[fieldName], {});
     // Optimistically change the store
@@ -16,11 +16,14 @@ class MetaDataConfigurationActions extends NodeEventEmitter {
       values: fieldValues,
     });
 
-    pushToUrl += "/" + fieldName;
+    if (!create) {
+      pushToUrl += "/" + fieldName;
+    }
+
     $.ajax({
       url: pushToUrl,
       dataType: "json",
-      method: "PUT",
+      method: (create) ? "POST" : "PUT",
       data: {
         fields: fieldValues,
       },
@@ -30,12 +33,14 @@ class MetaDataConfigurationActions extends NodeEventEmitter {
         AppEventEmitter.emit("MessageCenterDisplay", "info", "Collection updated");
       }).bind(this),
       error: (function(xhr) {
-        // Request to change failed, revert the store to previous values
-        AppDispatcher.dispatch({
-          actionType: MetaDataConfigurationActionTypes.MDC_CHANGE_FIELD,
-          name: fieldName,
-          values: previousValues,
-        });
+        if (!create) {
+          // Request to change failed, revert the store to previous values on if it is updated
+          AppDispatcher.dispatch({
+            actionType: MetaDataConfigurationActionTypes.MDC_CHANGE_FIELD,
+            name: fieldName,
+            values: previousValues,
+          });
+        }
         // Communicate the error to the user
         this.emit("ChangeFieldFinished", false, xhr);
         AppEventEmitter.emit("MessageCenterDisplay", "error", APIResponseMixin.apiErrorToString(xhr));

--- a/app/assets/javascripts/components/forms/DateField.jsx
+++ b/app/assets/javascripts/components/forms/DateField.jsx
@@ -37,17 +37,18 @@ var DateField = React.createClass({
     if (!this.props.value) {
       return;
     }
-    if (this.props.value.length) {
-      this.props.value = this.props.value[0];
+    var value = this.props.value;
+    if (value.length) {
+      value = value[0];
     }
 
     this.setState({
-      year: this.props.value.year,
-      month: this.props.value.month,
-      day: this.props.value.day,
-      bc: this.props.value.bc,
-      displayText: this.props.value.display_text,
-      chooseDisplayText: (this.props.value.display_text ? true : false)
+      year: value.year,
+      month: value.month,
+      day: value.day,
+      bc: value.bc,
+      displayText: value.display_text,
+      chooseDisplayText: (value.display_text ? true : false)
     });
   },
 

--- a/app/assets/javascripts/components/forms/ItemMetaDataForm.jsx
+++ b/app/assets/javascripts/components/forms/ItemMetaDataForm.jsx
@@ -111,7 +111,9 @@ var ItemMetaDataForm = React.createClass({
       utf8: "✓",
       _method: this.props.method,
       authenticity_token: this.props.authenticityToken,
-      item: this.state.formValues,
+      item: {
+        metadata: this.state.formValues,
+      }
     });
   },
 

--- a/app/assets/javascripts/components/forms/MetaDataFieldDialog.jsx
+++ b/app/assets/javascripts/components/forms/MetaDataFieldDialog.jsx
@@ -14,12 +14,8 @@ var MetaDataFieldDialog = React.createClass({
 
   propTypes: {
     open: React.PropTypes.bool.isRequired,
-<<<<<<< HEAD
-    updateUrl: React.PropTypes.string.isRequired,
     createForm: React.PropTypes.bool,
-=======
     baseUpdateUrl: React.PropTypes.string.isRequired,
->>>>>>> DEC-766-allow-metaconfig-to-be-updated
     fieldName: React.PropTypes.string,
   },
 
@@ -94,13 +90,13 @@ var MetaDataFieldDialog = React.createClass({
   },
 
   handleSave: function() {
-    MetaDataConfigurationActions.changeField(this.state.fieldName, this.state.fieldValues, this.props.baseUpdateUrl);
+    MetaDataConfigurationActions.changeField(this.state.fieldName, this.state.fieldValues, this.props.baseUpdateUrl, this.state.createForm);
     this.setState({ saving: true});
   },
 
   handleSaved: function(success, data) {
     if(success) {
-      this.setState({ open: false });
+      this.setState({ open: false, fieldName: null });
     } else {
       console.log("Add error handling stuff here when !success", data);
     }
@@ -153,6 +149,10 @@ var MetaDataFieldDialog = React.createClass({
     return (<mui.Checkbox style={{ width: "100%" }} disabled={disabled} label="Always show on the item form?" checkedLink={ this.linkFieldState('defaultFormField') } />);
   },
 
+  title: function() {
+    return this.state.createForm ? "New Metadata Field" : "Edit Metadata Field";
+  },
+
   render: function() {
     const actions = [
       <FlatButton
@@ -174,7 +174,7 @@ var MetaDataFieldDialog = React.createClass({
       <div>
         <Dialog
           ref="EditMetaDialog"
-          title="Edit Metadata Field"
+          title={this.title()}
           actions={actions}
           modal={true}
           bodyStyle={{ margin: "0 auto 0 auto" }}

--- a/app/assets/javascripts/components/forms/MetadataConfigurationForm.jsx
+++ b/app/assets/javascripts/components/forms/MetadataConfigurationForm.jsx
@@ -63,7 +63,7 @@ var MetaDataConfigurationForm = React.createClass({
   },
 
   handleNewClick: function() {
-    this.setState({ selectedField: "NEWFIELD"});
+    this.setState({ selectedField: Math.random().toString(36).substring(2)});
   },
 
   render: function(){

--- a/app/assets/javascripts/components/forms/MetadataConfigurationForm.jsx
+++ b/app/assets/javascripts/components/forms/MetadataConfigurationForm.jsx
@@ -62,10 +62,15 @@ var MetaDataConfigurationForm = React.createClass({
     this.setState({ selectedField: field });
   },
 
+  handleNewClick: function() {
+    this.setState({ selectedField: "NEWFIELD"});
+  },
+
   render: function(){
     const { selectedField } = this.state;
     return (
       <div>
+        <mui.RaisedButton label="New Metadata Field" onClick={ this.handleNewClick } />
         <MetaDataFieldDialog fieldName={ selectedField } open={ selectedField != undefined } updateUrl={ this.props.updateUrl }/>
         <mui.Table>
           <mui.TableHeader displaySelectAll={ false } >

--- a/app/assets/javascripts/stores/MetaDataConfigurationStore.js
+++ b/app/assets/javascripts/stores/MetaDataConfigurationStore.js
@@ -24,6 +24,10 @@ class MetaDataConfigurationStore extends EventEmitter {
   }
 
   changeField(name, values) {
+    // ensure the values
+    if (!values["order"]) {
+      values["order"] = this.fields.length + 1;
+    }
     this._data.fields[name] = values;
     this.emit("MetaDataConfigurationStoreChanged");
   }

--- a/app/assets/javascripts/stores/MetaDataConfigurationStore.js
+++ b/app/assets/javascripts/stores/MetaDataConfigurationStore.js
@@ -25,8 +25,8 @@ class MetaDataConfigurationStore extends EventEmitter {
 
   changeField(name, values) {
     // ensure the values
-    if (!values["order"]) {
-      values["order"] = this.fields.length + 1;
+    if (!values.order) {
+      values.order = this.fields.length + 1;
     }
     this._data.fields[name] = values;
     this.emit("MetaDataConfigurationStoreChanged");

--- a/app/controllers/v1/items_controller.rb
+++ b/app/controllers/v1/items_controller.rb
@@ -59,27 +59,7 @@ module V1
     protected
 
     def save_params
-      params.require(:item).permit(
-        :user_defined_id,
-        :name,
-        :description,
-        :image,
-        :manuscript_url,
-        :transcription,
-        :rights,
-        :uploaded_image,
-        [:creator, creator: []], # both :creator, and creator: [] are required bc it can pass null or an array.
-        [:publisher, publisher: []], # both :publisher, and publisher: [] are required bc it can pass null or an array.
-        [:alternate_name, alternate_name: []], # both :alternate_name, and alternate_name: [] are required bc it can pass null or an array.
-        [:contributor, contributor: []], # both :contributor, and contributor: [] are required bc it can pass null or an array.
-        [:original_language, original_language: []],
-        [:subject, subject: []],
-        [:call_number, call_number: []],
-        [:provenance, provenance: []],
-        [:date_created, [:value, :year, :month, :day, :bc, :display_text]],
-        [:date_modified, [:value, :year, :month, :day, :bc, :display_text]],
-        [:date_published, [:value, :year, :month, :day, :bc, :display_text]],
-      )
+      params[:item].to_hash
     end
   end
 end

--- a/app/controllers/v1/metadata_fields_controller.rb
+++ b/app/controllers/v1/metadata_fields_controller.rb
@@ -5,7 +5,27 @@ module V1
 
       return if rendered_forbidden?(@collection)
 
-      @return_value = Metadata::UpdateConfigurationField.call(@collection, params[:id], params[:fields])
+      if Metadata::UpdateConfigurationField.call(@collection, params[:id], params[:fields])
+        @return_value = :success
+      else
+        @return_value = :unprocessable_entity
+      end
+
+      respond_to do |format|
+        format.json { render json: { status: @return_value }.to_json }
+      end
+    end
+
+    def create
+      @collection = CollectionQuery.new.any_find(params[:collection_id])
+
+      return if rendered_forbidden?(@collection)
+
+      if Metadata::CreateConfigurationField.call(@collection, params[:fields])
+        @return_value = :success
+      else
+        @return_value = :unprocessable_entity
+      end
 
       respond_to do |format|
         format.json { render json: { status: @return_value }.to_json }

--- a/app/controllers/v1/metadata_fields_controller.rb
+++ b/app/controllers/v1/metadata_fields_controller.rb
@@ -5,9 +5,8 @@ module V1
 
       return if rendered_forbidden?(@collection)
 
-      if Metadata::UpdateConfigurationField.call(@collection, params[:id], params[:fields])
-        @return_value = :success
-      else
+      @return_value = :success
+      if !Metadata::UpdateConfigurationField.call(@collection, params[:id], params[:fields])
         @return_value = :unprocessable_entity
       end
 
@@ -21,9 +20,8 @@ module V1
 
       return if rendered_forbidden?(@collection)
 
-      if Metadata::CreateConfigurationField.call(@collection, params[:fields])
-        @return_value = :success
-      else
+      @return_value = :success
+      if !Metadata::CreateConfigurationField.call(@collection, params[:fields])
         @return_value = :unprocessable_entity
       end
 

--- a/app/models/metadata/configuration.rb
+++ b/app/models/metadata/configuration.rb
@@ -14,6 +14,7 @@ module Metadata
     def save_field(name, values)
       f = field(name)
       if !f
+        fields
         f = new_field(values)
         @fields << f
       else

--- a/app/models/metadata/configuration.rb
+++ b/app/models/metadata/configuration.rb
@@ -13,11 +13,16 @@ module Metadata
 
     def save_field(name, values)
       f = field(name)
-      return false if !f
-
-      if !f.update(values)
-        return false
+      if !f
+        f = new_field(values)
+        @fields << f
+      else
+        f.update(values)
       end
+
+      return false if !f.valid?
+
+      # process_reorder!
 
       data.metadata = fields.map(&:to_hash)
       data.save
@@ -96,7 +101,7 @@ module Metadata
     def build_fields
       data.metadata.map do |field_data|
         field_data = field_data.symbolize_keys
-        self.class::Field.new(**field_data)
+        new_field(field_data)
       end
     end
 
@@ -148,6 +153,10 @@ module Metadata
           hash[sort.name.to_sym] = sort
         end
       end.with_indifferent_access
+    end
+
+    def new_field(field_data)
+      self.class::Field.new(**field_data)
     end
   end
 end

--- a/app/models/metadata/configuration/field.rb
+++ b/app/models/metadata/configuration/field.rb
@@ -22,9 +22,6 @@ module Metadata
         multiple: false,
         required: false
       )
-        unless TYPES.include?(type.to_sym)
-          raise ArgumentError, "Invalid type: #{type}.  Must be one of #{TYPES.join(', ')}"
-        end
         @name = name.to_sym
         @type = type.to_sym
         @label = label
@@ -36,6 +33,10 @@ module Metadata
         @placeholder = placeholder
         @help = help
         @boost = boost
+
+        if !valid?
+          raise ArgumentError, errors.full_messages.join(", ")
+        end
       end
 
       def as_json(options = {})

--- a/app/models/waggle.rb
+++ b/app/models/waggle.rb
@@ -24,7 +24,7 @@ module Waggle
   end
 
   def self.search(**args)
-    set_configuration(::Metadata::Configuration.new(CollectionConfigurationQuery.new(args[:collection]).find))
+    set_configuration(CollectionConfigurationQuery.new(args[:collection]).find)
     args.delete(:collection)
     Waggle::Search::Query.new(**args).result
   end

--- a/app/services/create_collection_configuration.rb
+++ b/app/services/create_collection_configuration.rb
@@ -2,7 +2,7 @@ class CreateCollectionConfiguration
   attr_reader :collection
 
   def self.call(collection)
-    new(collection).create(force)
+    new(collection).create
   end
 
   def initialize(collection)

--- a/app/services/create_collection_configuration.rb
+++ b/app/services/create_collection_configuration.rb
@@ -2,7 +2,7 @@ class CreateCollectionConfiguration
   attr_reader :collection
 
   def self.call(collection)
-    new(collection).create
+    new(collection).create(force)
   end
 
   def initialize(collection)

--- a/app/services/metadata/configuration_input_cleaner.rb
+++ b/app/services/metadata/configuration_input_cleaner.rb
@@ -1,0 +1,58 @@
+module Metadata
+  class ConfigurationInputCleaner
+    attr_reader :data
+
+    def self.call(data)
+      new(data).clean!
+    end
+
+    def initialize(data)
+      @data = data
+    end
+
+    def clean!
+      ensure_symbols
+      ensure_json_fields_are_converted
+      ensure_name_from_label
+      ensure_boolean_values
+
+      data
+    end
+
+    private
+
+    def ensure_boolean_values
+      [:required, :default_form_field, :optional_form_field].each do |key|
+        data[key] = convert_value_to_bool(data[key]) if data.has_key?(key)
+      end
+    end
+
+    def convert_value_to_bool(value)
+      case value
+      when "true"
+        true
+      when "false"
+        false
+      when ""
+        false
+      else
+        value
+      end
+    end
+
+    def ensure_name_from_label
+      if data[:label]
+        data[:name] = data[:label].gsub(/\s/, "_").downcase
+      end
+    end
+
+    def ensure_symbols
+      @data = data.to_hash.symbolize_keys
+    end
+
+    def ensure_json_fields_are_converted
+      data[:default_form_field] = data.delete(:defaultFormField) if data[:defaultFormField]
+      data[:optional_form_field] = data.delete(:optionalFormField) if data[:optionalFormField]
+    end
+  end
+end

--- a/app/services/metadata/create_configuration_field.rb
+++ b/app/services/metadata/create_configuration_field.rb
@@ -1,0 +1,35 @@
+module Metadata
+  class CreateConfigurationField
+    attr_reader :collection
+
+    def self.call(collection, new_data)
+      new(collection).create_field(new_data)
+    end
+
+    def initialize(collection)
+      @collection = collection
+    end
+
+    def create_field(new_data)
+      new_data = set_preset_values(new_data)
+      configuration.save_field(new_data[:name], new_data)
+    end
+
+    private
+
+    def configuration
+      @configuration ||= CollectionConfigurationQuery.new(collection).find
+    end
+
+    def set_preset_values(new_data)
+      new_data = new_data.to_hash.symbolize_keys
+
+      new_data[:name] = new_data[:label].underscore.downcase
+      new_data[:default_form_field] = new_data.delete(:defaultFormField) || "false"
+      new_data[:optional_form_field] = new_data.delete(:optionalFormField) || "true"
+      new_data[:order] = configuration.fields.size + 1
+
+      new_data
+    end
+  end
+end

--- a/app/services/metadata/create_configuration_field.rb
+++ b/app/services/metadata/create_configuration_field.rb
@@ -11,7 +11,7 @@ module Metadata
     end
 
     def create_field(new_data)
-      new_data = set_preset_values(new_data)
+      new_data = ConfigurationInputCleaner.call(new_data)
       configuration.save_field(new_data[:name], new_data)
     end
 
@@ -19,17 +19,6 @@ module Metadata
 
     def configuration
       @configuration ||= CollectionConfigurationQuery.new(collection).find
-    end
-
-    def set_preset_values(new_data)
-      new_data = new_data.to_hash.symbolize_keys
-
-      new_data[:name] = new_data[:label].gsub(/\s/, "_").downcase
-      new_data[:default_form_field] = new_data.delete(:defaultFormField) || "false"
-      new_data[:optional_form_field] = new_data.delete(:optionalFormField) || "true"
-      new_data[:order] = configuration.fields.size + 1
-
-      new_data
     end
   end
 end

--- a/app/services/metadata/create_configuration_field.rb
+++ b/app/services/metadata/create_configuration_field.rb
@@ -24,7 +24,7 @@ module Metadata
     def set_preset_values(new_data)
       new_data = new_data.to_hash.symbolize_keys
 
-      new_data[:name] = new_data[:label].underscore.downcase
+      new_data[:name] = new_data[:label].gsub(/\s/, "_").downcase
       new_data[:default_form_field] = new_data.delete(:defaultFormField) || "false"
       new_data[:optional_form_field] = new_data.delete(:optionalFormField) || "true"
       new_data[:order] = configuration.fields.size + 1

--- a/app/services/metadata/update_configuration_field.rb
+++ b/app/services/metadata/update_configuration_field.rb
@@ -11,6 +11,7 @@ module Metadata
     end
 
     def update_field(field, new_data)
+      new_data = ConfigurationInputCleaner.call(new_data)
       configuration.save_field(field, new_data)
     end
 

--- a/app/services/metadata_input_cleaner.rb
+++ b/app/services/metadata_input_cleaner.rb
@@ -12,7 +12,11 @@ class MetadataInputCleaner
   def clean!
     item.metadata.each do |key, value|
       if !value.is_a?(Array)
-        item.metadata[key] = [value]
+        if value["0"]
+          item.metadata[key] = value["0"]
+        else
+          item.metadata[key] = [value]
+        end
       end
     end
   end

--- a/app/services/metadata_input_cleaner.rb
+++ b/app/services/metadata_input_cleaner.rb
@@ -12,11 +12,7 @@ class MetadataInputCleaner
   def clean!
     item.metadata.each do |key, value|
       if !value.is_a?(Array)
-        if value["0"]
-          item.metadata[key] = value["0"]
-        else
-          item.metadata[key] = [value]
-        end
+        item.metadata[key] = value["0"] ? value["0"] : [value]
       end
     end
   end

--- a/spec/controllers/v1/items_controller_spec.rb
+++ b/spec/controllers/v1/items_controller_spec.rb
@@ -117,36 +117,6 @@ RSpec.describe V1::ItemsController, type: :controller do
       expect(assigns(:item)).to eq(item)
     end
 
-    it "accepts an array for all base metadata that allows multiples" do
-      base_config[:fields].each do |field|
-        if field[:multiple]
-          update_params[:item][field[:name]] = []
-        end
-      end
-      expect(SaveItem).to receive(:call).with(item, update_params[:item])
-      subject
-    end
-
-    it "accepts a single value for all metadata that allows multiples" do
-      base_config[:fields].each do |field|
-        if field[:multiple]
-          update_params[:item][field[:name]] = field[:label]
-        end
-      end
-      expect(SaveItem).to receive(:call).with(item, update_params[:item])
-      subject
-    end
-
-    it "accepts nil for all metadata that allows multiples" do
-      base_config[:fields].each do |field|
-        if field[:multiple]
-          update_params[:item][field[:name]] = nil
-        end
-      end
-      expect(SaveItem).to receive(:call).with(item, update_params[:item])
-      subject
-    end
-
     it "uses the save item service" do
       expect(SaveItem).to receive(:call).and_return(true)
 

--- a/spec/controllers/v1/metadata_fields_controller_spec.rb
+++ b/spec/controllers/v1/metadata_fields_controller_spec.rb
@@ -4,17 +4,19 @@ require "cache_spec_helper"
 RSpec.describe V1::MetadataFieldsController, type: :controller do
   let(:collection) { instance_double(Collection, id: 1) }
   let(:configuration) { double(Metadata::Configuration) }
-  let(:update_params) { { label: "label" } }
 
   before(:each) do
     allow_any_instance_of(CollectionQuery).to receive(:any_find).and_return(collection)
-    allow(Metadata::UpdateConfigurationField).to receive(:call).and_return(true)
     @user = sign_in_admin
   end
 
   describe "update" do
-    let(:params) { { name: "name" } }
-    subject { put :update, collection_id: 1, id: "id", fields: update_params, format: :json }
+    let(:params) { { label: "name" } }
+    subject { put :update, collection_id: 1, id: "id", fields: params, format: :json }
+
+    before(:each) do
+      allow(Metadata::UpdateConfigurationField).to receive(:call).and_return(true)
+    end
 
     it "queries for the collection" do
       expect_any_instance_of(CollectionQuery).to receive(:any_find).and_return(collection)
@@ -22,7 +24,31 @@ RSpec.describe V1::MetadataFieldsController, type: :controller do
     end
 
     it "uses the Metadata::UpdateConfigurationField to update the data" do
-      expect(Metadata::UpdateConfigurationField).to receive(:call).with(collection, "id", update_params)
+      expect(Metadata::UpdateConfigurationField).to receive(:call).with(collection, "id", params)
+      subject
+    end
+
+    it "checks the editor permissions" do
+      expect_any_instance_of(described_class).to receive(:user_can_edit?).with(collection)
+      subject
+    end
+  end
+
+  describe "create" do
+    let(:params) { { label: "name" } }
+    subject { post :create, collection_id: 1, fields: params, format: :json }
+
+    before(:each) do
+      allow(Metadata::CreateConfigurationField).to receive(:call).and_return(true)
+    end
+
+    it "queries for the collection" do
+      expect_any_instance_of(CollectionQuery).to receive(:any_find).and_return(collection)
+      subject
+    end
+
+    it "uses the Metadata::CreateConfigurationField to update the data" do
+      expect(Metadata::CreateConfigurationField).to receive(:call).with(collection, params)
       subject
     end
 

--- a/spec/models/metadata/configuration_spec.rb
+++ b/spec/models/metadata/configuration_spec.rb
@@ -154,12 +154,12 @@ RSpec.describe Metadata::Configuration do
   end
 
   describe "#save_field" do
-    let(:field) { double(described_class::Field, update: true, to_hash: { name: "name" }) }
+    let(:field) { double(described_class::Field, valid?: true, update: true, to_hash: { name: "name" }) }
     let(:update_values) { { label: "label" } }
 
     before(:each) do
       allow(data).to receive(:save).and_return(true)
-      allow(subject).to receive(:field).with(:field_name).and_return(field)
+      allow(subject).to receive(:field).and_return(field)
     end
 
     it "retrieves the field from the name passed in" do
@@ -167,18 +167,21 @@ RSpec.describe Metadata::Configuration do
       subject.save_field(:field_name, update_values)
     end
 
-    it "returns false if the field is not found" do
+    it "creates a new field if the field is not found" do
       allow(subject).to receive(:field).with(:field_name).and_return(nil)
-      expect(subject.save_field(:field_name, update_values)).to be(false)
+      allow(described_class::Field).to receive(:new).and_return(field)
+      expect(described_class::Field).to receive(:new).with(update_values).and_return(field)
+      subject.save_field(:field_name, update_values)
     end
 
-    it "calls update on the field" do
+    it "calls update on the field when it already exists" do
       expect(field).to receive(:update).with(update_values).and_return(true)
       subject.save_field(:field_name, update_values)
     end
 
     it "returns false if the update of the field fails" do
       allow(field).to receive(:update).with(update_values).and_return(false)
+      allow(field).to receive(:valid?).and_return(false)
       expect(subject.save_field(:field_name, update_values)).to be(false)
     end
 

--- a/spec/services/metatdata/configuration_input_cleaner_spec.rb
+++ b/spec/services/metatdata/configuration_input_cleaner_spec.rb
@@ -15,6 +15,11 @@ RSpec.describe Metadata::ConfigurationInputCleaner do
     expect(subject).to eq(label: "Name", name: "name")
   end
 
+  it "creates a name out of the label" do
+    data[:label] = "Name"
+    expect(subject).to eq(label: "Name", name: "name")
+  end
+
   it "underscores spaces in the label to names" do
     data[:label] = "na me"
     expect(subject).to eq(label: "na me", name: "na_me")

--- a/spec/services/metatdata/configuration_input_cleaner_spec.rb
+++ b/spec/services/metatdata/configuration_input_cleaner_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+RSpec.describe Metadata::ConfigurationInputCleaner do
+  let(:data) { {} }
+
+  subject { described_class.call(data) }
+
+  it "converts string keys data to symbols" do
+    data["field"] = "data"
+    expect(subject).to eq(field: "data")
+  end
+
+  it "downcases labels into the name " do
+    data[:label] = "Name"
+    expect(subject).to eq(label: "Name", name: "name")
+  end
+
+  it "underscores spaces in the label to names" do
+    data[:label] = "na me"
+    expect(subject).to eq(label: "na me", name: "na_me")
+  end
+
+  [:required, :default_form_field, :optional_form_field].each do |key|
+    it "converts string \"true\" types for #{key} to true" do
+      data[key] = "true"
+      expect(subject).to eq(key => true)
+    end
+
+    it "converts string \"false\" types for #{key} to false" do
+      data[key] = "false"
+      expect(subject).to eq(key => false)
+    end
+
+    it "converts string \"\" types for #{key} to false" do
+      data[key] = ""
+      expect(subject).to eq(key => false)
+    end
+
+    it "retuns true for types #{key} to true" do
+      data[key] = true
+      expect(subject).to eq(key => true)
+    end
+
+    it "retuns false for types #{key} to false" do
+      data[key] = false
+      expect(subject).to eq(key => false)
+    end
+  end
+end

--- a/spec/services/metatdata/create_configuration_field_spec.rb
+++ b/spec/services/metatdata/create_configuration_field_spec.rb
@@ -1,9 +1,9 @@
 require "rails_helper"
 
-RSpec.describe Metadata::UpdateConfigurationField do
+RSpec.describe Metadata::CreateConfigurationField do
   let(:configuration) { double(Metadata::Configuration) }
   let(:collection) { double(Collection) }
-  let(:data) {  :new_data }
+  let(:data) { { name: "name" } }
 
   before(:each) do
     allow_any_instance_of(CollectionConfigurationQuery).to receive(:find).and_return(configuration)
@@ -12,12 +12,12 @@ RSpec.describe Metadata::UpdateConfigurationField do
   end
 
   it "calls save_field on the configuration" do
-    expect(configuration).to receive(:save_field).with(:field_name, data)
-    described_class.call(collection, :field_name, data)
+    expect(configuration).to receive(:save_field).with("name", data)
+    described_class.call(collection, data)
   end
 
   it "calls the cleaner on the input data" do
     expect(Metadata::ConfigurationInputCleaner).to receive(:call).with(data)
-    described_class.call(collection, :field_name, data)
+    described_class.call(collection, data)
   end
 end


### PR DESCRIPTION
Allow the creation of metadata fields.  

1.  Updates to the form to create fields.
2.  Added a parameter normalizer to ensure data is saved correctly. 
3.  Added routes and services to create 