### PR TITLE
DEC-801: Fix export import

### DIFF
--- a/app/models/metadata/fields/date_field.rb
+++ b/app/models/metadata/fields/date_field.rb
@@ -57,10 +57,10 @@ module Metadata
 
       def to_params
         {
+          bc: bc,
+          day: day,
           year: year,
           month: month,
-          day: day,
-          bc: bc,
           display_text: display_text,
         }.stringify_keys
       end

--- a/app/services/find_or_create_item.rb
+++ b/app/services/find_or_create_item.rb
@@ -60,6 +60,10 @@ class FindOrCreateItem
   private
 
   def update_props
+    if props[:metadata].present?
+      metadata = props.delete(:metadata)
+      Metadata::Setter.call(item, metadata)
+    end
     item.assign_attributes(props)
     CreateUniqueId.call(item)
     @is_valid = item.valid?

--- a/app/services/find_or_create_item.rb
+++ b/app/services/find_or_create_item.rb
@@ -50,7 +50,7 @@ class FindOrCreateItem
   end
 
   def find_or_create_by(criteria:)
-    @item = Item.find_or_create_by(criteria)
+    @item = Item.find_or_initialize_by(criteria)
     @is_new_record = item.new_record?
     update_props
     @is_changed = !item.new_record? && item.changed?

--- a/app/services/google_export_items.rb
+++ b/app/services/google_export_items.rb
@@ -18,7 +18,7 @@ class GoogleExportItems
     worksheet = session.get_worksheet(file: file, sheet: sheet)
     if worksheet.present?
       item_hashes = items.map do |item|
-        RewriteItemMetadataForExport.call(item_hash: item_hash(item: item), configuration: configuration(item.collection))
+        RewriteItemMetadataForExport.call(user_defined_id: item.user_defined_id, item_hash: item.metadata, configuration: configuration(item.collection))
       end
       session.hashes_to_worksheet(worksheet: worksheet, hashes: item_hashes)
     end
@@ -28,10 +28,5 @@ class GoogleExportItems
 
   def configuration(collection)
     @configuration ||= CollectionConfigurationQuery.new(collection).find
-  end
-
-  def item_hash(item:)
-    item_fields = { user_defined_id: item.user_defined_id }
-    item_fields.merge(item.metadata)
   end
 end

--- a/app/services/google_export_items.rb
+++ b/app/services/google_export_items.rb
@@ -18,7 +18,12 @@ class GoogleExportItems
     worksheet = session.get_worksheet(file: file, sheet: sheet)
     if worksheet.present?
       item_hashes = items.map do |item|
-        RewriteItemMetadataForExport.call(user_defined_id: item.user_defined_id, item_hash: item.metadata, configuration: configuration(item.collection))
+        meta_hash = RewriteItemMetadataForExport.call(user_defined_id: item.user_defined_id,
+                                                      item_hash: item.metadata,
+                                                      configuration: configuration(item.collection))
+        # Prefix all values with ' to force google to treat all values as text, otherwise it will reformat things like dates/numbers
+        # and cause problems on import
+        meta_hash.each { |k, v| meta_hash[k] = "'" + v unless v.nil? }
       end
       session.hashes_to_worksheet(worksheet: worksheet, hashes: item_hashes)
     end

--- a/app/services/google_export_items.rb
+++ b/app/services/google_export_items.rb
@@ -31,10 +31,7 @@ class GoogleExportItems
   end
 
   def item_hash(item:)
-    item_fields =
-      {
-        user_defined_id: item.user_defined_id,
-      }
+    item_fields = { user_defined_id: item.user_defined_id }
     item_fields.merge(item.metadata)
   end
 end

--- a/app/services/google_export_items.rb
+++ b/app/services/google_export_items.rb
@@ -27,7 +27,7 @@ class GoogleExportItems
   private
 
   def configuration(collection)
-    @configuration ||= Metadata::Configuration.new(CollectionConfigurationQuery.new(collection).find)
+    @configuration ||= CollectionConfigurationQuery.new(collection).find
   end
 
   def item_hash(item:)

