### PR TITLE
DEC-927: Metadata field cache bug

### DIFF
--- a/app/values/cache_keys/custom/v1_pages.rb
+++ b/app/values/cache_keys/custom/v1_pages.rb
@@ -9,6 +9,7 @@ module CacheKeys
       def show(page:)
         CacheKeys::ActiveRecord.new.generate(record: [page.object,
                                                       page.collection,
+                                                      page.collection.collection_configuration,
                                                       page.items,
                                                       page.next])
       end

--- a/app/values/cache_keys/custom/v1_sections.rb
+++ b/app/values/cache_keys/custom/v1_sections.rb
@@ -9,6 +9,7 @@ module CacheKeys
                                                       decorated_section.next,
                                                       decorated_section.previous,
                                                       decorated_section.collection,
+                                                      decorated_section.collection.collection_configuration,
                                                       decorated_section.showcase])
       end
     end

--- a/app/values/cache_keys/custom/v1_showcases.rb
+++ b/app/values/cache_keys/custom/v1_showcases.rb
@@ -9,6 +9,7 @@ module CacheKeys
       def show(showcase:)
         CacheKeys::ActiveRecord.new.generate(record: [showcase.object,
                                                       showcase.collection,
+                                                      showcase.collection.collection_configuration,
                                                       showcase.sections,
                                                       showcase.items,
                                                       showcase.next])

--- a/spec/controllers/v1/pages_controller_spec.rb
+++ b/spec/controllers/v1/pages_controller_spec.rb
@@ -2,8 +2,8 @@ require "rails_helper"
 require "cache_spec_helper"
 
 RSpec.describe V1::PagesController, type: :controller do
-  let(:collection) { instance_double(Collection, id: "1", updated_at: nil, pages: nil) }
-  let(:page) { instance_double(Page, id: "1", updated_at: nil, collection: nil, items: []) }
+  let(:collection) { instance_double(Collection, id: "1", updated_at: nil, pages: nil, collection_configuration: "collection_configuration") }
+  let(:page) { instance_double(Page, id: "1", updated_at: nil, collection: collection, items: []) }
 
   before(:each) do
     allow_any_instance_of(PageQuery).to receive(:public_find).and_return(page)

--- a/spec/controllers/v1/sections_controller_spec.rb
+++ b/spec/controllers/v1/sections_controller_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 require "cache_spec_helper"
 
 RSpec.describe V1::SectionsController, type: :controller do
-  let(:collection) { instance_double(Collection, id: "1") }
+  let(:collection) { instance_double(Collection, id: "1", collection_configuration: "collection_configuration") }
   let(:item) { instance_double(Item, id: "1", children: nil) }
-  let(:section) { instance_double(Section, id: "1", updated_at: nil, item: item, collection: nil, showcase: nil) }
+  let(:section) { instance_double(Section, id: "1", updated_at: nil, item: item, collection: collection, showcase: nil) }
 
   before(:each) do
     allow_any_instance_of(SectionQuery).to receive(:public_find).and_return(section)

--- a/spec/controllers/v1/showcases_controller_spec.rb
+++ b/spec/controllers/v1/showcases_controller_spec.rb
@@ -2,8 +2,8 @@ require "rails_helper"
 require "cache_spec_helper"
 
 RSpec.describe V1::ShowcasesController, type: :controller do
-  let(:collection) { instance_double(Collection, id: "1", updated_at: nil, showcases: nil) }
-  let(:showcase) { instance_double(Showcase, id: "1", updated_at: nil, sections: nil, items: nil, collection: nil) }
+  let(:collection) { instance_double(Collection, id: "1", updated_at: nil, showcases: nil, collection_configuration: "collection_configuration") }
+  let(:showcase) { instance_double(Showcase, id: "1", updated_at: nil, sections: nil, items: nil, collection: collection) }
 
   before(:each) do
     allow_any_instance_of(ShowcaseQuery).to receive(:public_find).and_return(showcase)

--- a/spec/values/cache_keys/custom/v1_pages_spec.rb
+++ b/spec/values/cache_keys/custom/v1_pages_spec.rb
@@ -16,10 +16,11 @@ RSpec.describe CacheKeys::Custom::V1Pages do
   end
 
   context "show" do
-    let(:page) { instance_double(Page, collection: "collection", items: []) }
+    let(:collection) { instance_double(Collection, pages: "pages", collection_configuration: "collection_configuration") }
+    let(:page) { instance_double(Page, collection: collection, items: []) }
     let(:page_json) do
       instance_double(V1::PageJSONDecorator,
-                      collection: "collection",
+                      collection: collection,
                       next: "next",
                       items: [],
                       object: page)
@@ -33,7 +34,7 @@ RSpec.describe CacheKeys::Custom::V1Pages do
     it "uses the correct data" do
       expect_any_instance_of(CacheKeys::ActiveRecord).
         to receive(:generate).
-        with(record: [page, page_json.collection, page_json.items, page_json.next])
+        with(record: [page, page_json.collection, page_json.collection.collection_configuration, page_json.items, page_json.next])
       subject.show(page: page_json)
     end
   end

--- a/spec/values/cache_keys/custom/v1_sections_spec.rb
+++ b/spec/values/cache_keys/custom/v1_sections_spec.rb
@@ -2,13 +2,14 @@ require "rails_helper"
 
 RSpec.describe CacheKeys::Custom::V1Sections do
   context "show" do
+    let(:collection) { instance_double(Collection, collection_configuration: "collection_configuration") }
     let(:decorated_section) do
       method_stubs = { object: "object",
                        item: "item",
                        item_children: "item_children",
                        next: "next",
                        previous: "previous",
-                       collection: "collection",
+                       collection: collection,
                        showcase: "showcase" }
       instance_double(V1::SectionJSONDecorator, method_stubs)
     end
@@ -19,7 +20,7 @@ RSpec.describe CacheKeys::Custom::V1Sections do
     end
 
     it "uses the correct data" do
-      params = ["object", "item", "item_children", "next", "previous", "collection", "showcase"]
+      params = ["object", "item", "item_children", "next", "previous", collection, "collection_configuration", "showcase"]
       expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with(record: params)
       subject.show(decorated_section: decorated_section)
     end

--- a/spec/values/cache_keys/custom/v1_showcases_spec.rb
+++ b/spec/values/cache_keys/custom/v1_showcases_spec.rb
@@ -16,10 +16,11 @@ RSpec.describe CacheKeys::Custom::V1Showcases do
   end
 
   context "show" do
+    let(:collection) { instance_double(Collection, collection_configuration: "collection_configuration") }
     let(:showcase) { instance_double(Showcase, collection: "collection") }
     let(:showcase_json) do
       instance_double(V1::ShowcaseJSONDecorator,
-                      collection: "collection",
+                      collection: collection,
                       sections: "sections",
                       items: "items",
                       next: "next",
@@ -34,7 +35,7 @@ RSpec.describe CacheKeys::Custom::V1Showcases do
     it "uses the correct data" do
       expect_any_instance_of(CacheKeys::ActiveRecord).
         to receive(:generate).
-        with(record: [showcase, showcase_json.collection, showcase_json.sections, showcase_json.items, showcase_json.next])
+        with(record: [showcase, showcase_json.collection, collection.collection_configuration, showcase_json.sections, showcase_json.items, showcase_json.next])
       subject.show(showcase: showcase_json)
     end
   end


### PR DESCRIPTION
Page/Section/Showcase#show all also render item metadata, so they need to check the metadata configuration id/updated_at when generating etag.