### PR TITLE
add file for vatican only metadata

### DIFF
--- a/config/metadata/vatican_item.yml
+++ b/config/metadata/vatican_item.yml
@@ -1,0 +1,153 @@
+---
+:fields:
+  - :name: :name
+    :active: true
+    :type: :string
+    :label: Name
+    :required: true
+    :default_form_field: true
+    :optional_form_field: false
+    :order: 1
+    :boost: 10
+    :immutable: [name, active, type, required, default_form_field, optional_form_field, order]
+  - :name: :description
+    :active: true
+    :type: :html
+    :label: Description
+    :default_form_field: true
+    :optional_form_field: false
+    :order: 2
+    :placeholder: "Example: \"Also known as \'La Giaconda\' in Italian, this half-length portrait is one of the most famous paintings in the world. It is thought to depict Lisa Gherardini, the wife of Francesco del Giocondo.\""
+  - :name: :date_created
+    :active: true
+    :type: :date
+    :label: Date Created
+    :default_form_field: true
+    :optional_form_field: false
+    :order: 3
+  - :name: :alternate_name
+    :active: true
+    :type: :string
+    :label: Alternate Name
+    :multiple: true
+    :default_form_field: false
+    :optional_form_field: true
+    :order: 5
+    :boost: 5
+    :placeholder: An additional name this work is known as.
+  - :name: :creator
+    :active: true
+    :type: :string
+    :label: Creator
+    :multiple: true
+    :default_form_field: false
+    :optional_form_field: true
+    :order: 8
+    :boost: 2
+    :placeholder: "Example: \"Leonardo da Vinci\""
+  - :name: :contributor
+    :active: true
+    :type: :string
+    :label: Contributor
+    :multiple: true
+    :default_form_field: false
+    :optional_form_field: true
+    :order: 4
+  - :name: :subject
+    :active: true
+    :type: :html
+    :label: Subject
+    :multiple: true
+    :default_form_field: false
+    :optional_form_field: true
+    :order: 6
+    :boost: 3
+  - :name: :transcription
+    :active: true
+    :type: :html
+    :label: Transcription
+    :default_form_field: false
+    :optional_form_field: true
+    :order: 7
+  - :name: :date_published
+    :active: true
+    :type: :date
+    :label: Date Published
+    :default_form_field: false
+    :optional_form_field: true
+    :order: 9
+  - :name: :date_modified
+    :active: true
+    :type: :date
+    :label: Date Modified
+    :default_form_field: false
+    :optional_form_field: true
+    :order: 10
+  - :name: :original_language
+    :active: true
+    :type: :string
+    :label: Original Language
+    :multiple: true
+    :default_form_field: false
+    :optional_form_field: true
+    :order: 11
+    :placeholder: "Example: \"French\""
+  - :name: :rights
+    :active: true
+    :type: :html
+    :label: Rights
+    :multiple: false
+    :default_form_field: false
+    :optional_form_field: true
+    :order: 12
+    :placeholder: "Example: \"Copyright held by Hesburgh Libraries\""
+  - :name: :order
+    :active: true
+    :type: :string
+    :label: Order
+    :multiple: false
+    :default_form_field: false
+    :optional_form_field: true
+    :order: 13
+  - :name: :parent_id
+    :active: true
+    :type: :string
+    :label: Document Id
+    :multiple: false
+    :default_form_field: false
+    :optional_form_field: true
+    :order: 14
+    :placeholder: "Example: \"Received as a gift from John Doe\""
+  - :name: :publisher
+    :active: true
+    :type: :string
+    :label: Publisher
+    :multiple: true
+    :default_form_field: false
+    :optional_form_field: true
+    :order: 15
+    :placeholder: "Example: \"Ballantine Books\""
+  - :name: :manuscript_url
+    :active: true
+    :type: :string
+    :label: Digitized Manuscript
+    :default_form_field: false
+    :optional_form_field: true
+    :order: 16
+    :placeholder: "http://"
+    :help: Link to externally hosted manuscript viewer.
+:facets:
+  - :name: :creator
+    :field_name: :creator
+  - :name: :language
+    :field_name: :original_language
+    :label: Language
+:sorts:
+  - :name: :name
+    :field_name: :name
+    :direction: :asc
+    :label: Name
+  - :name: :creator
+    :field_name: :creator
+    :direction: :asc
+    :label: Creator


### PR DESCRIPTION
I added an example vaitcan metadata file.  This file can be loaded into your collections metadata. 
It is required if you want to use any of the new pulls for zucchetto.
I imagine this file will change over time as we work through the development of zucchetto.  
To load:

```
# get the config of the collection you want.
collection_configuration = Collection.first.collection_configuration
# load the yml 
config = YAML.load_file(Rails.root.join("config/metadata/", "vatican_item.yml"))
# set and save
collection_configuration.metadata = config[:fields]
collection_configuration.save! 

```