### PR TITLE
DEC-1040: Custom sorts

### DIFF
--- a/app/models/waggle/search/query.rb
+++ b/app/models/waggle/search/query.rb
@@ -24,18 +24,28 @@ module Waggle
 
       def sort_field
         if sort.present?
-          sort.split(" ")[0].to_sym
+          sort_sym = sort.split(" ")[0].to_sym
+          sort_field = configuration.sort(sort_sym)
+          return sort_field.field_name if sort_field.present?
+          sort_sym
         end
       end
 
       def sort_direction
         if sort.present?
+          dir = "desc"
           sort_arr = sort.split(" ")
-          return "desc" if sort_arr.length < 2
-          dir = sort_arr[1]
-          return "desc" if dir != "desc" && dir != "asc"
-          dir
+          if sort_arr.length < 2
+            sort_field = configuration.sort(sort_arr[0].to_sym)
+            return get_valid_sort_direction(sort_field.direction) if sort_field.present?
+          end
+          get_valid_sort_direction(sort_arr[1])
         end
+      end
+
+      def get_valid_sort_direction(direction)
+        return "desc" if direction != "desc" && direction != "asc"
+        direction
       end
 
       def result

--- a/app/models/waggle/search/query.rb
+++ b/app/models/waggle/search/query.rb
@@ -33,7 +33,6 @@ module Waggle
 
       def sort_direction
         if sort.present?
-          dir = "desc"
           sort_arr = sort.split(" ")
           if sort_arr.length < 2
             sort_field = configuration.sort(sort_arr[0].to_sym)

--- a/app/models/waggle/search/query.rb
+++ b/app/models/waggle/search/query.rb
@@ -34,7 +34,7 @@ module Waggle
       def sort_direction
         if sort.present?
           sort_arr = sort.split(" ")
-          if sort_arr.length < 2
+          if sort_arr.length == 1
             sort_field = configuration.sort(sort_arr[0].to_sym)
             return get_valid_sort_direction(sort_field.direction) if sort_field.present?
           end

--- a/spec/models/waggle/adapters/solr/search/result_spec.rb
+++ b/spec/models/waggle/adapters/solr/search/result_spec.rb
@@ -135,11 +135,6 @@ RSpec.describe Waggle::Adapters::Solr::Search::Result do
         allow(query).to receive(:sort).and_return("name asc")
         expect(subject).to eq("name_sort asc")
       end
-
-      it "sorts desc by default when using another configured sort" do
-        allow(query).to receive(:sort).and_return("name")
-        expect(subject).to eq("name_sort desc")
-      end
     end
 
     describe "fq" do


### PR DESCRIPTION
Why: User would like to be able to specify custom sort options, including different directions for the same field.
How: Had to reinstate the config field lookups in the sort field and sort direction calls. This will allow specifying different directions for each sort option to use by default, ex: sort name asc, but date desc. This only comes into play when the caller does not specify a direction param. If a direction is not present in the params, or the config, it will fall back to "desc" to match the default solr behavior.