### PR TITLE
Dec 1064 update item metadata saving

### DIFF
--- a/app/assets/javascripts/components/forms/ItemMetaDataForm.jsx
+++ b/app/assets/javascripts/components/forms/ItemMetaDataForm.jsx
@@ -111,9 +111,7 @@ var ItemMetaDataForm = React.createClass({
       utf8: "✓",
       _method: this.props.method,
       authenticity_token: this.props.authenticityToken,
-      item: {
-        metadata: this.state.formValues,
-      }
+      metadata: this.state.formValues,
     });
   },
 

--- a/app/controllers/v1/metadata_controller.rb
+++ b/app/controllers/v1/metadata_controller.rb
@@ -1,0 +1,22 @@
+module V1
+  # Version 1 API
+  class MetadataController < APIController
+    def update
+      @item = ItemQuery.new.public_find(params[:item_id])
+
+      return if rendered_forbidden?(@item.collection)
+
+      if SaveMetadata.call(@item, save_params)
+        render :update
+      else
+        render :errors, status: :unprocessable_entity
+      end
+    end
+
+    private
+
+    def save_params
+      params[:metadata].to_hash
+    end
+  end
+end

--- a/app/decorators/item_decorator.rb
+++ b/app/decorators/item_decorator.rb
@@ -55,7 +55,7 @@ class ItemDecorator < Draper::Decorator
     h.react_component(
       "ItemMetaDataForm",
       authenticityToken: h.form_authenticity_token,
-      url: h.v1_item_path(object.unique_id),
+      url: h.v1_item_metadata_path(object.unique_id),
       method: "put",
       data: meta_data)
   end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -44,18 +44,6 @@ class Item < ActiveRecord::Base
     raise "Use Metadata::Setter.call instead see SaveItem"
   end
 
-  def valid?(context = nil)
-    valid = super(context)
-
-    if !item_metadata.valid?
-      item_metadata.errors.each do |key, message|
-        errors[key] << message
-      end
-      valid = false
-    end
-    valid
-  end
-
   private
 
   def manuscript_url_is_valid_uri

--- a/app/models/metadata/configuration.rb
+++ b/app/models/metadata/configuration.rb
@@ -3,10 +3,6 @@ module Metadata
     attr_reader :data
     private :data
 
-    def self.set_item_configuration(collection)
-      @item_configuration ||= new(CollectionConfigurationQuery.new(collection).find)
-    end
-
     def initialize(data)
       @data = data
     end

--- a/app/services/save_item.rb
+++ b/app/services/save_item.rb
@@ -12,7 +12,6 @@ class SaveItem
 
   def save
     fix_params
-    pre_process_metadata
     item.attributes = params
     check_user_defined_id
     check_unique_id
@@ -33,13 +32,6 @@ class SaveItem
     @params = params.with_indifferent_access
     fix_image_param!
     ParamCleaner.call(hash: params)
-  end
-
-  def pre_process_metadata
-    if params[:metadata].present?
-      metadata = params.delete(:metadata)
-      Metadata::Setter.call(item, metadata)
-    end
   end
 
   def pre_process_name

--- a/app/services/save_metadata.rb
+++ b/app/services/save_metadata.rb
@@ -1,0 +1,33 @@
+class SaveMetadata
+  attr_reader :params, :item
+
+  def self.call(item, params)
+    new(item, params).save
+  end
+
+  def initialize(item, params)
+    @params = params
+    @item = item
+  end
+
+  def save
+    set_metadata
+    if valid? && item.save
+      item.item_metadata
+    else
+      false
+    end
+  end
+
+  private
+
+  def set_metadata
+    if params.present?
+      Metadata::Setter.call(item, params)
+    end
+  end
+
+  def valid?
+    item.item_metadata.valid?
+  end
+end

--- a/app/services/save_metadata.rb
+++ b/app/services/save_metadata.rb
@@ -28,9 +28,7 @@ class SaveMetadata
   end
 
   def set_metadata
-    if params.present?
-      Metadata::Setter.call(item, params)
-    end
+    Metadata::Setter.call(item, params)
   end
 
   def valid?

