### PR TITLE
DEC-950 (v3.0): Creating a new item does not show thumbnail on search

### DIFF
--- a/spec/services/save_honeypot_image_spec.rb
+++ b/spec/services/save_honeypot_image_spec.rb
@@ -82,6 +82,18 @@ RSpec.describe SaveHoneypotImage do
         expect(item).not_to receive(:image_status=)
         subject
       end
+
+      it "reindexes the object if it's an Item" do
+        allow(item).to receive(:model_name).and_return("Item")
+        expect(Index::Item).to receive(:index!).with(item)
+        subject
+      end
+
+      it "does not reindex the object if it's not an Item" do
+        allow(item).to receive(:model_name).and_return("Something else")
+        expect(Index::Item).not_to receive(:index!).with(item)
+        subject
+      end
     end
   end
 


### PR DESCRIPTION
Added special handling of items after a honeypot job successfully saves. It will now reindex the item since the indexed doc depends on the thumbnail generated by honeypot.