### PR TITLE
DEC-1039: Custom facets

### DIFF
--- a/app/models/metadata/configuration/facet.rb
+++ b/app/models/metadata/configuration/facet.rb
@@ -1,14 +1,15 @@
 module Metadata
   class Configuration
     class Facet
-      attr_reader :field, :field_name, :name, :active
+      attr_reader :field, :field_name, :name, :active, :limit
 
-      def initialize(name:, field:, field_name:, label: nil, active: true)
+      def initialize(name:, field:, field_name:, label: nil, active: true, limit: nil)
         @name = name
         @field = field
         @field_name = field_name
         @label = label
         @active = active
+        @limit = limit
       end
 
       def label

--- a/app/models/waggle/adapters/solr/search/result.rb
+++ b/app/models/waggle/adapters/solr/search/result.rb
@@ -61,7 +61,7 @@ module Waggle
               defType: "edismax",
               :"facet.field" => facet_fields,
               mm: 1,
-            }
+            }.merge(facet_limits)
           end
 
           def solr_query_fields
@@ -89,6 +89,14 @@ module Waggle
               field = "#{facet.name}_facet"
               "{!ex=#{field}}#{field}"
             end
+          end
+
+          def facet_limits
+            result = {}
+            configuration.facets.each do |facet|
+              result[:"f.#{facet.name}_facet.facet.limit"] = facet.limit if facet.limit.present?
+            end
+            result
           end
 
           def solr_sort

--- a/spec/models/metadata/configuration/facet_spec.rb
+++ b/spec/models/metadata/configuration/facet_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Metadata::Configuration::Facet do
   let(:field) { instance_double(Metadata::Configuration::Field, name: :my_field, label: "Default Label") }
-  let(:data) { { name: :my_facet, field_name: :my_field, field: field, label: "Custom Label", active: false } }
+  let(:data) { { name: :my_facet, field_name: :my_field, field: field, label: "Custom Label", active: false, limit: 462 } }
   let(:instance) { described_class.new(data) }
   subject { instance }
 
@@ -43,6 +43,17 @@ RSpec.describe Metadata::Configuration::Facet do
     it "is assumed true if not given in params" do
       data.delete(:active)
       expect(subject.active).to eq(true)
+    end
+  end
+
+  describe "limit" do
+    it "is the expected value" do
+      expect(subject.limit).to eq(data.fetch(:limit))
+    end
+
+    it "is assumed nil if not given in params" do
+      data.delete(:limit)
+      expect(subject.limit).to eq(nil)
     end
   end
 end

--- a/spec/models/waggle/adapters/solr/search/result_spec.rb
+++ b/spec/models/waggle/adapters/solr/search/result_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Waggle::Adapters::Solr::Search::Result do
     )
   end
   let(:configuration) { double(Metadata::Configuration, fields: [], facets: [facet], sort: sort) }
-  let(:facet) { double(Metadata::Configuration::Facet, name: "creator") }
+  let(:facet) { double(Metadata::Configuration::Facet, name: "creator", limit: nil) }
   let(:sort) { double(Metadata::Configuration::Sort, field_name: "name", direction: "asc") }
 
   let(:instance) { described_class.new(query: query) }
@@ -121,6 +121,18 @@ RSpec.describe Waggle::Adapters::Solr::Search::Result do
             "{!ex=creator_facet}creator_facet"
           ]
         )
+      end
+    end
+
+    describe "facet.limit" do
+      it "creates a f.facet_field.facet.limit param when a limit is present in the facet" do
+        allow(facet).to receive(:limit).and_return(462)
+        expect(subject).to include(:"f.creator_facet.facet.limit" => 462)
+      end
+
+      it "does not create a f.facet_field.facet.limit param when limit is not present in the facet" do
+        allow(facet).to receive(:limit).and_return(nil)
+        expect(subject).not_to include(:"f.creator_facet.facet.limit")
       end
     end
 


### PR DESCRIPTION
We can customize facets for any client by modifying the configuration, but currently we had no way to customize the limits that are used when displaying each facet. Changed the facet object to allow specifying a limit per facet. If none is found, it will fall back to the default in the solrconfig.xml