--- a/app/services/save_metadata.rb
+++ b/app/services/save_metadata.rb
@@ -11,6 +11,7 @@ class SaveMetadata
   end
 
   def save
+    fix_params
     set_metadata
     if valid? && item.save
       item.item_metadata
@@ -20,6 +21,11 @@ class SaveMetadata
   end
 
   private
+
+  def fix_params
+    @params = params.with_indifferent_access
+    ParamCleaner.call(hash: params)
+  end
 
   def set_metadata
     if params.present?

--- a/app/validators/metadata_validator.rb
+++ b/app/validators/metadata_validator.rb
@@ -3,6 +3,7 @@ class MetadataValidator < ActiveModel::Validator
 
   def validate(record)
     @record = record
+    @configuration = load_configuration
     validates_presence
     validate_dates
   end
@@ -28,7 +29,7 @@ class MetadataValidator < ActiveModel::Validator
   end
 
   def configuration
-    @configuration ||= CollectionConfigurationQuery.new(record.item.collection).find
+    @configuration
   end
 
   def not_present?(field, value)
@@ -55,5 +56,9 @@ class MetadataValidator < ActiveModel::Validator
     if record.errors[field] && !date.to_date
       record.errors[field] << "Invalid Date"
     end
+  end
+
+  def load_configuration
+    CollectionConfigurationQuery.new(@record.item.collection).find
   end
 end

--- a/app/views/v1/metadata/errors.json.jbuilder
+++ b/app/views/v1/metadata/errors.json.jbuilder
@@ -1,0 +1,3 @@
+# Display item with errors
+V1::ItemJSONDecorator.display(@item, json)
+json.set! "errors", @item.item_metadata.errors

--- a/app/views/v1/metadata/update.json.jbuilder
+++ b/app/views/v1/metadata/update.json.jbuilder
@@ -1,0 +1,1 @@
+V1::ItemJSONDecorator.display(@item, json)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,7 @@ Rails.application.routes.draw do
     end
 
     resources :items, only: [:index, :new, :create]
+
     resources :showcases, only: [:index, :new, :create]
     resources :pages, only: [:index, :new, :create]
 
@@ -89,6 +90,7 @@ Rails.application.routes.draw do
     resources :items,
               only: [:show, :update],
               defaults: { format: :json } do
+      resource :metadata, only: [:update]
       get :showcases, defaults: { format: :json }
     end
     resources :showcases, only: [:show], defaults: { format: :json }

--- a/spec/controllers/v1/metadata_controller_spec.rb
+++ b/spec/controllers/v1/metadata_controller_spec.rb
@@ -2,10 +2,6 @@ require "rails_helper"
 require "cache_spec_helper"
 
 RSpec.describe V1::MetadataController, type: :controller do
-  let(:collection_configuration) { CollectionConfiguration.new }
-  let(:collection) { instance_double(Collection, id: "1", updated_at: nil, items: nil, collection_configuration: collection_configuration) }
-  let(:item) { instance_double(Item, id: "1", collection: collection, children: nil) }
-
   before(:each) do
     allow_any_instance_of(ItemQuery).to receive(:public_find).and_return(item)
     allow_any_instance_of(CollectionQuery).to receive(:public_find).and_return(collection)
@@ -60,7 +56,7 @@ RSpec.describe V1::MetadataController, type: :controller do
       expect(response).to render_template("errors")
     end
 
-    it "assigns and item" do
+    it "assigns an item" do
       subject
 
       assigns(:item)

