### PR TITLE
Update solr query parser

### DIFF
--- a/app/models/waggle/adapters/solr/search/result.rb
+++ b/app/models/waggle/adapters/solr/search/result.rb
@@ -58,6 +58,7 @@ module Waggle
               fq: solr_filters,
               sort: solr_sort,
               facet: true,
+              defType: "edismax",
               :"facet.field" => facet_fields,
             }
           end

--- a/solr/configsets/honeycomb/conf/solrconfig.xml
+++ b/solr/configsets/honeycomb/conf/solrconfig.xml
@@ -69,7 +69,7 @@
          will be overridden by parameters in the request
       -->
      <lst name="defaults">
-       <str name="defType">dismax</str>
+       <str name="defType">edismax</str>
        <str name="echoParams">explicit</str>
        <int name="rows">10</int>
 

--- a/spec/models/waggle/adapters/solr/search/result_spec.rb
+++ b/spec/models/waggle/adapters/solr/search/result_spec.rb
@@ -80,6 +80,7 @@ RSpec.describe Waggle::Adapters::Solr::Search::Result do
         pf: "phrase_fields",
         sort: "score desc",
         facet: true,
+        defType: "edismax",
         :"facet.field" => [
           "{!ex=creator_facet}creator_facet",
         ]


### PR DESCRIPTION
Changes the Query Parser to edismax which lets us use and AND and OR.   

Also it is in 2 places eventually I would remove the call in the Result Class eventually.  It allows me to switch the query type with out restarting solr which is currently a little bit of a pain.  