### PR TITLE
Dec 1132 remove brand bar on honeycomb

### DIFF
--- a/app/assets/stylesheets/nav_bar.css.scss
+++ b/app/assets/stylesheets/nav_bar.css.scss
@@ -1,26 +1,3 @@
-.brand-bar {
-  background-color: #002b5b;
-  background-image: none;
-  border-bottom: none;
-  padding: 15px 0;
-  margin: 0;
-  height: 50px;
-}
-
-.brand-bar a {
-  color: white;
-  font-size: 1em;
-  font-family: "Adobe Garamond Pro", Georgia, serif;
-  letter-spacing: 0.2em;
-  padding: 0.15em 0;
-  text-transform: uppercase;
-
-}
-
-.brand-bar a i {
-  text-transform: none;
-}
-
 .title-bar {
   background-color: #dcb439;
   background-image: none;

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -119,7 +119,6 @@ class CollectionsController < ApplicationController
       :id,
       :enable_search,
       :enable_browse,
-      :site_intro,
       :short_intro,
       :hide_title_on_home_page,
       :uploaded_image,

--- a/app/decorators/collections_side_nav.rb
+++ b/app/decorators/collections_side_nav.rb
@@ -10,10 +10,6 @@ class CollectionsSideNav < Draper::Decorator
     h.link_to("Homepage", h.site_setup_form_collection_path(collection, form: "homepage"))
   end
 
-  def collection_introduction_link
-    h.link_to("Introduction", h.site_setup_form_collection_path(collection, form: "collection_introduction"))
-  end
-
   def copyright_text_link
     h.link_to("Copyright", h.site_setup_form_collection_path(collection, form: "copyright_text"))
   end

--- a/app/decorators/v1/collection_json_decorator.rb
+++ b/app/decorators/v1/collection_json_decorator.rb
@@ -35,10 +35,6 @@ module V1
       object.description.to_s
     end
 
-    def site_intro
-      object.site_intro.to_s
-    end
-
     def short_intro
       object.short_intro.to_s
     end

--- a/app/views/collections/_collection_introduction_form.html.erb
+++ b/app/views/collections/_collection_introduction_form.html.erb
@@ -1,2 +1,0 @@
-<%= f.input :site_intro, input_html: { class: 'honeycomb_image_redactor'  } %>
-<%= f.input :unique_id, as: :hidden, input_html: { id: "image_collection_unique_id", value: @collection.unique_id } %>

--- a/app/views/collections/_side_nav.html.erb
+++ b/app/views/collections/_side_nav.html.erb
@@ -2,7 +2,6 @@
 <h4>Site Content</h4>
 <ul class="nav nav-pills nav-stacked">
   <li class="<%= side_nav.active_tab_class(tab: "homepage") %>"><%= side_nav.homepage_link %></li>
-  <li class="<%= side_nav.active_tab_class(tab: "collection_introduction") %>"><%= side_nav.collection_introduction_link %></li>
   <li class="<%= side_nav.active_tab_class(tab: "about_text") %>"><%= side_nav.about_text_link %></li>
   <li class="<%= side_nav.active_tab_class(tab: "site_path") %>"><%= side_nav.site_path_link %></li>
 </ul>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,19 +31,6 @@
   <% end %>
 
   <nav class="navbar navbar-default" role="navigation">
-    <div class="brand-bar">
-      <div class="container-fluid">
-        <div class="row">
-          <div class="col-sm-6">
-            <a href="http://www.nd.edu">University <i>of</i> Notre Dame</a>
-          </div>
-          <div class="col-sm-6">
-            <a class="pull-right" href="http://library.nd.edu">Hesburgh Libraries</a>
-          </div>
-        </div>
-      </div>
-    </div>
-
     <%= Nav::Top.new(controller).display %>
   </nav>
 </header>

--- a/app/views/v1/collections/_collection.json.jbuilder
+++ b/app/views/v1/collections/_collection.json.jbuilder
@@ -12,7 +12,6 @@ json.external_url collection_object.external_url
 json.name_line_1 collection_object.name_line_1
 json.name_line_2 collection_object.name_line_2
 json.short_description collection_object.short_intro
-json.description collection_object.site_intro
 json.about collection_object.about
 json.display_page_title collection_object.display_page_title
 json.image collection_object.image

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -48,7 +48,6 @@ en:
       collection:
         name_line_1: 'Name Line 1'
         name_line_2: 'Name Line 2'
-        site_intro: 'Site Introduction'
         short_intro: 'Short Introduction'
       showcase:
         title: 'Title Line 1'
@@ -60,7 +59,6 @@ en:
         image: "This image will appear tiled in the background of your showcase"
     placeholders:
       collection:
-        site_intro: "Create an introduction page to your site."
         short_intro: "Create a short introduction. Try to limit this to around 200 characters."
   collection_left_nav:
     items: 'Items'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,7 @@ Rails.application.routes.draw do
     end
 
     member do
-      site_setup_constraints = { form: /homepage|collection_introduction|about_text|copyright_text|site_path/ }
+      site_setup_constraints = { form: /homepage|about_text|copyright_text|site_path/ }
       get :site_setup
       get "site_setup/:form", to: "collections#site_setup", as: :site_setup_form, constraints: site_setup_constraints
       put "site_setup/:form", to: "collections#site_setup_update", as: :site_setup_update_form, constraints: site_setup_constraints

--- a/db/migrate/20160706194509_remove_site_intro_from_collections.rb
+++ b/db/migrate/20160706194509_remove_site_intro_from_collections.rb
@@ -1,0 +1,5 @@
+class RemoveSiteIntroFromCollections < ActiveRecord::Migration
+  def change
+    remove_column :collections, :site_intro, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160706175256) do
+
+ActiveRecord::Schema.define(version: 20160706194509) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -45,7 +46,6 @@ ActiveRecord::Schema.define(version: 20160706175256) do
     t.string   "name_line_2"
     t.boolean  "preview_mode"
     t.string   "url"
