### PR TITLE
Dec 925 fix for promise bug

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -29,4 +29,5 @@
 //= require menu-bar
 //= require flash
 //= require jquery.cookie
+require('es6-promise').polyfill();
 window.$ = window.jQuery = require('jquery');

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -2,3 +2,14 @@
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile", __FILE__)
 
 require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
+
+require 'rails/commands/server'
+
+module Rails
+  class Server
+    alias :default_options_bk :default_options
+    def default_options
+      default_options_bk.merge!(Host: '0.0.0.0')
+    end
+  end
+end

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -3,13 +3,13 @@ ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile", __FILE__)
 
 require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
 
-require 'rails/commands/server'
+require "rails/commands/server"
 
 module Rails
   class Server
     alias :default_options_bk :default_options
     def default_options
-      default_options_bk.merge!(Host: '0.0.0.0')
+      default_options_bk.merge!(Host: "0.0.0.0")
     end
   end
 end

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "browserify": "6.3.4",
     "browserify-incremental": "1.5.0",
     "classnames": "2.2.3",
+    "es6-promise": "^3.1.2",
     "eventemitter": "0.3.3",
     "flux": "2.1.1",
     "jquery": "2.2.0",


### PR DESCRIPTION
What: A bug was discovered related to the use of the Axios javascript library, only on IE and specifically IE 11. IE does not recognize the Promise object as having been defined.
How: Added a new module to NPM called 'es6-promise', which provides a polyfill back port that forces IE 10 and later to recognize the Promise definition.

**Note**: IE 10 and later also no longer recognize the comment conditionals (e.g. '[if IE]') so compensating javascript can no longer be included in the head of the document to correct IE compatibility issues

**ALSO**: Added an override to force Webrick to bind to IP address 0.0.0.0 to make it easier to debug from local VMs accessing Webrick running in the native OS