### PR TITLE
DEC-1069 Fix for custom slug update

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -115,6 +115,7 @@ class CollectionsController < ApplicationController
       :name_line_1,
       :name_line_2,
       :description,
+      :url_slug,
       :id,
       :enable_search,
       :enable_browse,


### PR DESCRIPTION
Bug: Custom slug updates via the UI were failing
Fix: Thought that this was related to caching but it ended up being related to the permitted save params. This was due to changes in the model and removing the custom_slug method earlier. Adding url_slug to the permitted params list resolved the issue.