### PR TITLE
DEC-1090 Fix for custom slug bug

### DIFF
--- a/app/services/create_url_slug.rb
+++ b/app/services/create_url_slug.rb
@@ -13,7 +13,7 @@ class CreateURLSlug
     if name.present?
       name.downcase.gsub(/\s+/, "-").gsub(/[^0-9a-z-]/i, "")
     else
-      "name"
+      nil
     end
   end
 end

--- a/spec/services/create_url_slug_spec.rb
+++ b/spec/services/create_url_slug_spec.rb
@@ -16,6 +16,6 @@ describe CreateURLSlug do
   end
 
   it "returns name for a blank name " do
-    expect(described_class.call("")).to eq("name")
+    expect(described_class.call("")).to be_nil
   end
 end


### PR DESCRIPTION
What: CreateURLSlug was returning "name" when no value was supplied. This caused a bug for the custom slug functionality.
Fix: Changed the CreateURLSlug class so that it returns nil if no value is supplied, and modified the associated spec.