--- a/app/services/metadata_input_cleaner.rb
+++ b/app/services/metadata_input_cleaner.rb
@@ -21,6 +21,7 @@ class MetadataInputCleaner
 
   def ensure_value_is_array(key, value)
     if value.is_a?(Array)
+      value.compact!
       item.metadata.delete(key) if value.empty?
     else
       if value.nil?

--- a/app/services/param_cleaner.rb
+++ b/app/services/param_cleaner.rb
@@ -21,12 +21,18 @@ class ParamCleaner
   # Similar to built-in Hash.transform_values! except it will transform it recursively
   # for nested hashes
   def self.transform_values_recursively!(hash:)
-    hash.each_pair do |key, value|
-      if value.respond_to?(:each_pair) && value.respond_to?("[]")
-        hash[key] = transform_values_recursively!(hash: value) { |v| yield(v) }
-      else
-        hash[key] = yield(value)
+    if hash.respond_to?(:each_index) && hash.respond_to?("[]")
+      # Transform each item in the array
+      hash = hash.each_index do |i|
+        hash[i] = transform_values_recursively!(hash: hash[i]) { |v| yield(v) }
       end
+    elsif hash.respond_to?(:each_pair) && hash.respond_to?("[]")
+      # Transform each pair in the hash
+      hash.each_pair do |key, value|
+        hash[key] = transform_values_recursively!(hash: value) { |v| yield(v) }
+      end
+    else
+      hash = yield(hash)
     end
   end
 end

--- a/app/services/rewrite_item_metadata.rb
+++ b/app/services/rewrite_item_metadata.rb
@@ -14,15 +14,21 @@ class RewriteItemMetadata
 
   def rewrite(item_hash:, errors:)
     result = Hash.new
+    metadata = Hash.new
     item_hash.each do |k, v|
-      new_pair = rewrite_pair(key: k, value: v)
-      if configuration.field?(new_pair.key)
-        result[new_pair.key] = new_pair.value
+      if k == "Identifier"
+        result[:user_defined_id] = v
       else
-        errors << "Unknown attribute #{k}"
+        new_pair = rewrite_pair(key: k, value: v)
+        if configuration.field?(new_pair.key) || new_pair.key == "user_defined_id"
+          metadata[new_pair.key] = new_pair.value
+        else
+          errors << "Unknown attribute #{k}"
+        end
       end
     end
-    field_map.merge!(result)
+    result[:metadata] = field_map.merge!(metadata)
+    result
   end
 
   private

--- a/app/services/rewrite_item_metadata_for_export.rb
+++ b/app/services/rewrite_item_metadata_for_export.rb
@@ -1,24 +1,27 @@
 # Translates a hash of Item properties to their common property names
 class RewriteItemMetadataForExport
-  attr_reader :configuration, :label_map
-  private :configuration, :label_map
+  attr_reader :configuration
+  private :configuration
 
   def initialize(configuration)
     @configuration = configuration
-    @label_map = Hash[configuration.field_labels.map { |name| [name, nil] }]
   end
 
-  def self.call(item_hash:, configuration:)
-    new(configuration).rewrite(item_hash: item_hash)
+  def self.call(user_defined_id:, item_hash:, configuration:)
+    new(configuration).rewrite(user_defined_id: user_defined_id, item_hash: item_hash)
   end
 
-  def rewrite(item_hash:)
-    result = Hash.new
+  def rewrite(user_defined_id:, item_hash:)
+    # First make a map of all labels, otherwise the result will only include those that have values
+    label_map = Hash[configuration.field_labels.map { |name| [name, nil] }]
+
+    item_values = Hash.new
     item_hash.each do |k, v|
       new_pair = rewrite_pair(key: k, value: v)
-      result[new_pair.key] = new_pair.value
+      item_values[new_pair.key] = new_pair.value
     end
-    label_map.merge!(result)
+    label_map.merge!(item_values)
+    { "Identifier" => user_defined_id }.merge(label_map)
   end
 
   private

