### PR TITLE
DEC-832: Reactivate a metadata field fails

### DIFF
--- a/app/models/metadata/configuration/field.rb
+++ b/app/models/metadata/configuration/field.rb
@@ -105,7 +105,12 @@ module Metadata
 
       def convert_strings_to_booleans(keys, hash)
         keys.each do |key|
-          hash[key] = hash[key] == "true" ? true : false if hash[key]
+          case hash[key]
+          when "true"
+            hash[key] = true
+          when "false"
+            hash[key] = false
+          end
         end
       end
     end


### PR DESCRIPTION
Fixed a comparison problem with convert_strings_to_boolean. If the kvp was already converted (ex: it went through ConfigurationInputCleaner), then the == "true" would fail for true values, and convert it to false