### PR TITLE
DEC-1050: Metadata only icon

### DIFF
--- a/app/assets/javascripts/components/search/SearchPage.jsx
+++ b/app/assets/javascripts/components/search/SearchPage.jsx
@@ -45,7 +45,8 @@ var Styles = {
       borderRadius: "4px",
     },
     textItemIcon: {
-      fontSize: "49px"
+      fontSize: "49px",
+      color: Colors.grey600
     },
     itemName: {
       color: "#2c5882",
@@ -111,7 +112,7 @@ var SearchPage = React.createClass({
 
   getThumbnail: function(thumbnailUrl) {
     if(thumbnailUrl == null || thumbnailUrl == ""){
-      return (<mui.FontIcon  className="material-icons" style={ Styles.cells.textItemIcon }>subject</mui.FontIcon>);
+      return (<mui.FontIcon  className="material-icons" style={ Styles.cells.textItemIcon }>local_offer</mui.FontIcon>);
     }
     var reg = new RegExp( '^(.*)(\/.*)([\/].*$)', 'i' );
     var string = reg.exec(thumbnailUrl);


### PR DESCRIPTION
Changed the item listing to use the tag icon (https://design.google.com/icons/#ic_local_offer) when no image is present to signify that the item will only render metadata tags.