### PR TITLE
Dec 927 fix cache expiration metadata fields

### DIFF
--- a/app/values/cache_keys/custom/v1_items.rb
+++ b/app/values/cache_keys/custom/v1_items.rb
@@ -3,15 +3,15 @@ module CacheKeys
     # Generator for v1/items_controller
     class V1Items
       def index(collection:)
-        CacheKeys::ActiveRecord.new.generate(record: [collection, collection.items])
+        CacheKeys::ActiveRecord.new.generate(record: [collection, collection.items, collection.collection_configuration])
       end
 
       def show(item:)
-        CacheKeys::ActiveRecord.new.generate(record: [item, item.collection, item.children])
+        CacheKeys::ActiveRecord.new.generate(record: [item, item.collection, item.children, item.collection.collection_configuration])
       end
 
       def showcases(item:)
-        CacheKeys::ActiveRecord.new.generate(record: [item, item.collection, item.showcases])
+        CacheKeys::ActiveRecord.new.generate(record: [item, item.collection, item.showcases, item.collection.collection_configuration])
       end
     end
   end

--- a/spec/controllers/v1/items_controller_spec.rb
+++ b/spec/controllers/v1/items_controller_spec.rb
@@ -2,8 +2,9 @@ require "rails_helper"
 require "cache_spec_helper"
 
 RSpec.describe V1::ItemsController, type: :controller do
-  let(:collection) { instance_double(Collection, id: "1", updated_at: nil, items: nil) }
-  let(:item) { instance_double(Item, id: "1", collection: nil, children: nil) }
+  let(:collection_configuration) { CollectionConfiguration.new }
+  let(:collection) { instance_double(Collection, id: "1", updated_at: nil, items: nil, collection_configuration: collection_configuration) }
+  let(:item) { instance_double(Item, id: "1", collection: collection, children: nil) }
 
   before(:each) do
     allow_any_instance_of(ItemQuery).to receive(:public_find).and_return(item)
@@ -63,7 +64,8 @@ RSpec.describe V1::ItemsController, type: :controller do
   end
 
   describe "PUT #update" do
-    let(:collection) { double(Collection, id: "1") }
+    let(:collection_configuration) { CollectionConfiguration.new }
+    let(:collection) { double(Collection, id: "1", collection_configuration: collection_configuration) }
     let(:item) { instance_double(Item, id: 1, parent: nil, collection: collection) }
     let(:update_params) { { format: :json, id: item.id, item: { name: "item" } } }
     let(:base_config) do
@@ -127,7 +129,8 @@ RSpec.describe V1::ItemsController, type: :controller do
   end
 
   describe "#create" do
-    let(:collection) { Collection.new(unique_id: "test", items: []) }
+    let(:collection_configuration) { CollectionConfiguration.new }
+    let(:collection) { Collection.new(unique_id: "test", items: [], collection_configuration: collection_configuration) }
     let(:item) { Item.new(id: 1, unique_id: "test", collection: collection) }
     let(:image) { double(path: Rails.root.join("spec/fixtures/test.jpg").to_s, content_type: "image/jpeg") }
     let(:image_params) { { collection_id: "test", item: { uploaded_image: fixture_file_upload("test.jpg", "image/jpeg", :binary) }, format: :json } }
@@ -165,8 +168,10 @@ RSpec.describe V1::ItemsController, type: :controller do
   end
 
   describe "#showcases" do
+    let(:collection_configuration) { CollectionConfiguration.new }
+    let(:collection) { Collection.new(unique_id: "test", items: [], collection_configuration: collection_configuration) }
     subject { get :showcases, item_id: "id", format: :json }
-    let(:item) { instance_double(Item, id: "1", collection: nil, children: nil, showcases: nil) }
+    let(:item) { instance_double(Item, id: "1", collection: collection, children: nil, showcases: nil) }
 
     it "calls ItemQuery" do
       expect_any_instance_of(ItemQuery).to receive(:public_find).with("id").and_return(item)

--- a/spec/values/cache_keys/custom/v1_items_spec.rb
+++ b/spec/values/cache_keys/custom/v1_items_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe CacheKeys::Custom::V1Items do
   context "index" do
-    let(:collection) { instance_double(Collection, items: "items") }
+    let(:collection) { instance_double(Collection, items: "items", collection_configuration: "config") }
 
     it "uses CacheKeys::ActiveRecord" do
       expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate)
@@ -10,13 +10,14 @@ RSpec.describe CacheKeys::Custom::V1Items do
     end
 
     it "uses the correct data" do
-      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with(record: [collection, "items"])
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with(record: [collection, "items", "config"])
       subject.index(collection: collection)
     end
   end
 
   context "show" do
-    let(:item) { instance_double(Item, collection: "collection", children: "children") }
+    let(:collection) { instance_double(Collection, items: "items", collection_configuration: "config") }
+    let(:item) { instance_double(Item, collection: collection, children: "children") }
 
     it "uses CacheKeys::ActiveRecord" do
       expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate)
@@ -24,13 +25,14 @@ RSpec.describe CacheKeys::Custom::V1Items do
     end
 
     it "uses the correct data" do
-      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with(record: [item, "collection", "children"])
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with(record: [item, collection, "children", "config"])
       subject.show(item: item)
     end
   end
 
   context "showcases" do
-    let(:item) { instance_double(Item, collection: "collection", children: "children", showcases: "showcases") }
+    let(:collection) { instance_double(Collection, items: "items", collection_configuration: "config") }
+    let(:item) { instance_double(Item, collection: collection, children: "children", showcases: "showcases") }
 
     it "uses CacheKeys::ActiveRecord" do
       expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate)
@@ -38,7 +40,7 @@ RSpec.describe CacheKeys::Custom::V1Items do
     end
 
     it "uses the correct data" do
-      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with(record: [item, "collection", "showcases"])
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with(record: [item, collection, "showcases", "config"])
       subject.showcases(item: item)
     end
   end


### PR DESCRIPTION
What: Cache was persisting for items when metadata fields were changed at the collection level. The metadata configuration was added as a changeable object to the item level caching methods on the V1 API.
How: Added the configuration as a potential mutable object in generating the cache keys. Also updated tests to account for the presence of the collection_configuration() on collection objects.