--- a/spec/controllers/v1/metadata_controller_spec.rb
+++ b/spec/controllers/v1/metadata_controller_spec.rb
@@ -1,0 +1,78 @@
+require "rails_helper"
+require "cache_spec_helper"
+
+RSpec.describe V1::MetadataController, type: :controller do
+  let(:collection_configuration) { CollectionConfiguration.new }
+  let(:collection) { instance_double(Collection, id: "1", updated_at: nil, items: nil, collection_configuration: collection_configuration) }
+  let(:item) { instance_double(Item, id: "1", collection: collection, children: nil) }
+
+  before(:each) do
+    allow_any_instance_of(ItemQuery).to receive(:public_find).and_return(item)
+    allow_any_instance_of(CollectionQuery).to receive(:public_find).and_return(collection)
+  end
+
+  describe "PUT #update" do
+    let(:collection_configuration) { CollectionConfiguration.new }
+    let(:collection) { double(Collection, id: "1", collection_configuration: collection_configuration) }
+    let(:item) { instance_double(Item, id: 1, parent: nil, collection: collection, item_metadata: double(valid?: true), metadata: {}) }
+    let(:update_params) { { format: :json, item_id: item.id, metadata: { name: "item" } } }
+    let(:base_config) do
+      c = CreateCollectionConfiguration.new("")
+      c.send(:base_config)
+    end
+    subject { put :update, update_params }
+
+    before(:each) do
+      sign_in_admin
+      allow(SaveMetadata).to receive(:call).and_return(true)
+      allow_any_instance_of(ItemQuery).to receive(:find).and_return(item)
+    end
+
+    it "checks the editor permissions" do
+      expect_any_instance_of(described_class).to receive(:user_can_edit?).with(collection)
+      subject
+    end
+
+    it "uses item query " do
+      expect_any_instance_of(ItemQuery).to receive(:public_find).with("1").and_return(item)
+      subject
+    end
+
+    it "returns ok on success" do
+      subject
+      expect(response).to be_success
+    end
+
+    it "renders the item only on success" do
+      subject
+      expect(response).to render_template("update")
+    end
+
+    it "returns unprocessable on failure" do
+      allow(SaveMetadata).to receive(:call).and_return(false)
+      subject
+      expect(response).to be_unprocessable
+    end
+
+    it "renders with errors" do
+      allow(SaveMetadata).to receive(:call).and_return(false)
+      subject
+      expect(response).to render_template("errors")
+    end
+
+    it "assigns and item" do
+      subject
+
+      assigns(:item)
+      expect(assigns(:item)).to eq(item)
+    end
+
+    it "uses the save metadata service" do
+      expect(SaveMetadata).to receive(:call).and_return(true)
+
+      subject
+    end
+
+  end
+
+end

--- a/spec/controllers/v1/metadata_controller_spec.rb
+++ b/spec/controllers/v1/metadata_controller_spec.rb
@@ -72,7 +72,5 @@ RSpec.describe V1::MetadataController, type: :controller do
 
       subject
     end
-
   end
-
 end

--- a/spec/decorators/item_decorator_spec.rb
+++ b/spec/decorators/item_decorator_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe ItemDecorator do
       expect(subject.h).to receive(:react_component).with(
         "ItemMetaDataForm",
         authenticityToken: "token",
-        url: "/v1/items/unique_id",
+        url: "/v1/items/unique_id/metadata",
         method: "put",
         data: { metadata: ["value"] }
       )

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -154,29 +154,4 @@ RSpec.describe Item do
       expect { subject.metadata = ({}) }.to raise_error
     end
   end
-
-  describe "valid?" do
-    before(:each) do
-      allow(subject).to receive(:item_metadata).and_return(item_metadata)
-    end
-
-    it "calls asks the metadata if it is valid" do
-      expect(item_metadata).to receive(:valid?).and_return(true)
-      subject.valid?
-    end
-
-    it "returns false if the item_metadata is false" do
-      allow(item_metadata).to receive(:valid?).and_return(false)
-      allow(item_metadata).to receive(:errors).and_return(name: "is required")
-      expect(subject.valid?).to be(false)
-    end
-
-    it "passes errors from the metadata to the item" do
-      expect(item_metadata).to receive(:valid?).and_return(false)
-      expect(item_metadata).to receive(:errors).and_return(name: "is required")
-      subject.valid?
-
-      expect(subject.errors[:name]).to eq(["is required"])
-    end
-  end
 end

