### PR TITLE
DEC-829: Creating a new collection fails

### DIFF
--- a/app/views/collections/_general_settings_form.html.erb
+++ b/app/views/collections/_general_settings_form.html.erb
@@ -1,9 +1,4 @@
-<%= display_errors(@collection) %>
-
-<%= f.input :name_line_1 %>
-<%= f.input :name_line_2 %>
-<%= render partial: 'search_and_browse_form', locals: { f: f } %>
+<%= render :partial => 'general_settings_subform', locals: { f: f } %>
 
 <%= f.button :submit, value: t('buttons.save'), :class => 'btn-primary' %>
-
 <%= DeletePanel.new(@collection).display  %>

--- a/app/views/collections/_general_settings_subform.html.erb
+++ b/app/views/collections/_general_settings_subform.html.erb
@@ -1,0 +1,5 @@
+<%= display_errors(@collection) %>
+
+<%= f.input :name_line_1 %>
+<%= f.input :name_line_2 %>
+<%= render partial: 'search_and_browse_form', locals: { f: f } %>

--- a/app/views/collections/new.html.erb
+++ b/app/views/collections/new.html.erb
@@ -8,7 +8,7 @@
       <h3 class="panel-title"><%= t('.title') %></h3>
     </div>
     <div class="panel-body">
-      <%= render :partial => 'form', locals: { f: f } %>
+      <%= render :partial => 'general_settings_subform', locals: { f: f } %>
     </div>
     <div class="panel-footer">
       <%= f.button :submit, value: t('buttons.save'), :class => 'btn-primary' %>


### PR DESCRIPTION
Refactored the pieces that were shared between the new collection form and the general settings form into its own partial and changed those two forms to render that partial. This structure changed when we added subforms to settings to accommodate the metadata configuration.