### PR TITLE
DEC-841 Fix for creating metadata fields with same label / name

### DIFF
--- a/app/services/metadata/create_configuration_field.rb
+++ b/app/services/metadata/create_configuration_field.rb
@@ -13,7 +13,9 @@ module Metadata
     def create_field(new_data)
       populate_defaults(values: new_data)
       new_data = ConfigurationInputCleaner.call(new_data)
-      configuration.save_field(new_data[:name], new_data)
+      unique_key = Metadata::GenerateUniqueKey.call
+      new_data[:name] = unique_key
+      configuration.save_field(unique_key, new_data)
     end
 
     private

--- a/app/services/metadata/generate_unique_key.rb
+++ b/app/services/metadata/generate_unique_key.rb
@@ -1,0 +1,13 @@
+require "securerandom"
+
+module Metadata
+  class GenerateUniqueKey
+    def self.call
+      new.generate!
+    end
+
+    def generate!
+      SecureRandom.uuid
+    end
+  end
+end

--- a/spec/services/metatdata/create_configuration_field_spec.rb
+++ b/spec/services/metatdata/create_configuration_field_spec.rb
@@ -3,17 +3,19 @@ require "rails_helper"
 RSpec.describe Metadata::CreateConfigurationField do
   let(:configuration) { double(Metadata::Configuration) }
   let(:collection) { double(Collection) }
-  let(:data) { { name: "name" } }
+  let(:unique_key) { Metadata::GenerateUniqueKey.call }
+  let(:data) { { name: "My Name" } }
 
   before(:each) do
     allow_any_instance_of(CollectionConfigurationQuery).to receive(:find).and_return(configuration)
     allow(configuration).to receive(:save_field)
     allow(Metadata::ConfigurationInputCleaner).to receive(:call).and_return(data)
+    allow(Metadata::GenerateUniqueKey).to receive(:call).and_return(unique_key)
     allow_any_instance_of(CollectionConfigurationQuery).to receive(:max_metadata_order).and_return(0)
   end
 
   it "calls save_field on the configuration" do
-    expect(configuration).to receive(:save_field).with("name", data)
+    expect(configuration).to receive(:save_field).with(unique_key, data)
     described_class.call(collection, data)
   end
 

--- a/spec/services/metatdata/generate_unique_key_spec.rb
+++ b/spec/services/metatdata/generate_unique_key_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe Metadata::GenerateUniqueKey do
+  subject { described_class.new }
+
+  it "uses the SecureRandom to generate the unique key" do
+    expect(SecureRandom).to receive(:uuid)
+    subject.generate!
+  end
+
+  it "generates a 36 character sequence" do
+    string = subject.generate!
+    expect(string.length).to eq 36
+  end
+
+  it "generates a character string with a specific pattern" do
+    string = subject.generate!
+    expect(string).to match(/.{8}-.{4}-.{4}-.{4}-.{12}/)
+  end
+
+  describe "#call" do
+    it "calls generate!" do
+      expect_any_instance_of(described_class).to receive(:generate!)
+      described_class.call
+    end
+  end
+end


### PR DESCRIPTION
What: Implemented a fix for condition when curator creates a duplicate metadata field
Fix: Created a class that generates a uuid that will be assigned to every custom metadata field. This avoids the problem of having truly duplicate fields, but does not address the possibility that a curator will create two metadata fields with the same label which presents a problem for serializing collections from the API. That will need to be addressed in another ticket.