### PR TITLE
DEC-815: Cannot delete a collection

### DIFF
--- a/app/services/destroy/collection.rb
+++ b/app/services/destroy/collection.rb
@@ -2,7 +2,8 @@ module Destroy
   class Collection
 
     # Allow injecting destroy objects to use when cascading
-    def initialize(destroy_collection_user: nil, destroy_showcase: nil, destroy_item: nil, destroy_page: nil)
+    def initialize(destroy_collection_configuration: nil, destroy_collection_user: nil, destroy_showcase: nil, destroy_item: nil, destroy_page: nil)
+      @destroy_collection_configuration = destroy_collection_configuration || Destroy::CollectionConfiguration.new
       @destroy_collection_user = destroy_collection_user || Destroy::CollectionUser.new
       @destroy_showcase = destroy_showcase || Destroy::Showcase.new
       @destroy_item = destroy_item || Destroy::Item.new
@@ -28,6 +29,9 @@ module Destroy
         end
         collection.pages.each do |child|
           @destroy_page.cascade!(page: child)
+        end
+        if collection.collection_configuration
+          @destroy_collection_configuration.cascade!(collection_configuration: collection.collection_configuration)
         end
         collection.destroy!
       end

--- a/app/services/destroy/collection_configuration.rb
+++ b/app/services/destroy/collection_configuration.rb
@@ -1,0 +1,14 @@
+module Destroy
+  class CollectionConfiguration
+    # Destroy the object only
+    def destroy!(collection_configuration:)
+      collection_configuration.destroy!
+    end
+
+    # There are no additional cascades for CollectionConfiguration,
+    # so destroys the object only
+    def cascade!(collection_configuration:)
+      collection_configuration.destroy!
+    end
+  end
+end

--- a/spec/controllers/admin/external_collections_controller_spec.rb
+++ b/spec/controllers/admin/external_collections_controller_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Admin::ExternalCollectionsController, type: :controller do
                     id: 1,
                     name_line_1: "COLLECTION",
                     destroy!: true,
+                    collection_configuration: nil,
                     collection_users: [],
                     showcases: [],
                     pages: [],

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 require "cache_spec_helper"
 
 RSpec.describe CollectionsController, type: :controller do
-  let(:collection) { instance_double(Collection, id: 1, name_line_1: "COLLECTION", destroy!: true, collection_users: [], showcases: [], pages: [], items: []) }
+  let(:collection) { instance_double(Collection, id: 1, name_line_1: "COLLECTION", destroy!: true, collection_configuration: nil, collection_users: [], showcases: [], pages: [], items: []) }
 
   let(:create_params) { { collection: { name_line_1: "TITLE!!" } } }
   let(:update_params) { { id: "1", published: true, collection: { name_line_1: "TITLE!!" } } }

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -2,7 +2,17 @@ require "rails_helper"
 require "cache_spec_helper"
 
 RSpec.describe CollectionsController, type: :controller do
-  let(:collection) { instance_double(Collection, id: 1, name_line_1: "COLLECTION", destroy!: true, collection_configuration: nil, collection_users: [], showcases: [], pages: [], items: []) }
+  let(:collection) do
+    instance_double(Collection,
+                    id: 1,
+                    name_line_1: "COLLECTION",
+                    destroy!: true,
+                    collection_configuration: nil,
+                    collection_users: [],
+                    showcases: [],
+                    pages: [],
+                    items: [])
+  end
 
   let(:create_params) { { collection: { name_line_1: "TITLE!!" } } }
   let(:update_params) { { id: "1", published: true, collection: { name_line_1: "TITLE!!" } } }

--- a/spec/factories/collection_configuration.rb
+++ b/spec/factories/collection_configuration.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :collection_configuration do |cc|
+    cc.id { 1 }
+    cc.collection_id { 1 }
+    cc.metadata { "{}" }
+  end
+end

--- a/spec/services/destroy/collection_configuration_spec.rb
+++ b/spec/services/destroy/collection_configuration_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+describe Destroy::CollectionConfiguration do
+  let(:collection_configuration) { instance_double(CollectionConfiguration) }
+
+  describe "#destroy" do
+    it "destroys the CollectionConfiguration" do
+      expect(collection_configuration).to receive(:destroy!)
+      subject.destroy!(collection_configuration: collection_configuration)
+    end
+  end
+
+  describe "#cascade" do
+    it "destroys the CollectionConfiguration" do
+      expect(collection_configuration).to receive(:destroy!)
+      subject.cascade!(collection_configuration: collection_configuration)
+    end
+  end
+
+  context "cascade transaction" do
+    let(:collection) { FactoryGirl.create(:collection) }
+    let(:collection_configuration) { FactoryGirl.create(:collection_configuration) }
+
+    # Ensures all data that was created still exists
+    # in the database
+    def data_still_exists!
+      expect { collection_configuration.reload }.not_to raise_error
+    end
+
+    it "rolls back if an error occurs with CollectionConfiguration.destroy!" do
+      collection
+      allow(collection_configuration).to receive(:destroy!).and_raise("error")
+      expect { subject.cascade!(collection_configuration: collection_configuration) }.to raise_error("error")
+      data_still_exists!
+    end
+  end
+end


### PR DESCRIPTION
Why: Throws an exception due to foreign key constraint on the associated collection configuration.
How: Added a destroy service for collection config and changed DestroyCollection to use this new service to delete the associated config on cascade delete.