### PR TITLE
DEC-624: Bugfix item list on Safari

### DIFF
--- a/app/assets/javascripts/components.js
+++ b/app/assets/javascripts/components.js
@@ -1,6 +1,12 @@
 //app/assets/javascripts/components.js
 //= require_self
 //= require react_ujs
+
+// Symbol definitions required by material-ui/Table
+// See https://github.com/callemall/material-ui/issues/1531
+window.Symbol = require('core-js/modules/es6.symbol');
+window.Symbol.iterator = require('core-js/fn/symbol/iterator');
+
 React = require("react");
 ReactDOM = require("react-dom");
 

--- a/app/assets/javascripts/components/search/SearchPage.jsx
+++ b/app/assets/javascripts/components/search/SearchPage.jsx
@@ -164,7 +164,7 @@ var SearchPage = React.createClass({
         { this.progressCircle() }
         <div style={{ width: "100%" }}>
           <SearchBox searchUrl={this.props.searchUrl} rows={this.props.rows} />
-          <SearchPagination key="PaginationHeader" rows={this.props.rows} searchUrl={this.props.searchUrl} style={ Styles.paginationHeader }/>
+          <SearchPagination keyPrefix="PaginationHeader" rows={this.props.rows} searchUrl={this.props.searchUrl} style={ Styles.paginationHeader }/>
         </div>
         <div style={ Styles.table }>
           <mui.Table selectable={false} fixedFooter={true} onCellClick={ this.openItem }>
@@ -186,7 +186,7 @@ var SearchPage = React.createClass({
             </mui.TableBody>
           </mui.Table>
         </div>
-        <SearchPagination key="PaginationFooter" rows={this.props.rows} searchUrl={this.props.searchUrl} style={ Styles.paginationFooter }/>
+        <SearchPagination keyPrefix="PaginationFooter" rows={this.props.rows} searchUrl={this.props.searchUrl} style={ Styles.paginationFooter }/>
       </div>
     );
   }

--- a/app/assets/javascripts/components/search/SearchPagination.jsx
+++ b/app/assets/javascripts/components/search/SearchPagination.jsx
@@ -34,7 +34,8 @@ var Styles = {
 var SearchPagination = React.createClass({
   propTypes: {
     searchUrl: React.PropTypes.string.isRequired,
-    rows: React.PropTypes.number.isRequired
+    rows: React.PropTypes.number.isRequired,
+    keyPrefix: React.PropTypes.string.isRequired,
   },
 
   queryPage: function(i) {
@@ -78,7 +79,7 @@ var SearchPagination = React.createClass({
     // if not first page
     if(SearchStore.start != 0) {
       nodes.push((
-        <mui.RaisedButton key={ this.props.key + "PreviousPageLink" } style={ Styles.pageButton } onTouchTap={ function(){ this.queryPage(0) }.bind(this) }>
+        <mui.RaisedButton key={ this.props.keyPrefix + "PreviousPageLink" } style={ Styles.pageButton } onTouchTap={ function(){ this.queryPage(0) }.bind(this) }>
           <i className="material-icons" style={ Styles.jumpArrows }>first_page</i>
         </mui.RaisedButton>
       ));
@@ -100,7 +101,7 @@ var SearchPagination = React.createClass({
     if(SearchStore.start + this.props.rows < SearchStore.found) {
       var start = this.props.rows*(last - 1);
       nodes.push((
-        <mui.RaisedButton key={ this.props.key + "NextPageLink" } style={ Styles.pageButton } onTouchTap={ function(){ this.queryPage(start) }.bind(this) }>
+        <mui.RaisedButton key={ this.props.keyPrefix + "NextPageLink" } style={ Styles.pageButton } onTouchTap={ function(){ this.queryPage(start) }.bind(this) }>
           <i className="material-icons" style={ Styles.jumpArrows }>last_page</i>
         </mui.RaisedButton>
       ));


### PR DESCRIPTION
Why: Cannot see items for a collection in Safari
How: Problem was with material-ui Table. Symbol is undefined. We're pretty close to a deployment so I don't want to go through updating react and material-ui just to fix this, defined Symbol instead, see https://github.com/callemall/material-ui/issues/1531. Also fixed a problem with passing the key prefix to the pagination component. this.props.key was deprecated, need to pass as a different prop.