### PR TITLE
DEC-1071 Fix broken preview link

### DIFF
--- a/app/services/create_beehive_url.rb
+++ b/app/services/create_beehive_url.rb
@@ -26,7 +26,7 @@ class CreateBeehiveURL
     if collection.url_slug
       "#{Rails.configuration.settings.beehive_url}/#{collection.url_slug}"
     else
-      "#{Rails.configuration.settings.beehive_url}/#{collection.unique_id}#{CreateURLSlug.call(collection.name_line_1)}"
+      "#{Rails.configuration.settings.beehive_url}/#{collection.unique_id}/#{CreateURLSlug.call(collection.name_line_1)}"
     end
   end
 

--- a/spec/services/create_beehive_url_spec.rb
+++ b/spec/services/create_beehive_url_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe CreateBeehiveURL do
 
       it "returns a beehive url for a collection" do
         object.name_line_1 = "Test title"
-        expect(subject.create).to eq "http://localhost:3018/test-title"
+        object.unique_id = "12345"
+        expect(subject.create).to eq "http://localhost:3018/12345/test-title"
       end
 
       it "returns custom slug if present" do
@@ -20,7 +21,8 @@ RSpec.describe CreateBeehiveURL do
 
       it "calls CreateURLSlug on the collection name_line_1" do
         object.name_line_1 = "Test title"
-        expect(subject.create).to eq "http://localhost:3018/test-title"
+        object.unique_id = "12345"
+        expect(subject.create).to eq "http://localhost:3018/12345/test-title"
       end
     end
 


### PR DESCRIPTION
Bug: Preview link was broken because of missing forward slash
Fix: I put the forward slash back in, but as a caveat, I previously needed to take the slash out because it was rendering a double forward slash - which broke the preview link as well