--- a/app/services/rewrite_item_metadata_for_export.rb
+++ b/app/services/rewrite_item_metadata_for_export.rb
@@ -42,6 +42,8 @@ class RewriteItemMetadataForExport
   def rewrite_values(field:, pair:)
     if field.multiple
       pair.value = pair.value.join("||")
+    else
+      pair.value = pair.value.first
     end
 
     if field.type == :date

--- a/app/services/rewrite_item_metadata_for_export.rb
+++ b/app/services/rewrite_item_metadata_for_export.rb
@@ -50,7 +50,7 @@ class RewriteItemMetadataForExport
     end
 
     if field.type == :date
-      pair.value = "'" + Metadata::Fields::DateField.from_hash(pair.value).to_string
+      pair.value = Metadata::Fields::DateField.from_hash(pair.value).to_string
     end
   end
 end

--- a/spec/models/metadata/fields/date_field_spec.rb
+++ b/spec/models/metadata/fields/date_field_spec.rb
@@ -114,6 +114,25 @@ RSpec.describe Metadata::Fields::DateField do
     end
   end
 
+  describe "to_params" do
+    it "stringifys the keys correctly" do
+      date = Metadata::Fields::DateField.new(year: "2010", month: "2", day: "1", bc: true, display_text: "display_text")
+      expect(date.to_params).to eq(
+        "bc" => true,
+        "day" => "1",
+        "year" => "2010",
+        "month" => "2",
+        "display_text" => "display_text"
+      )
+    end
+
+    it "matches Postgres' order for the keys" do
+      date = Metadata::Fields::DateField.new(year: "2010", month: "2", day: "1", bc: true, display_text: "display_text")
+      keys = ["bc", "day", "year", "month", "display_text"]
+      expect(date.to_params.keys).to eq(keys)
+    end
+  end
+
   context "validations" do
     describe "year" do
       it "does not allow nil" do

--- a/spec/services/find_or_create_item_spec.rb
+++ b/spec/services/find_or_create_item_spec.rb
@@ -14,6 +14,7 @@ describe FindOrCreateItem do
   end
 
   before(:each) do
+    allow(Metadata::Setter).to receive(:call).and_return(true)
     allow(Item).to receive(:find_or_create_by).and_return(item)
   end
 
@@ -75,7 +76,7 @@ describe FindOrCreateItem do
     end
   end
 
-  it "assigns the attributes given to the item" do
+  it "assigns the attributes given to the item using the Metadata::Setter" do
     expect(item).to receive(:assign_attributes).with(item_hash)
     subject.find_or_create_by(criteria: {})
   end

--- a/spec/services/find_or_create_item_spec.rb
+++ b/spec/services/find_or_create_item_spec.rb
@@ -15,17 +15,17 @@ describe FindOrCreateItem do
 
   before(:each) do
     allow(Metadata::Setter).to receive(:call).and_return(true)
-    allow(Item).to receive(:find_or_create_by).and_return(item)
+    allow(Item).to receive(:find_or_initialize_by).and_return(item)
   end
 
   context "using method" do
     it "uses both collection id and user defined id to find the item" do
-      expect(Item).to receive(:find_or_create_by).with(collection_id: 1, user_defined_id: "item").and_return(item)
+      expect(Item).to receive(:find_or_initialize_by).with(collection_id: 1, user_defined_id: "item").and_return(item)
       subject.using(prop_keys: [:collection_id, :user_defined_id])
     end
 
     it "uses empty hash to find the item when no prop_keys are given" do
-      expect(Item).to receive(:find_or_create_by).with({}).and_return(item)
+      expect(Item).to receive(:find_or_initialize_by).with({}).and_return(item)
       subject.using(prop_keys: [])
     end
   end

--- a/spec/services/google_export_items_spec.rb
+++ b/spec/services/google_export_items_spec.rb
@@ -63,18 +63,9 @@ RSpec.describe GoogleExportItems, helpers: :item_meta_helpers do
 
     it "calls RewriteItemMetadataForExport with the correct item hashes" do
       allow_any_instance_of(GoogleSession).to receive(:hashes_to_worksheet).and_return(true)
