### PR TITLE
DEC-928 Fix for Safari onClick bug for metadata button

### DIFF
--- a/app/assets/javascripts/components/forms/MetaDataConfigurationForm.jsx
+++ b/app/assets/javascripts/components/forms/MetaDataConfigurationForm.jsx
@@ -190,7 +190,7 @@ var MetaDataConfigurationForm = React.createClass({
         <Toolbar>
           <ToolbarTitle style={{ paddingLeft: "48px" }} text={ this.getListTitle() } />
           <ToolbarGroup float="left">
-            <FloatingActionButton onClick={ this.handleNewClick } mini={true} style={ this.addButtonStyle() }>
+            <FloatingActionButton onMouseDown={ this.handleNewClick } onTouchStart={ this.handleNewClick } mini={true} style={ this.addButtonStyle() }>
               <ContentAdd />
             </FloatingActionButton>
           </ToolbarGroup>


### PR DESCRIPTION
What: There is a bug related to Safari in material-ui that short circuits the on click events for certain components and forces the user to click the element twice for the event to fire.
How: Instead of using onClick(), I changed the component in question so that it uses onMouseDown() coupled with onTouchStart() for touch screen devices.