### PR TITLE
DEC-648 (v3.0): Honeycomb collection list with large collections is slow

### DIFF
--- a/app/decorators/collection_image.rb
+++ b/app/decorators/collection_image.rb
@@ -6,7 +6,9 @@ class CollectionImage
   end
 
   def display
-    if first_item_with_image
+    if collection.honeypot_image
+      HoneypotThumbnail.display(collection.honeypot_image)
+    elsif first_item_with_image
       HoneypotThumbnail.display(first_item_with_image.honeypot_image)
     else
       ""
@@ -16,6 +18,6 @@ class CollectionImage
   private
 
   def first_item_with_image
-    @first_item_with_image ||= collection.items.find(&:honeypot_image)
+    @first_item_with_image ||= collection.items.joins(:honeypot_image).first
   end
 end

--- a/spec/decorators/collection_image_spec.rb
+++ b/spec/decorators/collection_image_spec.rb
@@ -3,34 +3,39 @@ require "rails_helper"
 RSpec.describe CollectionImage do
   subject { described_class.new(collection) }
 
-  let(:collection) { instance_double(Collection, id: 2) }
-
+  let(:collection) { instance_double(Collection, id: 2, honeypot_image: collection_image, items: items) }
+  let(:image) { instance_double(ActiveRecord::AssociationRelation, first: item_with_image) }
+  let(:items) { instance_double(ActiveRecord::Associations::CollectionProxy, joins: image) }
   let(:item_with_image) { double(Item, honeypot_image: honeypot_image) }
   let(:item_with_no_image) { double(Item, honeypot_image: nil) }
-
+  let(:collection_image) { double(HoneypotImage, url: "http://image.collection.com/image", image_json: { contentUrl: "http://collection.com/image.jpg" }) }
   let(:honeypot_image) { double(HoneypotImage, url: "http://image.image.com/image", image_json: { contentUrl: "http://example.com/image.jpg" }) }
 
   it "uses the item decorator to call the image display" do
-    allow(collection).to receive(:items).and_return([item_with_image])
-
+    allow(image).to receive(:first).and_return(item_with_image)
     expect_any_instance_of(HoneypotThumbnail).to receive(:display)
     subject.display
   end
 
-  it "dislpays the first image found" do
-    allow(collection).to receive(:items).and_return([item_with_image])
-
-    expect(subject.display).to eq("<div data-react-class=\"Thumbnail\" data-react-props=\"{&quot;image&quot;:{&quot;contentUrl&quot;:&quot;http://example.com/image.jpg&quot;}}\"></div>")
+  it "displays the first image found if the collection has none" do
+    allow(collection).to receive(:honeypot_image).and_return(nil)
+    expect(subject.display).to eq("<div " \
+      "data-react-class=\"Thumbnail\" " \
+      "data-react-props=\"{&quot;image&quot;:{&quot;contentUrl&quot;:&quot;http://example.com/image.jpg&quot;}}\">" \
+      "</div>")
   end
 
-  it "displays the second image if the first item does not have an image" do
-    allow(collection).to receive(:items).and_return([item_with_no_image, item_with_image])
-
-    expect(subject.display).to eq("<div data-react-class=\"Thumbnail\" data-react-props=\"{&quot;image&quot;:{&quot;contentUrl&quot;:&quot;http://example.com/image.jpg&quot;}}\"></div>")
+  it "displays the collection image even if an item has an image" do
+    allow(image).to receive(:first).and_return(item_with_image)
+    expect(subject.display).to eq("<div " \
+      "data-react-class=\"Thumbnail\" " \
+      "data-react-props=\"{&quot;image&quot;:{&quot;contentUrl&quot;:&quot;http://collection.com/image.jpg&quot;}}\">" \
+      "</div>")
   end
 
   it "displays nothing if there are no images" do
-    allow(collection).to receive(:items).and_return([])
+    allow(image).to receive(:first).and_return(nil)
+    allow(collection).to receive(:honeypot_image).and_return(nil)
 
     expect(subject.display).to eq("")
   end


### PR DESCRIPTION
Problem was with how it was finding a thumbnail to use. Changed it to use the collection image if it has one. If none is available, it will find the first item that has a honeypot image via a query instead of a block test.