-      expect(RewriteItemMetadataForExport).to receive(:call).with(
-        item_hash: item_meta_hash_remapped(item_id: 1).merge(user_defined_id: "id1"),
-        configuration: configuration
-      )
-      expect(RewriteItemMetadataForExport).to receive(:call).with(
-        item_hash: item_meta_hash_remapped(item_id: 2).merge(user_defined_id: "id2"),
-        configuration: configuration
-      )
-      expect(RewriteItemMetadataForExport).to receive(:call).with(
-        item_hash: item_meta_hash_remapped(item_id: 3).merge(user_defined_id: "id3"),
-        configuration: configuration
-      )
+      expect(RewriteItemMetadataForExport).to receive(:call).with(hash_including(item_hash: item_meta_hash_remapped(item_id: 1), configuration: configuration))
+      expect(RewriteItemMetadataForExport).to receive(:call).with(hash_including(item_hash: item_meta_hash_remapped(item_id: 2), configuration: configuration))
+      expect(RewriteItemMetadataForExport).to receive(:call).with(hash_including(item_hash: item_meta_hash_remapped(item_id: 3), configuration: configuration))
       subject
     end
   end

--- a/spec/services/google_export_items_spec.rb
+++ b/spec/services/google_export_items_spec.rb
@@ -49,9 +49,14 @@ RSpec.describe GoogleExportItems, helpers: :item_meta_helpers do
   end
 
   context "collection has items" do
-    let(:hashes) { [{ item: "item!" }, { item: "item!" }, { item: "item!" }] }
+    before (:each) do
+      allow(RewriteItemMetadataForExport).to receive(:call) do
+        { item: "item!" }
+      end
+    end
+
     it "uses GoogleSession to populate the worksheet" do
-      expect_any_instance_of(GoogleSession).to receive(:hashes_to_worksheet).with(worksheet: worksheet, hashes: hashes)
+      expect_any_instance_of(GoogleSession).to receive(:hashes_to_worksheet).with(hash_including(worksheet: worksheet))
       subject
     end
 
@@ -66,6 +71,12 @@ RSpec.describe GoogleExportItems, helpers: :item_meta_helpers do
       expect(RewriteItemMetadataForExport).to receive(:call).with(hash_including(item_hash: item_meta_hash_remapped(item_id: 1), configuration: configuration))
       expect(RewriteItemMetadataForExport).to receive(:call).with(hash_including(item_hash: item_meta_hash_remapped(item_id: 2), configuration: configuration))
       expect(RewriteItemMetadataForExport).to receive(:call).with(hash_including(item_hash: item_meta_hash_remapped(item_id: 3), configuration: configuration))
+      subject
+    end
+
+    it "adds a string literal indicator to all values" do
+      rewritten_hashes = [{ item: "'item!" }, { item: "'item!" }, { item: "'item!" }]
+      expect_any_instance_of(GoogleSession).to receive(:hashes_to_worksheet).with(worksheet: worksheet, hashes: rewritten_hashes)
       subject
     end
   end

--- a/spec/services/metadata_input_cleaner_spec.rb
+++ b/spec/services/metadata_input_cleaner_spec.rb
@@ -3,13 +3,13 @@ RSpec.describe MetadataInputCleaner do
   let(:item) { instance_double(Item, metadata: metadata) }
   subject { described_class.call(item) }
 
-  it "convertes a string to an array" do
+  it "converts a string to an array" do
     metadata[:string] = "string"
     subject
     expect(item.metadata["string"]).to eq(["string"])
   end
 
-  it "convertes a javascript array hashs of 0 => { } hash to an array" do
+  it "converts a javascript array hashes of 0 => { } hash to an array" do
     metadata[:hash] = { "0" => "YES" }
     subject
     expect(item.metadata["hash"]).to eq(["YES"])
@@ -36,10 +36,16 @@ RSpec.describe MetadataInputCleaner do
   it "removes empty arrays and their associated key" do
     metadata[:array] = []
     subject
-    expect(item.metadata.has_key?(:array)).to eq(false)
+    expect(item.metadata.has_key?("array")).to eq(false)
   end
 
