### PR TITLE
DEC-864, DEC-840: Cannot insert image into page

### DIFF
--- a/app/assets/javascripts/imagemanager.js
+++ b/app/assets/javascripts/imagemanager.js
@@ -96,8 +96,8 @@
               if (typeof image == 'object')
               {
                 var img = $('<img src="' +
-                  image['thumbnail/small']['contentUrl'] +
-                  '" rel="' + image['thumbnail/medium']['contentUrl'] +
+                  image['thumbnail/small'].contentUrl +
+                  '" rel="' + image['thumbnail/medium'].contentUrl +
                   '" item_id="' + val.id +
                   '"title="' + thumbtitle +
                   '" style="width: 100px; height: 75px; cursor: pointer;" />');

--- a/app/assets/javascripts/imagemanager.js
+++ b/app/assets/javascripts/imagemanager.js
@@ -73,7 +73,8 @@
 
         var csrfMeta = document.querySelector('meta[name="csrf-token"]');
         var csrfToken = csrfMeta && csrfMeta.getAttribute('content');
-        var authenticityToken = $('<input type="hidden" id="image_upload_auth_token" name="request_forgery_protection_token" value="' + csrfToken + '" >');
+        var authenticityToken = $('<input type="hidden" id="image_upload_auth_token" name="request_forgery_protection_token" value="' +
+                                  csrfToken + '" >');
         $modal.append(authenticityToken);
 
         $.ajax({
@@ -94,7 +95,12 @@
               var image = val.image;
               if (typeof image == 'object')
               {
-                var img = $('<img src="' + image['thumbnail/small']['contentUrl'] + '" rel="' + image['thumbnail/medium']['contentUrl'] + '" item_id="' + val.id + '"title="' + thumbtitle + '" style="width: 100px; height: 75px; cursor: pointer;" />');
+                var img = $('<img src="' +
+                  image['thumbnail/small']['contentUrl'] +
+                  '" rel="' + image['thumbnail/medium']['contentUrl'] +
+                  '" item_id="' + val.id +
+                  '"title="' + thumbtitle +
+                  '" style="width: 100px; height: 75px; cursor: pointer;" />');
                 $('#redactor-image-manager-box').append(img);
                 $(img).click($.proxy(this.imagemanager.insert, this));
               }


### PR DESCRIPTION
DEC-864:
-Temporarily disabled the ability to shortcut creating items via the insert image tool. This does not work correctly when background processing is enabled.
DEC-840:
-Also found a fix to the redactor reverting the changes after inserting an image. The insert.html seems to work better, and there were a few calls that insert.node was missing compared to insert.html.