### PR TITLE
DEC-1093 Prevent duplicate metadata label data entry

### DIFF
--- a/app/assets/javascripts/actions/MetaDataConfigurationActions.js
+++ b/app/assets/javascripts/actions/MetaDataConfigurationActions.js
@@ -79,7 +79,7 @@ class MetaDataConfigurationActions extends NodeEventEmitter {
         });
         // Communicate the error to the user
         this.emit("ChangeFieldFinished", false, xhr);
-        AppEventEmitter.emit("MessageCenterDisplay", "error", "Save failed. Please ensure to select a label and a type and try again.");
+        AppEventEmitter.emit("MessageCenterDisplay", "error", "Save failed. Please select a unique label and a type and try again.");
       }).bind(this)
     });
   }
@@ -107,7 +107,7 @@ class MetaDataConfigurationActions extends NodeEventEmitter {
       error: (function(xhr) {
         // Communicate the error to the user
         this.emit("CreateFieldFinished", false, xhr);
-        AppEventEmitter.emit("MessageCenterDisplay", "error", "Create failed. Please ensure to select a label and a type and try again.");
+        AppEventEmitter.emit("MessageCenterDisplay", "error", "Create failed. Please select a unique label and a type and try again.");
       }).bind(this)
     });
   }

--- a/app/assets/javascripts/actions/MetaDataConfigurationActions.js
+++ b/app/assets/javascripts/actions/MetaDataConfigurationActions.js
@@ -79,7 +79,7 @@ class MetaDataConfigurationActions extends NodeEventEmitter {
         });
         // Communicate the error to the user
         this.emit("ChangeFieldFinished", false, xhr);
-        AppEventEmitter.emit("MessageCenterDisplay", "error", "Save failed. Please select a unique label and a type and try again.");
+        AppEventEmitter.emit("MessageCenterDisplay", "error", "Save failed. Please select a type and unique label and try again.");
       }).bind(this)
     });
   }
@@ -107,7 +107,7 @@ class MetaDataConfigurationActions extends NodeEventEmitter {
       error: (function(xhr) {
         // Communicate the error to the user
         this.emit("CreateFieldFinished", false, xhr);
-        AppEventEmitter.emit("MessageCenterDisplay", "error", "Create failed. Please select a unique label and a type and try again.");
+        AppEventEmitter.emit("MessageCenterDisplay", "error", "Create failed. Please select a unique label and try again.");
       }).bind(this)
     });
   }

--- a/spec/services/metatdata/create_configuration_field_spec.rb
+++ b/spec/services/metatdata/create_configuration_field_spec.rb
@@ -10,47 +10,76 @@ RSpec.describe Metadata::CreateConfigurationField do
     allow_any_instance_of(CollectionConfigurationQuery).to receive(:find).and_return(configuration)
     allow(configuration).to receive(:save_field)
     allow(Metadata::ConfigurationInputCleaner).to receive(:call).and_return(data)
+    allow_any_instance_of(Metadata::CreateConfigurationField).to receive(:duplicate_label?).and_return(false)
     allow(Metadata::GenerateUniqueKey).to receive(:call).and_return(unique_key)
     allow_any_instance_of(CollectionConfigurationQuery).to receive(:max_metadata_order).and_return(0)
   end
 
-  it "calls save_field on the configuration" do
-    expect(configuration).to receive(:save_field).with(unique_key, data)
-    described_class.call(collection, data)
+  context "when label is unique" do
+    it "calls save_field on the configuration" do
+      expect(configuration).to receive(:save_field).with(unique_key, data)
+      described_class.call(collection, data)
+    end
+
+    it "calls the cleaner on the input data" do
+      expect(Metadata::ConfigurationInputCleaner).to receive(:call).with(data)
+      described_class.call(collection, data)
+    end
+
+    it "uses CollectionConfigurationQuery to get a default order when one is not present" do
+      data.delete(:order)
+      expect_any_instance_of(CollectionConfigurationQuery).to receive(:max_metadata_order).and_return(0)
+      described_class.call(collection, data)
+    end
+
+    it "doesn't call CollectionConfigurationQuery to get the max order when one is given" do
+      data[:order] = 10
+      expect_any_instance_of(CollectionConfigurationQuery).not_to receive(:max_metadata_order)
+      described_class.call(collection, data)
+    end
+
+    it "uses the order given when one is present" do
+      data[:order] = 10
+      described_class.call(collection, data)
+      expect(data[:order]).to eq(10)
+    end
+
+    it "populates a default value for active when one is not present" do
+      data.delete(:active)
+      described_class.call(collection, data)
+      expect(data[:active]).to eq(true)
+    end
+
+    it "uses the value given for active when one is present" do
+      data[:active] = false
+      described_class.call(collection, data)
+      expect(data[:active]).to eq(false)
+    end
   end
 
-  it "calls the cleaner on the input data" do
-    expect(Metadata::ConfigurationInputCleaner).to receive(:call).with(data)
-    described_class.call(collection, data)
-  end
+  context "when label is not unique" do
+    before(:each) do
+      allow_any_instance_of(Metadata::CreateConfigurationField).to receive(:duplicate_label?).and_return(true)
+    end
 
-  it "uses CollectionConfigurationQuery to get a default order when one is not present" do
-    data.delete(:order)
-    expect_any_instance_of(CollectionConfigurationQuery).to receive(:max_metadata_order).and_return(0)
-    described_class.call(collection, data)
-  end
+    it "returns duplicate_found" do
+      expect(described_class.call(collection, data)).to be_nil
+    end
 
-  it "doesn't call CollectionConfigurationQuery to get the max order when one is given" do
-    data[:order] = 10
-    expect_any_instance_of(CollectionConfigurationQuery).not_to receive(:max_metadata_order)
-    described_class.call(collection, data)
-  end
+    it "does not save_field on the configuration" do
+      expect(configuration).to_not receive(:save_field).with(unique_key, data)
+      described_class.call(collection, data)
+    end
 
-  it "uses the order given when one is present" do
-    data[:order] = 10
-    described_class.call(collection, data)
-    expect(data[:order]).to eq(10)
-  end
+    it "calls the cleaner on the input data" do
+      expect(Metadata::ConfigurationInputCleaner).to receive(:call).with(data)
+      described_class.call(collection, data)
+    end
 
-  it "populates a default value for active when one is not present" do
-    data.delete(:active)
-    described_class.call(collection, data)
-    expect(data[:active]).to eq(true)
-  end
-
-  it "uses the value given for active when one is present" do
-    data[:active] = false
-    described_class.call(collection, data)
-    expect(data[:active]).to eq(false)
+    it "populates a default value for active when one is not present" do
+      data.delete(:active)
+      described_class.call(collection, data)
+      expect(data[:active]).to eq(true)
+    end
   end
 end


### PR DESCRIPTION
What: This is part 2 of the fix for entering a duplicate metadata field in the collection configuration. This PR addresses the potential problem of a curator entering in a duplicate metadata label.
Fix: Added a method to check for a duplicate label value against all of the extant metadata fields. It reports back with a true or false. create_field() in CreateConfigurationField now has a conditional to test for the duplicate label and returns nil if the entered parameter is a duplicate. The standard controller behavior was left untouched.