-  it "converts symbols to stings" do
+  it "removes nil arrays and their associated key" do
+    metadata[:array] = [nil, nil, nil]
+    subject
+    expect(item.metadata.has_key?("array")).to eq(false)
+  end
+
+  it "converts symbols to strings" do
     metadata[:string] = "string"
     subject
     expect(item.metadata["string"]).to eq(["string"])

--- a/spec/services/param_cleaner_spec.rb
+++ b/spec/services/param_cleaner_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe ParamCleaner do
-  context "transform_values_recursively!" do
+  describe "transform_values_recursively!" do
     it "allows injecting a custom block to perform the rewrite" do
       hash1 = { some_key: "previous value" }
       hash2 = { some_key: "new value" }
@@ -9,7 +9,52 @@ RSpec.describe ParamCleaner do
       expect(hash1).to eq(hash2)
     end
 
-    it "works recursively" do
+    it "works with an empty hash" do
+      hash1 = {}
+      hash2 = {}
+      described_class.transform_values_recursively!(hash: hash1) do |_value|
+        "new value"
+      end
+      expect(hash1).to eq(hash2)
+    end
+
+    it "works with an empty array" do
+      hash1 = []
+      hash2 = []
+      described_class.transform_values_recursively!(hash: hash1) do |_value|
+        "new value"
+      end
+      expect(hash1).to eq(hash2)
+    end
+
+    it "works with a flat hash" do
+      hash1 = { some_key: "previous value", some_other_key: "previous value"  }
+      hash2 = { some_key: "new value", some_other_key: "new value" }
+      described_class.transform_values_recursively!(hash: hash1) do |_value|
+        "new value"
+      end
+      expect(hash1).to eq(hash2)
+    end
+
+    it "works with a flat array" do
+      hash1 = [ "previous value", "previous value" ]
+      hash2 = [ "new value", "new value" ]
+      described_class.transform_values_recursively!(hash: hash1) do |_value|
+        "new value"
+      end
+      expect(hash1).to eq(hash2)
+    end
+
+    it "works recursively on arrays" do
+      hash1 = ["previous value", ["previous value"]]
+      hash2 = ["new value", ["new value"]]
+      described_class.transform_values_recursively!(hash: hash1) do |_value|
+        "new value"
+      end
+      expect(hash1).to eq(hash2)
+    end
+
+    it "works recursively on hashes" do
       hash1 = { some_key: "previous value", some_hash: { some_key: "previous value" } }
       hash2 = { some_key: "new value", some_hash: { some_key: "new value" } }
       described_class.transform_values_recursively!(hash: hash1) do |_value|
@@ -17,9 +62,45 @@ RSpec.describe ParamCleaner do
       end
       expect(hash1).to eq(hash2)
     end
+
+    it "works recursively on arrays within hashes" do
+      hash1 = { some_key: "previous value", some_hash: ["previous value"] }
+      hash2 = { some_key: "new value", some_hash: ["new value"] }
+      described_class.transform_values_recursively!(hash: hash1) do |_value|
+        "new value"
+      end
+      expect(hash1).to eq(hash2)
+    end
+
+    it "works recursively on hashes within arrays" do
+      hash1 = ["previous value", { some_inner_key: "previous value" }]
+      hash2 = ["new value", { some_inner_key: "new value" }]
+      described_class.transform_values_recursively!(hash: hash1) do |_value|
+        "new value"
+      end
+      expect(hash1).to eq(hash2)
+    end
+
+    it "works recursively on arrays within sub-hashes" do
+      hash1 = { some_key: "previous value", some_hash: { some_key: ["previous value"] } }
+      hash2 = { some_key: "new value", some_hash: { some_key: ["new value"] } }
+      described_class.transform_values_recursively!(hash: hash1) do |_value|
+        "new value"
+      end
+      expect(hash1).to eq(hash2)
+    end
+
+    it "works recursively on hashes within sub-arrays" do
+      hash1 = ["previous value", ["previous value", { some_inner_key: "previous value" }]]
+      hash2 = ["new value", ["new value", { some_inner_key: "new value" }]]
+      described_class.transform_values_recursively!(hash: hash1) do |_value|
+        "new value"
+      end
+      expect(hash1).to eq(hash2)
+    end
   end
 
