### PR TITLE
DEC-796: User would like to remove/restore metadata fields

### DIFF
--- a/app/assets/javascripts/actions/MetaDataConfigurationActions.js
+++ b/app/assets/javascripts/actions/MetaDataConfigurationActions.js
@@ -12,7 +12,7 @@ class MetaDataConfigurationActions extends NodeEventEmitter {
     var fieldValues = update(MetaDataConfigurationStore.fields[fieldName], {});
 
     // Optimistically change the store
-    fieldValues["active"] = activeValue;
+    fieldValues.active = activeValue;
     AppDispatcher.dispatch({
       actionType: MetaDataConfigurationActionTypes.MDC_CHANGE_FIELD,
       name: fieldName,
@@ -34,7 +34,7 @@ class MetaDataConfigurationActions extends NodeEventEmitter {
       }).bind(this),
       error: (function(xhr) {
         // Request to change failed, revert the store to previous values
-        fieldValues["active"] = previousValue;
+        fieldValues.active = previousValue;
         AppDispatcher.dispatch({
           actionType: MetaDataConfigurationActionTypes.MDC_CHANGE_FIELD,
           name: fieldName,

--- a/app/assets/javascripts/actions/MetaDataConfigurationActions.js
+++ b/app/assets/javascripts/actions/MetaDataConfigurationActions.js
@@ -6,6 +6,47 @@ var APIResponseMixin = require("../mixins/APIResponseMixin");
 var update = require("react-addons-update");
 
 class MetaDataConfigurationActions extends NodeEventEmitter {
+  changeActive(fieldName, activeValue, pushToUrl){
+    // Clone values in order to revert the store if the change fails
+    const previousValue = MetaDataConfigurationStore.fields[fieldName].active;
+    var fieldValues = update(MetaDataConfigurationStore.fields[fieldName], {});
+
+    // Optimistically change the store
+    fieldValues["active"] = activeValue;
+    AppDispatcher.dispatch({
+      actionType: MetaDataConfigurationActionTypes.MDC_CHANGE_FIELD,
+      name: fieldName,
+      values: fieldValues,
+    });
+
+    pushToUrl += "/" + fieldName;
+    $.ajax({
+      url: pushToUrl,
+      dataType: "json",
+      method: "PUT",
+      data: {
+        fields: fieldValues,
+      },
+      success: (function() {
+        // Store was already changed, nothing to do here
+        this.emit("ChangeActiveFinished", true);
+        AppEventEmitter.emit("MessageCenterDisplay", "info", "Collection updated");
+      }).bind(this),
+      error: (function(xhr) {
+        // Request to change failed, revert the store to previous values
+        fieldValues["active"] = previousValue;
+        AppDispatcher.dispatch({
+          actionType: MetaDataConfigurationActionTypes.MDC_CHANGE_FIELD,
+          name: fieldName,
+          values: fieldValues,
+        });
+        // Communicate the error to the user
+        this.emit("ChangeActiveFinished", false, xhr);
+        AppEventEmitter.emit("MessageCenterDisplay", "error", APIResponseMixin.apiErrorToString(xhr));
+      }).bind(this)
+    });
+  }
+
   changeField(fieldName, fieldValues, pushToUrl) {
     // Clone values in order to revert the store if the change fails
     const previousValues = update(MetaDataConfigurationStore.fields[fieldName], {});

--- a/app/assets/javascripts/components/forms/ItemMetaDataForm.jsx
+++ b/app/assets/javascripts/components/forms/ItemMetaDataForm.jsx
@@ -39,7 +39,7 @@ var ItemMetaDataForm = React.createClass({
 
   getInitialState: function() {
     return {
-      formFields: _.sortBy(MetaDataConfigurationStore.fields, 'order'),
+      formFields: _.sortBy(MetaDataConfigurationStore.activeFields, 'order'),
       formValues: this.props.data,
       formState: "new",
       dataState: "clean",
@@ -69,7 +69,7 @@ var ItemMetaDataForm = React.createClass({
 
   setFormFieldsFromConfiguration: function() {
     this.setState({
-      formFields: _.sortBy(MetaDataConfigurationStore.fields, 'order'),
+      formFields: _.sortBy(MetaDataConfigurationStore.activeFields, 'order'),
     });
   },
 

--- a/app/assets/javascripts/components/forms/MetadataConfigurationForm.jsx
+++ b/app/assets/javascripts/components/forms/MetadataConfigurationForm.jsx
@@ -4,14 +4,19 @@ var mui = require("material-ui");
 var ReactLink = require('react/lib/ReactLink');
 var ReactStateSetters = require('react/lib/ReactStateSetters');
 var MetaDataConfigurationActions = require("../../actions/MetaDataConfigurationActions");
+var Colors = require("material-ui/lib/styles/colors");
+var MoreVertIcons = require("material-ui/lib/svg-icons/navigation/more-vert");
+var FloatingActionButton = require("material-ui/lib/floating-action-button");
+var ContentAdd = require("material-ui/lib/svg-icons/content/add");
 var Paper = mui.Paper;
 var List = mui.List;
 var ListItem = mui.ListItem;
 var FontIcon = mui.FontIcon;
 var IconButton = mui.IconButton;
 var Toggle = mui.Toggle;
-var Colors = require("material-ui/lib/styles/colors");
-var MoreVertIcons = require("material-ui/lib/svg-icons/navigation/more-vert");
+var Toolbar = mui.Toolbar;
+var ToolbarGroup = mui.ToolbarGroup;
+var ToolbarTitle = mui.ToolbarTitle;
 
 var MetaDataConfigurationForm = React.createClass({
   propTypes: {
@@ -104,15 +109,19 @@ var MetaDataConfigurationForm = React.createClass({
 
   backgroundStyle: function() {
     return {
-      maxWidth: "400px",
+      maxWidth: "500px",
       marginTop: "0px",
       marginLeft: "48px",
       padding: "20px"
     };
   },
 
-  listStyle: function() {
+  addButtonStyle: function() {
     return {
+      position: "absolute",
+      top: "2.5em",
+      left: "-16px",
+      zIndex: "1"
     };
   },
 
@@ -125,7 +134,7 @@ var MetaDataConfigurationForm = React.createClass({
   },
 
   getListTitle: function() {
-    return this.state.showInactive ? "All Fields" : "Active Fields";
+    return this.state.showInactive ? "All Metadata Fields" : "Active Metadata Fields";
   },
 
   getFieldItems: function() {
@@ -172,10 +181,19 @@ var MetaDataConfigurationForm = React.createClass({
     const { selectedField } = this.state;
     return (
       <Paper style={ this.backgroundStyle() } zDepth={0}>
-        <mui.RaisedButton label="New Metadata Field" onClick={ this.handleNewClick } />
-        <Toggle labelStyle={{ paddingLeft: "20px" }} label={ this.getListTitle() } onToggle={ this.handleShowInactive } />
         <MetaDataFieldDialog fieldName={ selectedField } open={ selectedField != undefined } baseUpdateUrl={ this.props.baseUpdateUrl }/>
-        <List style={ this.listStyle() }>
+        <Toolbar>
+          <ToolbarTitle style={{ paddingLeft: "48px" }} text={ this.getListTitle() } />
+          <ToolbarGroup float="left">
+            <FloatingActionButton onClick={ this.handleNewClick } mini={true} style={ this.addButtonStyle() }>
+              <ContentAdd />
+            </FloatingActionButton>
+          </ToolbarGroup>
+          <ToolbarGroup float="right" style={{ top: "25%" }}>
+            <Toggle onToggle={ this.handleShowInactive }/>
+          </ToolbarGroup>
+        </Toolbar>
+        <List>
           {this.getFieldItems()}
         </List>
       </Paper>

--- a/app/assets/javascripts/components/forms/MetadataConfigurationForm.jsx
+++ b/app/assets/javascripts/components/forms/MetadataConfigurationForm.jsx
@@ -6,6 +6,7 @@ var ReactStateSetters = require('react/lib/ReactStateSetters');
 var MetaDataConfigurationActions = require("../../actions/MetaDataConfigurationActions");
 var Paper = mui.Paper;
 var List = mui.List;
+var ListItem = mui.ListItem;
 var FontIcon = mui.FontIcon;
 var IconButton = mui.IconButton;
 var Toggle = mui.Toggle;
@@ -78,13 +79,14 @@ var MetaDataConfigurationForm = React.createClass({
     }
 
     if(field.active) {
+      var icon = "delete";
       return (
         <IconButton
           tooltip="Remove"
           tooltipPosition="top-center"
           onTouchTap={function() { this.handleRemove(field.name) }.bind(this) }
         >
-          field.active && <FontIcon className="material-icons" color={Colors.grey500} hoverColor={Colors.red500}>remove</FontIcon>
+          field.active && <FontIcon className="material-icons" color={Colors.grey500} hoverColor={Colors.red500}>{icon}</FontIcon>
         </IconButton>
       );
     } else {
@@ -100,16 +102,43 @@ var MetaDataConfigurationForm = React.createClass({
     }
   },
 
+  backgroundStyle: function() {
+    return {
+      maxWidth: "400px",
+      marginTop: "0px",
+      marginLeft: "48px",
+      padding: "20px"
+    };
+  },
+
+  listStyle: function() {
+    return {
+    };
+  },
+
+  listItemStyle: function() {
+    return {
+      borderBottomStyle: "solid",
+      borderBottomWidth: "1px",
+      borderBottomColor: Colors.grey500
+    };
+  },
+
+  getListTitle: function() {
+    return this.state.showInactive ? "All Fields" : "Active Fields";
+  },
+
   getFieldItems: function() {
     return this.state.fields.map(function(field) {
       return (
-        <mui.ListItem
+        <ListItem
           key={ field.name }
           primaryText={ field.label }
           secondaryText={ field.required && "Required" }
-          leftIcon={this.getLeftIcon(field.type)}
-          rightIconButton={this.getRightIcon(field)}
-          onTouchTap={function() { this.handleEditClick(field.name) }.bind(this) }
+          leftIcon={ this.getLeftIcon(field.type) }
+          rightIconButton={ this.getRightIcon(field) }
+          onTouchTap={ function() { this.handleEditClick(field.name) }.bind(this) }
+          style={ this.listItemStyle() }
         />
       );
     }.bind(this));
@@ -138,10 +167,10 @@ var MetaDataConfigurationForm = React.createClass({
   render: function(){
     const { selectedField } = this.state;
     return (
-      <Paper style={{ maxWidth: "300px" }} zDepth={0}>
-        <Toggle label="Show Inactive Fields" onToggle={ this.handleShowInactive } />
+      <Paper style={ this.backgroundStyle() } zDepth={0}>
+        <Toggle labelStyle={{ paddingLeft: "20px" }} label={ this.getListTitle() } onToggle={ this.handleShowInactive } />
         <MetaDataFieldDialog fieldName={ selectedField } open={ selectedField != undefined } baseUpdateUrl={ this.props.baseUpdateUrl }/>
-        <List >
+        <List style={ this.listStyle() }>
           {this.getFieldItems()}
         </List>
       </Paper>

--- a/app/assets/javascripts/components/forms/MetadataConfigurationForm.jsx
+++ b/app/assets/javascripts/components/forms/MetadataConfigurationForm.jsx
@@ -73,6 +73,10 @@ var MetaDataConfigurationForm = React.createClass({
   },
 
   getRightIcon: function(field) {
+    if(_.contains(field.immutable, "active")) {
+      return null;
+    }
+
     if(field.active) {
       return (
         <IconButton

--- a/app/assets/javascripts/stores/MetaDataConfigurationStore.js
+++ b/app/assets/javascripts/stores/MetaDataConfigurationStore.js
@@ -10,6 +10,7 @@ class MetaDataConfigurationStore extends EventEmitter {
     this._data = {};
 
     Object.defineProperty(this, "fields", { get: function() { return this._data.fields; } });
+    Object.defineProperty(this, "activeFields", { get: function() { return _.where(this._data.fields, {active: true}); } });
     Object.defineProperty(this, "facets", { get: function() { return this._data.facets; } });
     Object.defineProperty(this, "sorts", { get: function() { return this._data.sorts; } });
     AppDispatcher.register(this.receiveAction.bind(this));

--- a/app/decorators/v1/metadata_json.rb
+++ b/app/decorators/v1/metadata_json.rb
@@ -8,7 +8,7 @@ module V1
       {}.tap do |hash|
         object.item_metadata.fields.each do |key, value|
           field_config = configuration.field(key)
-          if field_config.present?
+          if field_config.present? && field_config.active
             hash[key] = field_hash(value, field_config)
           end
         end

--- a/app/models/metadata/configuration.rb
+++ b/app/models/metadata/configuration.rb
@@ -113,7 +113,7 @@ module Metadata
       data.sorts.map do |sort_data|
         sort_data = sort_data.symbolize_keys
         sort_field = field(sort_data.fetch(:field_name))
-        arguments = sort_data.merge(field: sort_field)
+        arguments = sort_data.merge(active: sort_field.active, field: sort_field)
         Metadata::Configuration::Sort.new(**arguments)
       end
     end

--- a/app/models/metadata/configuration.rb
+++ b/app/models/metadata/configuration.rb
@@ -104,7 +104,7 @@ module Metadata
       data.facets.map do |facet_data|
         facet_data = facet_data.symbolize_keys
         facet_field = field(facet_data.fetch(:field_name))
-        arguments = facet_data.merge(field: facet_field)
+        arguments = facet_data.merge(active: facet_field.active, field: facet_field)
         Metadata::Configuration::Facet.new(**arguments)
       end
     end

--- a/app/models/metadata/configuration/facet.rb
+++ b/app/models/metadata/configuration/facet.rb
@@ -1,13 +1,14 @@
 module Metadata
   class Configuration
     class Facet
-      attr_reader :field, :field_name, :name
+      attr_reader :field, :field_name, :name, :active
 
-      def initialize(name:, field:, field_name:, label: nil)
+      def initialize(name:, field:, field_name:, label: nil, active: true)
         @name = name
         @field = field
         @field_name = field_name
         @label = label
+        @active = active
       end
 
       def label

--- a/app/models/metadata/configuration/field.rb
+++ b/app/models/metadata/configuration/field.rb
@@ -4,7 +4,8 @@ module Metadata
       include ActiveModel::Validations
       TYPES = [:string, :html, :date]
 
-      attr_accessor :name, :active, :type, :label, :multiple, :required, :default_form_field, :optional_form_field, :order, :placeholder, :help, :boost, :immutable
+      attr_accessor :name, :active, :type, :label, :multiple, :required, :default_form_field,
+                    :optional_form_field, :order, :placeholder, :help, :boost, :immutable
 
       validates :name, :type, :label, :order, presence: true
       validates :type, inclusion: TYPES

--- a/app/models/metadata/configuration/field.rb
+++ b/app/models/metadata/configuration/field.rb
@@ -4,13 +4,14 @@ module Metadata
       include ActiveModel::Validations
       TYPES = [:string, :html, :date]
 
-      attr_accessor :name, :type, :label, :multiple, :required, :default_form_field, :optional_form_field, :order, :placeholder, :help, :boost
+      attr_accessor :name, :active, :type, :label, :multiple, :required, :default_form_field, :optional_form_field, :order, :placeholder, :help, :boost
 
       validates :name, :type, :label, :order, presence: true
       validates :type, inclusion: TYPES
 
       def initialize(
         name:,
+        active: true,
         type:,
         label:,
         default_form_field:,
@@ -26,6 +27,7 @@ module Metadata
           raise ArgumentError, "Invalid type: #{type}.  Must be one of #{TYPES.join(', ')}"
         end
         @name = name.to_sym
+        @active = active
         @type = type.to_sym
         @label = label
         @multiple = multiple
@@ -48,6 +50,7 @@ module Metadata
       def to_hash
         {
           name: name,
+          active: active,
           type: type,
           label: label,
           multiple: multiple,
@@ -86,7 +89,7 @@ module Metadata
         hash[:default_form_field] = hash.delete(:defaultFormField) if hash[:defaultFormField]
         hash[:optional_form_field] = hash.delete(:optionalFormField) if hash[:optionalFormField]
 
-        convert_strings_to_booleans([:multiple, :required, :default_form_field, :optional_form_field], hash)
+        convert_strings_to_booleans([:multiple, :required, :default_form_field, :optional_form_field, :active], hash)
       end
 
       def convert_strings_to_booleans(keys, hash)

--- a/app/models/metadata/configuration/sort.rb
+++ b/app/models/metadata/configuration/sort.rb
@@ -1,14 +1,15 @@
 module Metadata
   class Configuration
     class Sort
-      attr_reader :field, :field_name, :name, :direction
+      attr_reader :field, :field_name, :name, :direction, :active
 
-      def initialize(name:, field:, field_name:, direction:, label: nil)
+      def initialize(name:, field:, field_name:, direction:, label: nil, active: true)
         @name = name
         @field = field
         @field_name = field_name
         @direction = direction
         @label = label
+        @active = active
       end
 
       def label

--- a/app/models/waggle.rb
+++ b/app/models/waggle.rb
@@ -24,7 +24,7 @@ module Waggle
   end
 
   def self.search(**args)
-    set_configuration(::Metadata::Configuration.new(CollectionConfigurationQuery.new(args[:collection]).find))
+    set_configuration(CollectionConfigurationQuery.new(args[:collection]).find)
     args.delete(:collection)
     Waggle::Search::Query.new(**args).result
   end

--- a/app/models/waggle/adapters/solr/search/facet.rb
+++ b/app/models/waggle/adapters/solr/search/facet.rb
@@ -19,6 +19,10 @@ module Waggle
             facet_config.name
           end
 
+          def active
+            facet_config.active
+          end
+
           def values
             @values ||= facet_rows.each_slice(2).map { |row| Waggle::Adapters::Solr::Search::FacetValue.new(row) }
           end

--- a/app/models/waggle/search/result.rb
+++ b/app/models/waggle/search/result.rb
@@ -24,7 +24,7 @@ module Waggle
       end
 
       def facets
-        adapter_result.facets.select { |facet| facet.active }
+        adapter_result.facets.select(&:active)
       end
 
       def sorts

--- a/app/models/waggle/search/result.rb
+++ b/app/models/waggle/search/result.rb
@@ -24,14 +24,16 @@ module Waggle
       end
 
       def facets
-        adapter_result.facets
+        adapter_result.facets.select { |facet| facet.active }
       end
 
       def sorts
         @sorts ||= [].tap do |array|
           array.push relevancy_sort
           configured_sorts.each do |sort_config|
-            array.push Waggle::Search::SortField.from_config(sort_config)
+            if sort_config.active
+              array.push Waggle::Search::SortField.from_config(sort_config)
+            end
           end
         end
       end

--- a/app/models/waggle/search/sort_field.rb
+++ b/app/models/waggle/search/sort_field.rb
@@ -1,15 +1,16 @@
 module Waggle
   module Search
     class SortField
-      attr_reader :name, :value
+      attr_reader :name, :value, :active
 
       def self.from_config(sort_configuration)
-        new(name: sort_configuration.label, value: sort_configuration.name)
+        new(name: sort_configuration.label, value: sort_configuration.name, active: sort_configuration.active)
       end
 
-      def initialize(name:, value:)
+      def initialize(name:, value:, active: true)
         @name = name
         @value = value
+        @active = active
       end
     end
   end

--- a/app/views/collections/settings.html.erb
+++ b/app/views/collections/settings.html.erb
@@ -6,7 +6,7 @@
     <%= simple_form_for @collection, method: :put, :url => settings_update_form_collection_path(@collection, form: (params[:form] ? "#{params[:form]}" : 'general')) do |f| %>
       <div class="panel panel-default">
         <div class="panel-heading">
-          <h3 class="panel-title">Site Setup</h3>
+          <h3 class="panel-title">Settings</h3>
         </div>
         <div class="panel-body">
           <%= render partial: (params[:form] ? "#{params[:form]}_settings_form" : 'general_settings_form'), locals: { f: f } %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,6 +17,7 @@
     <link href="//fonts.googleapis.com/css?family=Roboto" rel="stylesheet" type="text/css">
     <%= favicon_link_tag "/images/favicon.ico", rel: "shortcut icon" %>
 
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <%= javascript_include_tag "application" %>
     <%= javascript_include_tag 'flash', 'jquery.cookie' %>
   </head>

--- a/app/views/v1/search/index.json.jbuilder
+++ b/app/views/v1/search/index.json.jbuilder
@@ -7,7 +7,9 @@ json.hits do
   end
 end
 json.facets @search.facets do |facet|
-  json.partial! "v1/search/facet", facet: facet
+  if facet.active
+    json.partial! "v1/search/facet", facet: facet
+  end
 end
 json.sorts @search.sorts do |sort_field|
   json.partial! "v1/search/sort_field", sort_field: sort_field

--- a/app/views/v1/search/index.json.jbuilder
+++ b/app/views/v1/search/index.json.jbuilder
@@ -7,9 +7,7 @@ json.hits do
   end
 end
 json.facets @search.facets do |facet|
-  if facet.active
-    json.partial! "v1/search/facet", facet: facet
-  end
+  json.partial! "v1/search/facet", facet: facet
 end
 json.sorts @search.sorts do |sort_field|
   json.partial! "v1/search/sort_field", sort_field: sort_field

--- a/config/metadata/item.yml
+++ b/config/metadata/item.yml
@@ -8,6 +8,7 @@
     :default_form_field: false
     :optional_form_field: true
     :order: 100
+    :immutable: [name, active, type, required, default_form_field, optional_form_field, order]
   - :name: :name
     :active: true
     :type: :string
@@ -17,6 +18,7 @@
     :optional_form_field: false
     :order: 1
     :boost: 10
+    :immutable: [name, active, type, required, default_form_field, optional_form_field, order]
   - :name: :description
     :active: true
     :type: :html

--- a/config/metadata/item.yml
+++ b/config/metadata/item.yml
@@ -1,6 +1,7 @@
 ---
 :fields:
   - :name: :user_defined_id
+    :active: true
     :type: :string
     :label: Identifier
     :required: true
@@ -8,6 +9,7 @@
     :optional_form_field: true
     :order: 100
   - :name: :name
+    :active: true
     :type: :string
     :label: Name
     :required: true
@@ -16,6 +18,7 @@
     :order: 1
     :boost: 10
   - :name: :description
+    :active: true
     :type: :html
     :label: Description
     :default_form_field: true
@@ -23,12 +26,14 @@
     :order: 2
     :placeholder: "Example: \"Also known as \'La Giaconda\' in Italian, this half-length portrait is one of the most famous paintings in the world. It is thought to depict Lisa Gherardini, the wife of Francesco del Giocondo.\""
   - :name: :date_created
+    :active: true
     :type: :date
     :label: Date Created
     :default_form_field: true
     :optional_form_field: false
     :order: 3
   - :name: :alternate_name
+    :active: true
     :type: :string
     :label: Alternate Name
     :multiple: true
@@ -38,6 +43,7 @@
     :boost: 5
     :placeholder: An additional name this work is known as.
   - :name: :creator
+    :active: true
     :type: :string
     :label: Creator
     :multiple: true
@@ -47,6 +53,7 @@
     :boost: 2
     :placeholder: "Example: \"Leonardo da Vinci\""
   - :name: :contributor
+    :active: true
     :type: :string
     :label: Contributor
     :multiple: true
@@ -54,6 +61,7 @@
     :optional_form_field: true
     :order: 4
   - :name: :subject
+    :active: true
     :type: :html
     :label: Subject
     :multiple: true
@@ -62,24 +70,28 @@
     :order: 6
     :boost: 3
   - :name: :transcription
+    :active: true
     :type: :html
     :label: Transcription
     :default_form_field: false
     :optional_form_field: true
     :order: 7
   - :name: :date_published
+    :active: true
     :type: :date
     :label: Date Published
     :default_form_field: false
     :optional_form_field: true
     :order: 9
   - :name: :date_modified
+    :active: true
     :type: :date
     :label: Date Modified
     :default_form_field: false
     :optional_form_field: true
     :order: 10
   - :name: :original_language
+    :active: true
     :type: :string
     :label: Original Language
     :multiple: true
@@ -88,6 +100,7 @@
     :order: 11
     :placeholder: "Example: \"French\""
   - :name: :rights
+    :active: true
     :type: :html
     :label: Rights
     :multiple: false
@@ -96,6 +109,7 @@
     :order: 12
     :placeholder: "Example: \"Copyright held by Hesburgh Libraries\""
   - :name: :call_number
+    :active: true
     :type: :string
     :label: Call Number
     :multiple: true
@@ -103,6 +117,7 @@
     :optional_form_field: true
     :order: 13
   - :name: :provenance
+    :active: true
     :type: :string
     :label: Provenance
     :multiple: true
@@ -111,6 +126,7 @@
     :order: 14
     :placeholder: "Example: \"Received as a gift from John Doe\""
   - :name: :publisher
+    :active: true
     :type: :string
     :label: Publisher
     :multiple: true
@@ -119,6 +135,7 @@
     :order: 15
     :placeholder: "Example: \"Ballantine Books\""
   - :name: :manuscript_url
+    :active: true
     :type: :string
     :label: Digitized Manuscript
     :default_form_field: false

--- a/spec/decorators/v1/metadata_json_spec.rb
+++ b/spec/decorators/v1/metadata_json_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe V1::MetadataJSON do
   let(:item_metadata) { double(Metadata::Retrieval, fields: item_metadata_fields) }
   let(:item_metadata_fields) { { "name" => [metadata_string] } }
   let(:metadata_string) { double(MetadataString, to_hash: "HASH") }
-  let(:metadata_config) { double(name: "Name", label: "Label", type: :string) }
+  let(:metadata_config) { double(name: "Name", label: "Label", type: :string, active: true) }
 
   before(:each) do
     allow_any_instance_of(described_class).to receive(:configuration).and_return(collection_configuration)
@@ -55,6 +55,11 @@ RSpec.describe V1::MetadataJSON do
 
     it "does not add the field if there is no config" do
       allow(collection_configuration).to receive(:field).with("name").and_return(nil)
+      expect(subject).to eq({})
+    end
+
+    it "does not add the field if it is inactive" do
+      allow(metadata_config).to receive(:active).and_return(false)
       expect(subject).to eq({})
     end
   end

--- a/spec/models/metadata/configuration/facet_spec.rb
+++ b/spec/models/metadata/configuration/facet_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Metadata::Configuration::Facet do
   let(:field) { instance_double(Metadata::Configuration::Field, name: :my_field, label: "Default Label") }
-  let(:data) { { name: :my_facet, field_name: :my_field, field: field, label: "Custom Label" } }
+  let(:data) { { name: :my_facet, field_name: :my_field, field: field, label: "Custom Label", active: false } }
   let(:instance) { described_class.new(data) }
   subject { instance }
 
@@ -32,6 +32,17 @@ RSpec.describe Metadata::Configuration::Facet do
     it "defaults to the field label" do
       data[:label] = nil
       expect(subject.label).to eq(field.label)
+    end
+  end
+
+  describe "active" do
+    it "is the expected value" do
+      expect(subject.active).to eq(data.fetch(:active))
+    end
+
+    it "is assumed true if not given in params" do
+      data.delete(:active)
+      expect(subject.active).to eq(true)
     end
   end
 end

--- a/spec/models/metadata/configuration/field_spec.rb
+++ b/spec/models/metadata/configuration/field_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Metadata::Configuration::Field do
   let(:data) do
     {
       name: :string_field,
+      active: false,
       type: :string,
       label: "String",
       placeholder: "placeholder",
@@ -19,6 +20,17 @@ RSpec.describe Metadata::Configuration::Field do
   describe "name" do
     it "is the expected value" do
       expect(subject.name).to eq(data[:name])
+    end
+  end
+
+  describe "active" do
+    it "is the expected value" do
+      expect(subject.active).to eq(data[:active])
+    end
+
+    it "is true by default" do
+      subject = described_class.new(data.except(:active))
+      expect(subject.active).to eq(true)
     end
   end
 
@@ -168,6 +180,7 @@ RSpec.describe Metadata::Configuration::Field do
     it "converts the data to a hash." do
       expect(subject.to_hash).to eq(
         name: :string_field,
+        active: false,
         type: :string,
         label: "String",
         multiple: false,

--- a/spec/models/metadata/configuration/field_spec.rb
+++ b/spec/models/metadata/configuration/field_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe Metadata::Configuration::Field do
       help: "help",
       default_form_field: true,
       optional_form_field: false,
-      order: true
+      order: true,
+      immutable: []
     }
   end
 
@@ -31,6 +32,17 @@ RSpec.describe Metadata::Configuration::Field do
     it "is true by default" do
       subject = described_class.new(data.except(:active))
       expect(subject.active).to eq(true)
+    end
+  end
+
+  describe "immutable" do
+    it "is the expected value" do
+      expect(subject.immutable).to eq(data[:immutable])
+    end
+
+    it "returns name by default" do
+      subject = described_class.new(data.except(:immutable))
+      expect(subject.immutable).to eq(["name"])
     end
   end
 
@@ -133,7 +145,7 @@ RSpec.describe Metadata::Configuration::Field do
     end
   end
 
-  describe "updatee" do
+  describe "update" do
     it "changes the values of the fields passed in" do
       subject.update(order: "new_order", label: "NAME!")
       expect(subject.order).to eq("new_order")
@@ -174,6 +186,28 @@ RSpec.describe Metadata::Configuration::Field do
       subject.update("label" => "NAME!")
       expect(subject.label).to eq("NAME!")
     end
+
+    it "does not update an immutable property" do
+      data[:immutable] = ["type"]
+      subject.update(type: "mynewtype")
+      expect(subject.type).not_to eq(:mynewtype)
+    end
+
+    it "updates the immutable list" do
+      subject.update(immutable: ["type"])
+      expect(subject.immutable).to eq(["type"])
+    end
+
+    it "updates a field if the immutable list has been changed to remove that field" do
+      data[:immutable] = ["type"]
+      subject.update(type: "test", immutable: [])
+      expect(subject.type).to eq(:test)
+    end
+
+    it "does not allow updating immutable to contain immutable" do
+      subject.update(immutable: ["immutable", :immutable])
+      expect(subject.immutable).to eq([])
+    end
   end
 
   describe "to_hash" do
@@ -190,7 +224,8 @@ RSpec.describe Metadata::Configuration::Field do
         order: true,
         placeholder: "placeholder",
         help: "help",
-        boost: 1
+        boost: 1,
+        immutable: []
       )
     end
   end

--- a/spec/models/metadata/configuration/sort_spec.rb
+++ b/spec/models/metadata/configuration/sort_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Metadata::Configuration::Sort do
   let(:field) { instance_double(Metadata::Configuration::Field, name: :my_field, label: "Default Label") }
-  let(:data) { { name: :my_sort, field_name: :my_field, field: field, direction: :asc, label: "Custom Label" } }
+  let(:data) { { name: :my_sort, field_name: :my_field, field: field, direction: :asc, label: "Custom Label", active: false } }
   let(:instance) { described_class.new(data) }
   subject { instance }
 
@@ -38,6 +38,17 @@ RSpec.describe Metadata::Configuration::Sort do
     it "defaults to the field label" do
       data[:label] = nil
       expect(subject.label).to eq(field.label)
+    end
+  end
+
+  describe "active" do
+    it "is the expected value" do
+      expect(subject.active).to eq(data.fetch(:active))
+    end
+
+    it "is assumed true if not given in params" do
+      data.delete(:active)
+      expect(subject.active).to eq(true)
     end
   end
 end

--- a/spec/models/metadata/configuration_spec.rb
+++ b/spec/models/metadata/configuration_spec.rb
@@ -146,8 +146,8 @@ RSpec.describe Metadata::Configuration do
     subject { instance.sorts }
 
     it "is an array of sorts" do
-      expect(described_class::Sort).to receive(:new).with(sort_data[0].merge(field: kind_of(described_class::Field))).and_call_original
-      expect(described_class::Sort).to receive(:new).with(sort_data[1].merge(field: kind_of(described_class::Field))).and_call_original
+      expect(described_class::Sort).to receive(:new).with(sort_data[0].merge(active: true, field: kind_of(described_class::Field))).and_call_original
+      expect(described_class::Sort).to receive(:new).with(sort_data[1].merge(active: true, field: kind_of(described_class::Field))).and_call_original
       expect(subject).to be_kind_of(Array)
       expect(subject.first).to be_kind_of(described_class::Sort)
     end

--- a/spec/models/metadata/configuration_spec.rb
+++ b/spec/models/metadata/configuration_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe Metadata::Configuration do
   end
   let(:facet_data) do
     [
-      { name: "string_field_facet", field_name: "string_field" },
-      { name: "string_field_facet_2", field_name: "string_field", label: "Custom Label" },
+      { name: "string_field_facet", field_name: "string_field", active: true },
+      { name: "string_field_facet_2", field_name: "string_field", active: true, label: "Custom Label" },
     ]
   end
   let(:sort_data) do

--- a/spec/models/waggle/adapters/solr/search/facet_spec.rb
+++ b/spec/models/waggle/adapters/solr/search/facet_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Waggle::Adapters::Solr::Search::Facet do
     { "creator_facet" => ["Bob Bobbers", 10, "Sven Svenly", 5, "Norbert", 1] }
   end
   let(:facet_rows) { facet_fields.fetch("creator_facet") }
-  let(:facet_config) { instance_double(Metadata::Configuration::Facet, name: "creator", label: "Creator") }
+  let(:facet_config) { instance_double(Metadata::Configuration::Facet, name: "creator", label: "Creator", active: false) }
   let(:instance) { described_class.new(facet_rows: facet_rows, facet_config: facet_config) }
   subject { instance }
 
@@ -18,6 +18,12 @@ RSpec.describe Waggle::Adapters::Solr::Search::Facet do
   describe "name" do
     it "is the label of the facet config" do
       expect(subject.name).to eq(facet_config.label)
+    end
+  end
+
+  describe "active" do
+    it "is the value of the facet config" do
+      expect(subject.active).to eq(facet_config.active)
     end
   end
 

--- a/spec/models/waggle/search/result_spec.rb
+++ b/spec/models/waggle/search/result_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Waggle::Search::Result do
     it "only returns fields that are active" do
       facets = [double(Object, active: true), double(Object, active: true), double(Object, active: false)]
       expect(adapter_result).to receive(:facets).and_return(facets)
-      expect(subject.facets).to eq([facets[0],facets[1]])
+      expect(subject.facets).to eq([facets[0], facets[1]])
     end
   end
 

--- a/spec/models/waggle/search/result_spec.rb
+++ b/spec/models/waggle/search/result_spec.rb
@@ -40,8 +40,9 @@ RSpec.describe Waggle::Search::Result do
 
   describe "facets" do
     it "returns the adapter facets" do
-      expect(adapter_result).to receive(:facets).and_return([:facets])
-      expect(subject.facets).to eq([:facets])
+      facets = double(Object, active: true)
+      expect(adapter_result).to receive(:facets).and_return([facets])
+      expect(subject.facets).to eq([facets])
     end
   end
 

--- a/spec/models/waggle/search/result_spec.rb
+++ b/spec/models/waggle/search/result_spec.rb
@@ -44,6 +44,12 @@ RSpec.describe Waggle::Search::Result do
       expect(adapter_result).to receive(:facets).and_return([facets])
       expect(subject.facets).to eq([facets])
     end
+
+    it "only returns fields that are active" do
+      facets = [double(Object, active: true), double(Object, active: true), double(Object, active: false)]
+      expect(adapter_result).to receive(:facets).and_return(facets)
+      expect(subject.facets).to eq([facets[0],facets[1]])
+    end
   end
 
   describe "sorts" do
@@ -55,6 +61,26 @@ RSpec.describe Waggle::Search::Result do
       configuration.sorts.each_with_index do |sort_config, index|
         expect(subject.sorts[index + 1].name).to eq(sort_config.label)
         expect(subject.sorts[index + 1].value).to eq(sort_config.name)
+      end
+    end
+
+    it "only returns fields that are active" do
+      sorts = [
+        double(Object, active: true, label: "label", name: "one"),
+        double(Object, active: true, label: "label", name: "two"),
+        double(Object, active: false, label: "label", name: "three")
+      ]
+      expected_attributes = [
+        { active: true, name: "Relevance", value: "score" },
+        { active: true, name: "label", value: "one" },
+        { active: true, name: "label", value: "two" }
+      ]
+      allow(configuration).to receive(:sorts).and_return(sorts)
+      expect(subject.sorts.length).to eq(expected_attributes.length)
+      expected_attributes.each_with_index do |attributes, index|
+        attributes.each do |attr, value|
+          expect(subject.sorts[index].send(attr)).to eq(value)
+        end
       end
     end
   end

--- a/spec/models/waggle/search/sort_field_spec.rb
+++ b/spec/models/waggle/search/sort_field_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Waggle::Search::SortField do
-  let(:sort_config) { instance_double(Metadata::Configuration::Sort, name: "creatorasc", label: "Creator", active: true) }
-  subject { described_class.new(name: "Name", value: "nameasc") }
+  let(:sort_config) { instance_double(Metadata::Configuration::Sort, name: "creatorasc", label: "Creator", active: false) }
+  subject { described_class.new(name: "Name", value: "nameasc", active: false) }
 
   describe "name" do
     it "is the name" do
@@ -23,6 +23,17 @@ RSpec.describe Waggle::Search::SortField do
       expect(subject).to be_kind_of(described_class)
       expect(subject.name).to eq("Creator")
       expect(subject.value).to eq("creatorasc")
+    end
+  end
+
+  describe "active" do
+    it "is the expected value" do
+      expect(subject.active).to eq(sort_config.active)
+    end
+
+    it "is assumed true if not given in params" do
+      subject = described_class.new(name: "Name", value: "nameasc")
+      expect(subject.active).to eq(true)
     end
   end
 end

--- a/spec/models/waggle/search/sort_field_spec.rb
+++ b/spec/models/waggle/search/sort_field_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Waggle::Search::SortField do
-  let(:sort_config) { instance_double(Metadata::Configuration::Sort, name: "creatorasc", label: "Creator") }
+  let(:sort_config) { instance_double(Metadata::Configuration::Sort, name: "creatorasc", label: "Creator", active: true) }
   subject { described_class.new(name: "Name", value: "nameasc") }
 
   describe "name" do


### PR DESCRIPTION
Why: User needs a way to remove and restore removed fields from their configuration, except for necessary fields like name.
How: 
  - Added an "active" property to all fields. 
  - Changed the configuration form to a list with a button that allows them to remove/restore each field. 
  - Added an immutable property list to each metadata field that allows us to restrict what properties a user can change. Ex: for the name field, active is now an immutable property.
  - Changed item api to filter out metadata fields that are inactive.
  - Changed search to filter out inactive fields from facets and sorts.