### PR TITLE
DEC-934 Fix for changed external collection attr

### DIFF
--- a/app/assets/javascripts/components/forms/ExternalCollectionForm.jsx
+++ b/app/assets/javascripts/components/forms/ExternalCollectionForm.jsx
@@ -72,7 +72,7 @@ var ExternalCollectionForm = React.createClass({
           <PanelBody>
               <StringField objectType={this.props.objectType} name="name_line_1" required={true} title="Name" value={this.state.formValues.name_line_1} handleFieldChange={this.handleFieldChange} errorMsg={this.fieldError('name_line_1')} />
               <StringField objectType={this.props.objectType} name="url" required={true} title="URL" value={this.state.formValues.url} handleFieldChange={this.handleFieldChange} errorMsg={this.fieldError('url')} />
-              <HtmlField objectType={this.props.objectType} name="description" title="Description" value={this.state.formValues.description} handleFieldChange={this.handleFieldChange} errorMsg={this.fieldError('description')} placeholder="Example: This is an collection external to the honeycomb system" />
+              <HtmlField objectType={this.props.objectType} name="about" title="Description" value={this.state.formValues.about} handleFieldChange={this.handleFieldChange} errorMsg={this.fieldError('about')} placeholder="Example: This is an collection external to the honeycomb system" />
               {this.thumbnailImage()}
               <UploadFileField objectType={this.props.objectType} name="uploaded_image" title="Image" handleFieldChange={this.handleFieldChange} errorMsg={this.fieldError('image')} />
           </PanelBody>

--- a/app/controllers/admin/external_collections_controller.rb
+++ b/app/controllers/admin/external_collections_controller.rb
@@ -59,7 +59,7 @@ module Admin
     def save_params
       params.require(:external_collection).permit(
         :name_line_1,
-        :description,
+        :about,
         :id,
         :url,
         :uploaded_image,

--- a/app/views/admin/external_collections/_form.html.erb
+++ b/app/views/admin/external_collections/_form.html.erb
@@ -4,7 +4,7 @@
   data: {
     name_line_1: @external_collection.name_line_1,
     url: @external_collection.url,
-    description: @external_collection.description,
+    about: @external_collection.about,
     image: @external_collection.image
   },
   url: @form_action,

--- a/app/views/admin/external_collections/_list.html.erb
+++ b/app/views/admin/external_collections/_list.html.erb
@@ -36,7 +36,7 @@
           <a href="<%= raw collection.url %>"><%= raw collection.url %></a>
         </td>
         <td>
-          <%= raw collection.description %>
+          <%= raw collection.about %>
         </td>
         <td>
           <a className="remove-external-collection"


### PR DESCRIPTION
What: The attributes for collections and thus external collections changed and the description attr was deprecated. That needed to be corrected for the related forms and lists to work related to external collections.
How: I changed the attribute reference to 'about' instead of 'description' and updated the appropriate code and view pages to reflect that.