-  context "call" do
+  describe "call" do
     it "rewrites 'false' to false" do
       hash1 = { some_key: "false" }
       hash2 = { some_key: false }

--- a/spec/services/param_cleaner_spec.rb
+++ b/spec/services/param_cleaner_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe ParamCleaner do
     end
 
     it "works with a flat hash" do
-      hash1 = { some_key: "previous value", some_other_key: "previous value"  }
+      hash1 = { some_key: "previous value", some_other_key: "previous value" }
       hash2 = { some_key: "new value", some_other_key: "new value" }
       described_class.transform_values_recursively!(hash: hash1) do |_value|
         "new value"
@@ -37,8 +37,8 @@ RSpec.describe ParamCleaner do
     end
 
     it "works with a flat array" do
-      hash1 = [ "previous value", "previous value" ]
-      hash2 = [ "new value", "new value" ]
+      hash1 = ["previous value", "previous value"]
+      hash2 = ["new value", "new value"]
       described_class.transform_values_recursively!(hash: hash1) do |_value|
         "new value"
       end

--- a/spec/services/rewrite_item_metadata_fields_spec.rb
+++ b/spec/services/rewrite_item_metadata_fields_spec.rb
@@ -19,13 +19,18 @@ RSpec.describe RewriteItemMetadata, helpers: :item_meta_helpers do
     allow(configuration).to receive(:label?).and_return(false)
   end
 
+  it "rewrites the hash to match item property structure" do
+    item["Identifier"] = "identifier"
+    expect(subject).to include(:user_defined_id, :metadata)
+  end
+
   it "rewrites all fields from labels to field names" do
     allow(configuration).to receive(:label).with("Name").and_return(field)
     allow(configuration).to receive(:field?).with("name").and_return(true)
     allow(configuration).to receive(:label?).with("Name").and_return(true)
 
     item["Name"] = "the name"
-    expect(subject).to eq("name" => "the name", "alternate_name" => nil, "date_created" => nil)
+    expect(subject[:metadata]).to eq("name" => "the name", "alternate_name" => nil, "date_created" => nil)
   end
 
   it "rewrites multiples to an array" do
@@ -34,7 +39,7 @@ RSpec.describe RewriteItemMetadata, helpers: :item_meta_helpers do
     allow(configuration).to receive(:label?).with("Alternate Name").and_return(true)
 
     item["Alternate Name"] = "name1||name2"
-    expect(subject).to eq("name" => nil, "alternate_name" => ["name1", "name2"], "date_created" => nil)
+    expect(subject[:metadata]).to eq("name" => nil, "alternate_name" => ["name1", "name2"], "date_created" => nil)
   end
 
   context "rewrites dates" do
@@ -44,7 +49,7 @@ RSpec.describe RewriteItemMetadata, helpers: :item_meta_helpers do
       allow(configuration).to receive(:label?).with("Date Created").and_return(true)
 
       item["Date Created"] = "-2001/01/01"
