### PR TITLE
DEC-892 Initial script to cache vatican data

### DIFF
--- a/lib/scripts/cache_data.sh
+++ b/lib/scripts/cache_data.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+PROJECT=csthr
+BUCKET=${PROJECT}.library.nd.edu
+ENV_ALIAS=honeycombpprd-vm
+
+cd ./public/cache_data
+
+curl -o cst_data.json https://${ENV_ALIAS}.library.nd.edu/v1/collections/vatican/items
+curl -o ihrl_data.json https://${ENV_ALIAS}library.nd.edu/v1/collections/humanrights/items
+
+aws s3 mb s3://${BUCKET}
+aws s3 website s3://${BUCKET} --index-document index.html --error-document index.html
+aws s3 sync . s3://${BUCKET} --exclude '.*' --exclude '*.md' --delete --acl public-read
+
+echo ${BUCKET}.s3-website-us-east-1.amazonaws.com


### PR DESCRIPTION
What: Created script that grabs the collection data from the CST and IHRL collections and deposits those files into the S3 bucket for consumption.
Why: In order to speed up the initial load process for the search interface of the CCHR research database.