### PR TITLE
DEC-835: Cannot create new metafield

### DIFF
--- a/app/assets/javascripts/actions/MetaDataConfigurationActions.js
+++ b/app/assets/javascripts/actions/MetaDataConfigurationActions.js
@@ -79,7 +79,6 @@ class MetaDataConfigurationActions extends NodeEventEmitter {
         // Communicate the error to the user
         this.emit("ChangeFieldFinished", false, xhr);
         AppEventEmitter.emit("MessageCenterDisplay", "error", "Save failed. Please ensure to select a label and a type and try again.");
-        //AppEventEmitter.emit("MessageCenterDisplay", "error", APIResponseMixin.apiErrorToString(xhr));
       }).bind(this)
     });
   }
@@ -108,7 +107,6 @@ class MetaDataConfigurationActions extends NodeEventEmitter {
         // Communicate the error to the user
         this.emit("CreateFieldFinished", false, xhr);
         AppEventEmitter.emit("MessageCenterDisplay", "error", "Create failed. Please ensure to select a label and a type and try again.");
-        //AppEventEmitter.emit("MessageCenterDisplay", "error", APIResponseMixin.apiErrorToString(xhr));
       }).bind(this)
     });
   }

--- a/app/assets/javascripts/actions/MetaDataConfigurationActions.js
+++ b/app/assets/javascripts/actions/MetaDataConfigurationActions.js
@@ -85,8 +85,8 @@ class MetaDataConfigurationActions extends NodeEventEmitter {
   }
 
   createField(fieldName, fieldValues, pushToUrl) {
-    var requiredValues = _.pick(fieldValues, 'defaultFormField', 'label', 'multiple', 'optionalFormField', 'required', 'type');
-    var postValues = _.omit(requiredValues, function(value, key, object) { return _.isNull(value) });
+    var requiredValues = _.pick(fieldValues, "defaultFormField", "label", "multiple", "optionalFormField", "required", "type");
+    var postValues = _.omit(requiredValues, function(value) { return _.isNull(value); });
 
     $.ajax({
       url: pushToUrl,

--- a/app/assets/javascripts/components/forms/MetaDataFieldDialog.jsx
+++ b/app/assets/javascripts/components/forms/MetaDataFieldDialog.jsx
@@ -58,6 +58,7 @@ var MetaDataFieldDialog = React.createClass({
 
   componentWillMount: function() {
     MetaDataConfigurationActions.on("ChangeFieldFinished", this.handleSaved);
+    MetaDataConfigurationActions.on("CreateFieldFinished", this.handleSaved);
   },
 
   componentWillReceiveProps: function(nextProps) {
@@ -90,8 +91,12 @@ var MetaDataFieldDialog = React.createClass({
   },
 
   handleSave: function() {
-    MetaDataConfigurationActions.changeField(this.state.fieldName, this.state.fieldValues, this.props.baseUpdateUrl, this.state.createForm);
-    this.setState({ saving: true});
+    if(this.state.createForm){
+      MetaDataConfigurationActions.createField(this.state.fieldName, this.state.fieldValues, this.props.baseUpdateUrl);
+    } else {
+      MetaDataConfigurationActions.changeField(this.state.fieldName, this.state.fieldValues, this.props.baseUpdateUrl);
+    }
+    this.setState({ saving: true });
   },
 
   handleSaved: function(success, data) {

--- a/app/controllers/v1/metadata_fields_controller.rb
+++ b/app/controllers/v1/metadata_fields_controller.rb
@@ -5,13 +5,11 @@ module V1
 
       return if rendered_forbidden?(@collection)
 
-      @return_value = :success
-      if !Metadata::UpdateConfigurationField.call(@collection, params[:id], params[:fields])
-        @return_value = :unprocessable_entity
-      end
-
-      respond_to do |format|
-        format.json { render json: { status: @return_value }.to_json }
+      result = Metadata::UpdateConfigurationField.call(@collection, params[:id], field_params)
+      if result
+        render json: { field: result }.to_json
+      else
+        render status: :unprocessable_entity, json: { field: field_params }.to_json
       end
     end
 
@@ -19,12 +17,19 @@ module V1
       @collection = CollectionQuery.new.any_find(params[:collection_id])
 
       return if rendered_forbidden?(@collection)
-      result = Metadata::CreateConfigurationField.call(@collection, params[:fields])
+
+      result = Metadata::CreateConfigurationField.call(@collection, field_params)
       if result
-        render json: { status: :success, field: result }.to_json
+        render json: { field: result }.to_json
       else
-        render json: { status: :unprocessable_entity, field: params[:fields] }.to_json
+        render status: :unprocessable_entity, json: { field: field_params }.to_json
       end
+    end
+
+    private
+
+    def field_params
+      @field_params ||= params[:fields] ? params[:fields] : {}
     end
   end
 end

--- a/app/models/metadata/configuration/field.rb
+++ b/app/models/metadata/configuration/field.rb
@@ -12,14 +12,14 @@ module Metadata
       validates :type, inclusion: TYPES
 
       def initialize(
-        name:,
+        name: "",
         active: true,
-        type:,
-        label:,
-        default_form_field:,
-        optional_form_field:,
+        type: "",
+        label: "",
+        default_form_field: false,
+        optional_form_field: false,
         boost: 1,
-        order:,
+        order: 0,
         help: "",
         placeholder: "",
         multiple: false,
@@ -39,10 +39,7 @@ module Metadata
         @help = help
         @boost = boost
         @immutable = immutable
-
-        if !valid?
-          raise ArgumentError, errors.full_messages.join(", ")
-        end
+        validate
       end
 
       def as_json(options = {})

--- a/app/models/metadata/configuration/field.rb
+++ b/app/models/metadata/configuration/field.rb
@@ -8,6 +8,7 @@ module Metadata
                     :optional_form_field, :order, :placeholder, :help, :boost, :immutable
 
       validates :name, :type, :label, :order, presence: true
+      validates :order, :boost, numericality: { only_integer: true }
       validates :type, inclusion: TYPES
 
       def initialize(

--- a/app/services/metadata/configuration_input_cleaner.rb
+++ b/app/services/metadata/configuration_input_cleaner.rb
@@ -46,7 +46,9 @@ module Metadata
 
     def ensure_int_values
       [:order, :boost].each do |key|
-        data[key] = data[key].to_i if data.has_key?(key)
+        if data.has_key?(key)
+          data[key] = Integer(data[key]) rescue data[key]
+        end
       end
     end
 

--- a/app/services/metadata/configuration_input_cleaner.rb
+++ b/app/services/metadata/configuration_input_cleaner.rb
@@ -47,7 +47,11 @@ module Metadata
     def ensure_int_values
       [:order, :boost].each do |key|
         if data.has_key?(key)
-          data[key] = Integer(data[key]) rescue data[key]
+          begin
+            data[key] = Integer(data[key])
+          rescue
+            # Leave the value as is to allow the problem to pass through to field validation
+          end
         end
       end
     end

--- a/app/services/metadata/configuration_input_cleaner.rb
+++ b/app/services/metadata/configuration_input_cleaner.rb
@@ -18,6 +18,7 @@ module Metadata
       ensure_json_fields_are_converted
       ensure_name_from_label
       ensure_boolean_values
+      ensure_int_values
 
       data
     end
@@ -40,6 +41,12 @@ module Metadata
         false
       else
         value
+      end
+    end
+
+    def ensure_int_values
+      [:order, :boost].each do |key|
+        data[key] = data[key].to_i if data.has_key?(key)
       end
     end
 

--- a/spec/controllers/v1/metadata_fields_controller_spec.rb
+++ b/spec/controllers/v1/metadata_fields_controller_spec.rb
@@ -23,6 +23,11 @@ RSpec.describe V1::MetadataFieldsController, type: :controller do
       subject
     end
 
+    it "calls Metadata::UpdateConfigurationField with an empty hash even if there are no params in order to perform validation" do
+      expect(Metadata::UpdateConfigurationField).to receive(:call).with(collection, "id", {}).and_return(true)
+      put :update, collection_id: 1, id: "id", format: :json
+    end
+
     it "uses the Metadata::UpdateConfigurationField to update the data" do
       expect(Metadata::UpdateConfigurationField).to receive(:call).with(collection, "id", params)
       subject
@@ -47,6 +52,11 @@ RSpec.describe V1::MetadataFieldsController, type: :controller do
       subject
     end
 
+    it "calls Metadata::CreateConfigurationField with an empty hash even if there are no params in order to perform validation" do
+      expect(Metadata::CreateConfigurationField).to receive(:call).with(collection, {}).and_return(true)
+      post :create, collection_id: 1, id: "id", format: :json
+    end
+
     it "uses the Metadata::CreateConfigurationField to update the data" do
       expect(Metadata::CreateConfigurationField).to receive(:call).with(collection, params)
       subject
@@ -57,9 +67,9 @@ RSpec.describe V1::MetadataFieldsController, type: :controller do
       subject
     end
 
-    it "renders the status in the json response if the save succeeds" do
+    it "renders success if the save succeeds" do
       subject
-      expect(JSON.parse(response.body)).to include("status" => "success")
+      expect(response.status).to eq(200)
     end
 
     it "renders the new field in the json response if the save succeeds" do
@@ -67,10 +77,10 @@ RSpec.describe V1::MetadataFieldsController, type: :controller do
       expect(JSON.parse(response.body)).to include("field" => true)
     end
 
-    it "returns the status in the json response if the save fails" do
+    it "returns unprocessable entity if the save fails" do
       allow(Metadata::CreateConfigurationField).to receive(:call).with(collection, params).and_return(false)
       subject
-      expect(JSON.parse(response.body)).to include("status" => "unprocessable_entity")
+      expect(response.status).to eq(422)
     end
 
     it "returns the field params in the json response if the save fails" do

--- a/spec/models/metadata/configuration/field_spec.rb
+++ b/spec/models/metadata/configuration/field_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe Metadata::Configuration::Field do
 
     [:order, :boost].each do |key|
       it "validates #{key} is an integer" do
-        expect(subject.update("#{key}" => nil)).to be(false)
+        expect(subject.update(key => nil)).to be(false)
         expect(subject).to have_at_least(1).errors_on(key)
         expect(subject.errors.messages[key]).to include("is not a number")
       end

--- a/spec/models/metadata/configuration/field_spec.rb
+++ b/spec/models/metadata/configuration/field_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Metadata::Configuration::Field do
 
     it "cannot be an unknown type" do
       data[:type] = :fake_type
-      expect { subject }.to raise_error(ArgumentError)
+      expect(subject.valid?).to eq(false)
     end
   end
 

--- a/spec/models/metadata/configuration/field_spec.rb
+++ b/spec/models/metadata/configuration/field_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Metadata::Configuration::Field do
       help: "help",
       default_form_field: true,
       optional_form_field: false,
-      order: true,
+      order: 1,
       immutable: []
     }
   end
@@ -123,7 +123,7 @@ RSpec.describe Metadata::Configuration::Field do
     end
   end
 
-  context "validataions" do
+  context "validations" do
     it "validates the presence of a name" do
       subject.name = nil
       expect(subject).to have(1).errors_on(:name)
@@ -141,7 +141,16 @@ RSpec.describe Metadata::Configuration::Field do
 
     it "validates the presence of order" do
       expect(subject.update(order: nil)).to be(false)
-      expect(subject).to have(1).errors_on(:order)
+      expect(subject).to have_at_least(1).errors_on(:order)
+      expect(subject.errors.messages[:order]).to include("can't be blank")
+    end
+
+    [:order, :boost].each do |key|
+      it "validates #{key} is an integer" do
+        expect(subject.update("#{key}" => nil)).to be(false)
+        expect(subject).to have_at_least(1).errors_on(key)
+        expect(subject.errors.messages[key]).to include("is not a number")
+      end
     end
   end
 
@@ -221,7 +230,7 @@ RSpec.describe Metadata::Configuration::Field do
         required: false,
         default_form_field: true,
         optional_form_field: false,
-        order: true,
+        order: 1,
         placeholder: "placeholder",
         help: "help",
         boost: 1,

--- a/spec/models/metadata/configuration_spec.rb
+++ b/spec/models/metadata/configuration_spec.rb
@@ -3,8 +3,8 @@ require "rails_helper"
 RSpec.describe Metadata::Configuration do
   let(:field_data) do
     [
-      { name: "string_field", type: "string", label: "String", default_form_field: true, optional_form_field: false, order: true },
-      { name: "date_field", type: "date", label: "Date", default_form_field: true, optional_form_field: false, order: true },
+      { name: "string_field", type: "string", label: "String", default_form_field: true, optional_form_field: false, order: 0 },
+      { name: "date_field", type: "date", label: "Date", default_form_field: true, optional_form_field: false, order: 0 },
     ]
   end
   let(:facet_data) do

--- a/spec/services/metatdata/configuration_input_cleaner_spec.rb
+++ b/spec/services/metatdata/configuration_input_cleaner_spec.rb
@@ -51,4 +51,31 @@ RSpec.describe Metadata::ConfigurationInputCleaner do
       expect(subject).to eq(key => false)
     end
   end
+
+  [:order, :boost].each do |key|
+    it "retains the value if #{key} is already an integer" do
+      data[key] = 10
+      expect(subject).to eq(key => 10)
+    end
+
+    it "converts string \"integer\" types for #{key} to int" do
+      data[key] = "1"
+      expect(subject).to eq(key => 1)
+    end
+
+    it "does not convert the empty string for #{key}" do
+      data[key] = ""
+      expect(subject).to eq(key => "")
+    end
+
+    it "does not convert a non numeric string for #{key}" do
+      data[key] = "1 - This is not a number"
+      expect(subject).to eq(key => "1 - This is not a number")
+    end
+
+    it "does not convert #{key} if it's not a string" do
+      data[key] = { k: 1 }
+      expect(subject).to eq(key => { k: 1 })
+    end
+  end
 end


### PR DESCRIPTION
Why: After making a change (such as deactivating) a configuration field, subsequent calls to create a new field would fail.
How: 
-The configuration properties "boost" and "order" are assumed to be integers, but the config update is receiving these as strings. Changed the input cleaner to convert stringified integers such as "15", but not things like "15abc". 
-Changed the validation to ensure boost and order are integers. This way if anything gets passed other than a basic integer that's been stringified, it will throw a validation error back to the app that posted the update.
-Separated create/update actions so that create can stop passing values for the properties that have none, this way the api can properly perform validation on all data passed in.