### PR TITLE
Set homepage as active option on Site Setup page

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -267,7 +267,7 @@ GEM
     jwt (1.5.1)
     launchy (2.4.3)
       addressable (~> 2.3)
-    libv8 (3.16.14.7)
+    libv8 (3.16.14.15)
     listen (2.7.11)
       celluloid (>= 0.15.2)
       rb-fsevent (>= 0.9.3)
@@ -590,4 +590,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   1.10.6
+   1.12.5

--- a/app/decorators/collections_side_nav.rb
+++ b/app/decorators/collections_side_nav.rb
@@ -29,6 +29,7 @@ class CollectionsSideNav < Draper::Decorator
   def active_tab_class(tab:)
     return "active" if tab == form
     return "active" if tab == "edit" && form.nil?
+    return "active" if tab == "homepage" && form.nil?
     ""
   end
 end

--- a/app/decorators/collections_side_nav.rb
+++ b/app/decorators/collections_side_nav.rb
@@ -28,7 +28,6 @@ class CollectionsSideNav < Draper::Decorator
 
   def active_tab_class(tab:)
     return "active" if tab == form
-    return "active" if tab == "edit" && form.nil?
     return "active" if tab == "homepage" && form.nil?
     ""
   end

--- a/spec/decorators/collections_side_nav_spec.rb
+++ b/spec/decorators/collections_side_nav_spec.rb
@@ -91,11 +91,6 @@ RSpec.describe CollectionsSideNav do
       expect(subject.active_tab_class(tab: "not_the_form")).to eq("")
     end
 
-    it "returns active if the form is nil and the tab == edit " do
-      subject = described_class.new(collection: collection, form: nil)
-      expect(subject.active_tab_class(tab: "edit")).to eq("active")
-    end
-
     it "returns active if the form is nil and the tab == homepage " do
       subject = described_class.new(collection: collection, form: nil)
       expect(subject.active_tab_class(tab: "homepage")).to eq("active")

--- a/spec/decorators/collections_side_nav_spec.rb
+++ b/spec/decorators/collections_side_nav_spec.rb
@@ -95,5 +95,10 @@ RSpec.describe CollectionsSideNav do
       subject = described_class.new(collection: collection, form: nil)
       expect(subject.active_tab_class(tab: "edit")).to eq("active")
     end
+
+    it "returns active if the form is nil and the tab == homepage " do
+      subject = described_class.new(collection: collection, form: nil)
+      expect(subject.active_tab_class(tab: "homepage")).to eq("active")
+    end
   end
 end


### PR DESCRIPTION
Added homepage as the default active option upon entry to Site Setup page.

Added code into collections_side_nav.rb to set returned value to "active" for homepage as a default option. This is used in the _site_nav partial to set the class value.