### PR TITLE
DEC-913: Change default search to OR (3.0)

### DIFF
--- a/app/models/waggle/adapters/solr/search/result.rb
+++ b/app/models/waggle/adapters/solr/search/result.rb
@@ -59,6 +59,7 @@ module Waggle
               sort: solr_sort,
               facet: true,
               :"facet.field" => facet_fields,
+              mm: 1,
             }
           end
 

--- a/solr/configsets/honeycomb/conf/solrconfig.xml
+++ b/solr/configsets/honeycomb/conf/solrconfig.xml
@@ -74,7 +74,7 @@
        <int name="rows">10</int>
 
        <str name="q.alt">*:*</str>
-       <str name="mm">2&lt;-1 5&lt;-2 6&lt;90%</str>
+       <str name="mm">1</str>
 
        <!-- this qf and pf are used by default, if not otherwise specified by
             client. The default blacklight_config will use these for the

--- a/spec/models/waggle/adapters/solr/search/result_spec.rb
+++ b/spec/models/waggle/adapters/solr/search/result_spec.rb
@@ -76,6 +76,7 @@ RSpec.describe Waggle::Adapters::Solr::Search::Result do
         q: "query",
         fl: "score *",
         fq: [],
+        mm: 1,
         qf: "query_fields",
         pf: "phrase_fields",
         sort: "score desc",


### PR DESCRIPTION
Why: For our purposes, search needs to default to OR when given terms separated by space.
How: Changed the mm param to solr to 1. This effectively works as an OR operator between optional terms. Things like +term or -term, or "term AND term" are all still obeyed.

For more info on the mm param, see: [The mm (Minimum Should Match) Parameter](https://cwiki.apache.org/confluence/display/solr/The+DisMax+Query+Parser#TheDisMaxQueryParser-Themm(MinimumShouldMatch)Parameter)