### PR TITLE
DEC-1101 Fix for preview link urls

### DIFF
--- a/app/services/create_beehive_url.rb
+++ b/app/services/create_beehive_url.rb
@@ -1,13 +1,14 @@
 class CreateBeehiveURL
   # object can be a Collection, Showcase, or Item
-  attr_reader :object
+  attr_reader :object, :custom_url_flag
 
-  def self.call(object)
-    new(object).create
+  def self.call(object, custom_url_flag = false)
+    new(object, custom_url_flag).create
   end
 
-  def initialize(object)
+  def initialize(object, custom_url_flag)
     @object = object
+    @custom_url_flag = custom_url_flag
   end
 
   def create
@@ -23,7 +24,7 @@ class CreateBeehiveURL
   private
 
   def collection_url(collection)
-    if collection.url_slug
+    if collection.url_slug && custom_url_flag
       "#{Rails.configuration.settings.beehive_url}/#{collection.url_slug}"
     else
       "#{Rails.configuration.settings.beehive_url}/#{collection.unique_id}/#{CreateURLSlug.call(collection.name_line_1)}"

--- a/app/views/shared/_collection_left_nav.html.erb
+++ b/app/views/shared/_collection_left_nav.html.erb
@@ -10,7 +10,7 @@
     <li role="presentation" class="divider"></li>
 
     <%= react_component "CollectionPreviewPublishLink", {
-          previewLinkURL: CreateBeehiveURL.call(nav.collection),
+          previewLinkURL: CreateBeehiveURL.call(nav.collection, true),
           previewLinkLabel: t('collection_left_nav.preview_site'),
           liveLinkLabel: t('collection_left_nav.live_site')
       }

--- a/spec/services/create_beehive_url_spec.rb
+++ b/spec/services/create_beehive_url_spec.rb
@@ -5,24 +5,38 @@ RSpec.describe CreateBeehiveURL do
 
   describe "#create" do
     context "Collection" do
-      let(:object) { Collection.new }
-      let(:subject) { CreateBeehiveURL.new(object) }
+      context "custom url flag set to true" do
+        let(:object) { Collection.new }
+        let(:subject) { CreateBeehiveURL.new(object, true) }
 
-      it "returns a beehive url for a collection" do
-        object.name_line_1 = "Test title"
-        object.unique_id = "12345"
-        expect(subject.create).to eq "http://localhost:3018/12345/test-title"
+        it "returns a beehive url for a collection" do
+          object.name_line_1 = "Test title"
+          object.unique_id = "12345"
+          expect(subject.create).to eq "http://localhost:3018/12345/test-title"
+        end
+
+        it "returns custom slug pattern if present" do
+          object.url_slug = "test"
+          expect(subject.create).to eq "http://localhost:3018/test"
+        end
+
+        it "calls CreateURLSlug on the collection name_line_1" do
+          object.name_line_1 = "Test title"
+          object.unique_id = "12345"
+          expect(subject.create).to eq "http://localhost:3018/12345/test-title"
+        end
       end
 
-      it "returns custom slug if present" do
-        object.url_slug = "test"
-        expect(subject.create).to eq "http://localhost:3018/test"
-      end
+      context "custom url flag set to false" do
+        let(:object) { Collection.new }
+        let(:subject) { CreateBeehiveURL.new(object, false) }
 
-      it "calls CreateURLSlug on the collection name_line_1" do
-        object.name_line_1 = "Test title"
-        object.unique_id = "12345"
-        expect(subject.create).to eq "http://localhost:3018/12345/test-title"
+        it "returns normal collection url" do
+          object.url_slug = "test"
+          object.name_line_1 = "Test title"
+          object.unique_id = "12345"
+          expect(subject.create).to eq "http://localhost:3018/12345/test-title"
+        end
       end
     end
 


### PR DESCRIPTION
Bug: The preview links on the item edit and showcase edit pages were broken when a custom slug was established. The preview links tried to use the custom url as the base url for the preview.
Fix: Added a flag in the method call for CreateBeehiveURL that will output the custom url if the flag is set to true; by default the flag is set to false, and it's an optional parameter for the call() method.