-    t.text     "site_intro"
     t.text     "short_intro"
     t.text     "about"
     t.text     "copyright"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,6 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
 ActiveRecord::Schema.define(version: 20160706194509) do
 
   # These are extensions that must be enabled in order to support this database

--- a/spec/decorators/collections_side_nav_spec.rb
+++ b/spec/decorators/collections_side_nav_spec.rb
@@ -21,24 +21,6 @@ RSpec.describe CollectionsSideNav do
     end
   end
 
-  describe "#collection_introduction_link" do
-    let(:context) { double("context", site_setup_form_collection_path: "path", link_to: "link") }
-    let(:subject) { described_class.new(collection: collection, form: nil) }
-
-    before(:each) do
-      allow(subject).to receive(:h).and_return(context)
-    end
-
-    it "returns a link to the collection_introduction_form" do
-      expect(subject.collection_introduction_link).to eq("link")
-    end
-
-    it "calls the correct path method" do
-      expect(context).to receive(:site_setup_form_collection_path).with(collection, form: "collection_introduction")
-      subject.collection_introduction_link
-    end
-  end
-
   describe "#about_text_link" do
     let(:context) { double("context", site_setup_form_collection_path: "path", link_to: "link") }
     let(:subject) { described_class.new(collection: collection, form: nil) }

--- a/spec/decorators/v1/collection_json_decorator_spec.rb
+++ b/spec/decorators/v1/collection_json_decorator_spec.rb
@@ -80,19 +80,6 @@ RSpec.describe V1::CollectionJSONDecorator do
     end
   end
 
-  describe "#site_intro" do
-    let(:collection) { double(Collection, site_intro: nil) }
-
-    it "converts null to empty string" do
-      expect(subject.site_intro).to eq("")
-    end
-
-    it "gets the value from #site_intro" do
-      expect(subject).to receive(:site_intro).and_return("intro")
-      expect(subject.site_intro).to eq("intro")
-    end
-  end
-
   describe "#short_intro" do
     let(:collection) { double(Collection, short_intro: nil) }
 

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Collection do
   [:name_line_1, :name_line_2, :items, :unique_id, :showcases,
    :collection_users, :published, :preview_mode, :users, :updated_at, :created_at,
-   :site_intro, :short_intro, :showcases, :hide_title_on_home_page, :about, :copyright,
+   :short_intro, :showcases, :hide_title_on_home_page, :about, :copyright,
    :enable_search, :enable_browse, :image, :url_slug, :pages, :collection_configuration].each do |field|
     it "has field, #{field}" do
       expect(subject).to respond_to(field)


### PR DESCRIPTION
Removed ND/Library brand bar HTML and CSS from honeycomb.

Rebased on top of DEC-1103 due to schema conflict with deleted site_intro field.