--- a/spec/services/save_metadata_spec.rb
+++ b/spec/services/save_metadata_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+RSpec.describe SaveMetadata, type: :model do
+  subject { described_class.call(item, params) }
+  let(:item) { double(Item, item_metadata: item_metadata, save: true) }
+  let(:params) { { name: "name" } }
+  let(:item_metadata) { double(valid?: true) }
+
+  before(:each) do
+    allow(Metadata::Setter).to receive(:call).and_return(true)
+  end
+
+  it "sets the metadata with the metadata setter" do
+    expect(Metadata::Setter).to receive(:call).with(item, params).and_return(true)
+    subject
+  end
+
+  it "does not set the metadata if the params are nil" do
+    expect(Metadata::Setter).to_not receive(:call).with(params)
+    params = nil
+    subject
+  end
+
+  it "calls item#save if the item_metadata is valid? " do
+    expect(item_metadata).to receive(:valid?).and_return(true)
+    expect(item).to receive(:save).and_return(true)
+    subject
+  end
+
+  it "does not call item#save if the item_metadata is not valid?" do
+    expect(item_metadata).to receive(:valid?).and_return(false)
+    expect(item).to_not receive(:save)
+    subject
+  end
+
+  it "returns the item_metadata if the process is successful" do
+    expect(subject).to eq(item_metadata)
+  end
+
+  it "returns false if the the item_metadata is not valid?" do
+    expect(item_metadata).to receive(:valid?).and_return(false)
+    expect(subject).to eq(false)
+  end
+
+  it "returns false if the the item save is false" do
+    expect(item).to receive(:save).and_return(false)
+    expect(subject).to eq(false)
+  end
+end

--- a/spec/services/save_metadata_spec.rb
+++ b/spec/services/save_metadata_spec.rb
@@ -46,4 +46,9 @@ RSpec.describe SaveMetadata, type: :model do
     expect(item).to receive(:save).and_return(false)
     expect(subject).to eq(false)
   end
+
+  it "calls the metadata params cleaner on the input" do
+    expect(ParamCleaner).to receive(:call).with(hash: params).ordered
+    subject
+  end
 end

--- a/spec/services/save_metadata_spec.rb
+++ b/spec/services/save_metadata_spec.rb
@@ -15,20 +15,14 @@ RSpec.describe SaveMetadata, type: :model do
     subject
   end
 
-  it "does not set the metadata if the params are nil" do
-    expect(Metadata::Setter).to_not receive(:call).with(params)
-    params = nil
-    subject
-  end
-
   it "calls item#save if the item_metadata is valid? " do
-    expect(item_metadata).to receive(:valid?).and_return(true)
+    allow(item_metadata).to receive(:valid?).and_return(true)
     expect(item).to receive(:save).and_return(true)
     subject
   end
 
   it "does not call item#save if the item_metadata is not valid?" do
-    expect(item_metadata).to receive(:valid?).and_return(false)
+    allow(item_metadata).to receive(:valid?).and_return(false)
     expect(item).to_not receive(:save)
     subject
   end
@@ -38,12 +32,12 @@ RSpec.describe SaveMetadata, type: :model do
   end
 
   it "returns false if the the item_metadata is not valid?" do
-    expect(item_metadata).to receive(:valid?).and_return(false)
+    allow(item_metadata).to receive(:valid?).and_return(false)
     expect(subject).to eq(false)
   end
 
   it "returns false if the the item save is false" do
-    expect(item).to receive(:save).and_return(false)
+    allow(item).to receive(:save).and_return(false)
     expect(subject).to eq(false)
   end
 

--- a/spec/validators/metadata_validator_spec.rb
+++ b/spec/validators/metadata_validator_spec.rb
@@ -14,7 +14,7 @@ describe MetadataValidator do
   subject { MetadataValidator.new.validate(metadata) }
 
   before(:each) do
-    allow_any_instance_of(described_class).to receive(:configuration).and_return(configuration)
+    allow_any_instance_of(described_class).to receive(:load_configuration).and_return(configuration)
   end
 
   context "required_field" do


### PR DESCRIPTION
Why: the current implementation was validating the metadata on create which was causing new item creation to fail also there was a bug with the custom metadata validator in that it always used the first loaded collection configuration to validate agains.
What:  I separated the routes for updating items and metadata.  All routes to items should only save item data.  There is a new api route v1/items/ID/metadata that saves the metadata.   There is also a new save_metadata class for saving metadata.  
SaveItem no longer saves metadata.  