-      expect(subject).to eq(
+      expect(subject[:metadata]).to eq(
         "name" => nil,
         "alternate_name" => nil,
         "date_created" => { "year" => "2001", "month" => "1", "day" => "1", "bc" => true, "display_text" => nil }
@@ -57,7 +62,7 @@ RSpec.describe RewriteItemMetadata, helpers: :item_meta_helpers do
       allow(configuration).to receive(:label?).with("Date Created").and_return(true)
 
       item["Date Created"] = "'-2001/01/01"
-      expect(subject).to eq(
+      expect(subject[:metadata]).to eq(
         "name" => nil,
         "alternate_name" => nil,
         "date_created" => { "year" => "2001", "month" => "1", "day" => "1", "bc" => true, "display_text" => nil }

--- a/spec/services/rewrite_item_metadata_for_export_spec.rb
+++ b/spec/services/rewrite_item_metadata_for_export_spec.rb
@@ -69,15 +69,7 @@ RSpec.describe RewriteItemMetadataForExport, helpers: :item_meta_helpers do
       allow(configuration).to receive(:field?).with(:date_created).and_return(true)
 
       item[:date_created] = [{ "year" => "2001", "month" => "1", "day" => "1", "bc" => true, "display_text" => nil }]
-      expect(subject).to include("Date Created" => "'-2001/01/01")
-    end
-
-    it "adds a string literal indicator" do
-      allow(configuration).to receive(:field).with(:date_created).and_return(date_field)
-      allow(configuration).to receive(:field?).with(:date_created).and_return(true)
-
-      item[:date_created] = [{ "year" => "", "month" => "", "day" => "", "bc" => false, "display_text" => nil }]
-      expect(subject).to include("Date Created" => "'")
+      expect(subject).to include("Date Created" => "-2001/01/01")
     end
   end
 end

--- a/spec/services/rewrite_item_metadata_for_export_spec.rb
+++ b/spec/services/rewrite_item_metadata_for_export_spec.rb
@@ -24,11 +24,25 @@ RSpec.describe RewriteItemMetadataForExport, helpers: :item_meta_helpers do
     allow(configuration).to receive(:label?).and_return(false)
   end
 
+  it "rewrites non-multiples as a single value" do
+    allow(configuration).to receive(:field).with(:name).and_return(field)
+    allow(configuration).to receive(:field?).with(:name).and_return(true)
+    item[:name] = ["Name"]
+    expect(subject).to eq("Name" => "Name", "Alternate Name" => nil, "Date Created" => nil)
+  end
+
+  it "grabs the first value if its not a multiple" do
+    allow(configuration).to receive(:field).with(:name).and_return(field)
+    allow(configuration).to receive(:field?).with(:name).and_return(true)
+    item[:name] = ["Name1", "Name2"]
+    expect(subject).to eq("Name" => "Name1", "Alternate Name" => nil, "Date Created" => nil)
+  end
+
   it "rewrites all fields from labels to field names" do
     allow(configuration).to receive(:field).with(:name).and_return(field)
     allow(configuration).to receive(:field?).with(:name).and_return(true)
 
-    item[:name] = "the Name"
+    item[:name] = ["the Name"]
 
     expect(subject).to eq("Name" => "the Name", "Alternate Name" => nil, "Date Created" => nil)
   end
@@ -46,7 +60,7 @@ RSpec.describe RewriteItemMetadataForExport, helpers: :item_meta_helpers do
       allow(configuration).to receive(:field).with(:date_created).and_return(date_field)
       allow(configuration).to receive(:field?).with(:date_created).and_return(true)
 
-      item[:date_created] = { "year" => "2001", "month" => "1", "day" => "1", "bc" => true, "display_text" => nil }
+      item[:date_created] = [{ "year" => "2001", "month" => "1", "day" => "1", "bc" => true, "display_text" => nil }]
       expect(subject).to eq("Name" => nil, "Alternate Name" => nil, "Date Created" => "'-2001/01/01")
     end
 
@@ -54,7 +68,7 @@ RSpec.describe RewriteItemMetadataForExport, helpers: :item_meta_helpers do
       allow(configuration).to receive(:field).with(:date_created).and_return(date_field)
       allow(configuration).to receive(:field?).with(:date_created).and_return(true)
 
-      item[:date_created] = { "year" => "", "month" => "", "day" => "", "bc" => false, "display_text" => nil }
+      item[:date_created] = [{ "year" => "", "month" => "", "day" => "", "bc" => false, "display_text" => nil }]
       expect(subject).to eq("Name" => nil, "Alternate Name" => nil, "Date Created" => "'")
     end
   end

--- a/spec/services/rewrite_item_metadata_for_export_spec.rb
+++ b/spec/services/rewrite_item_metadata_for_export_spec.rb
@@ -17,25 +17,33 @@ RSpec.describe RewriteItemMetadataForExport, helpers: :item_meta_helpers do
   let(:field) { double(name: "name", label: "Name", multiple: false, type: :string) }
   let(:date_field) { double(name: "date_created", label: "Date Created", multiple: false, type: :date) }
   let(:multiple_field) { double(name: "alternate_name", label: "Alternate Name", multiple: true, type: :string) }
-  let(:subject) { described_class.call(item_hash: item, configuration: configuration) }
+  let(:subject) { described_class.call(item_hash: item, configuration: configuration, user_defined_id: "user_defined_id") }
 
   before(:each) do
     allow(configuration).to receive(:field?).and_return(false)
     allow(configuration).to receive(:label?).and_return(false)
   end
 
+  it "adds the user defined id" do
+    expect(subject).to include("Identifier" => "user_defined_id")
+  end
+
+  it "adds all fields, even when there is no metadata assigned" do
+    expect(subject).to include("Name" => nil, "Alternate Name" => nil, "Date Created" => nil)
+  end
+
   it "rewrites non-multiples as a single value" do
     allow(configuration).to receive(:field).with(:name).and_return(field)
     allow(configuration).to receive(:field?).with(:name).and_return(true)
     item[:name] = ["Name"]
-    expect(subject).to eq("Name" => "Name", "Alternate Name" => nil, "Date Created" => nil)
+    expect(subject).to include("Name" => "Name")
   end
 
   it "grabs the first value if its not a multiple" do
     allow(configuration).to receive(:field).with(:name).and_return(field)
     allow(configuration).to receive(:field?).with(:name).and_return(true)
     item[:name] = ["Name1", "Name2"]
-    expect(subject).to eq("Name" => "Name1", "Alternate Name" => nil, "Date Created" => nil)
+    expect(subject).to include("Name" => "Name1")
   end
 
   it "rewrites all fields from labels to field names" do
@@ -44,7 +52,7 @@ RSpec.describe RewriteItemMetadataForExport, helpers: :item_meta_helpers do
 
     item[:name] = ["the Name"]
 
-    expect(subject).to eq("Name" => "the Name", "Alternate Name" => nil, "Date Created" => nil)
+    expect(subject).to include("Name" => "the Name")
   end
 
   it "rewrites multiples to an array" do
@@ -52,7 +60,7 @@ RSpec.describe RewriteItemMetadataForExport, helpers: :item_meta_helpers do
     allow(configuration).to receive(:field?).with(:alternate_name).and_return(true)
 
     item[:alternate_name] = ["name1", "name2"]
-    expect(subject).to eq("Name" => nil, "Alternate Name" => "name1||name2", "Date Created" => nil)
+    expect(subject).to include("Alternate Name" => "name1||name2")
   end
 
   context "rewrites dates" do
@@ -61,7 +69,7 @@ RSpec.describe RewriteItemMetadataForExport, helpers: :item_meta_helpers do
       allow(configuration).to receive(:field?).with(:date_created).and_return(true)
 
       item[:date_created] = [{ "year" => "2001", "month" => "1", "day" => "1", "bc" => true, "display_text" => nil }]
-      expect(subject).to eq("Name" => nil, "Alternate Name" => nil, "Date Created" => "'-2001/01/01")
+      expect(subject).to include("Date Created" => "'-2001/01/01")
     end
 
     it "adds a string literal indicator" do
@@ -69,7 +77,7 @@ RSpec.describe RewriteItemMetadataForExport, helpers: :item_meta_helpers do
       allow(configuration).to receive(:field?).with(:date_created).and_return(true)
 
       item[:date_created] = [{ "year" => "", "month" => "", "day" => "", "bc" => false, "display_text" => nil }]
-      expect(subject).to eq("Name" => nil, "Alternate Name" => nil, "Date Created" => "'")
+      expect(subject).to include("Date Created" => "'")
     end
   end
 end


### PR DESCRIPTION
Why: Lots of changes to the way metadata is handled to accommodate the dynamic metadata, which broke export/import.
How: User defined id is no longer part of metadata, but is still needed for export/import. Added special handling to merge this with meta fields. Changed the parsing/rewriting now that all metadata will be stored as arrays. Changed import to use the new metadata setter service to assign metadata to the items. Also fixed a problem associated with postgres' ordering of keys that caused imports to appear as though an item changed when it had not (See DEC-812 for more info).