### PR TITLE
Standardize page styles for editors and setup

### DIFF
--- a/app/views/collections/_side_nav.html.erb
+++ b/app/views/collections/_side_nav.html.erb
@@ -1,5 +1,5 @@
 <% side_nav = CollectionsSideNav.new(collection: collection, form: form) %>
-<h4>Site Content</h4>
+<h4>Site Setup</h4>
 <ul class="nav nav-pills nav-stacked">
   <li class="<%= side_nav.active_tab_class(tab: "homepage") %>"><%= side_nav.homepage_link %></li>
   <li class="<%= side_nav.active_tab_class(tab: "about_text") %>"><%= side_nav.about_text_link %></li>

--- a/app/views/collections/new.html.erb
+++ b/app/views/collections/new.html.erb
@@ -1,17 +1,15 @@
 <% page_title(t('.title')) %>
-
 <%= back_action_bar(collections_path, '#' ) %>
 
-<%= simple_form_for @collection, :html => { :class => 'form-horizontal' } do |f| %>
-  <div class="panel panel-default">
-    <div class="panel-heading">
-      <h3 class="panel-title"><%= t('.title') %></h3>
+<div class="row">
+  <div class="col-md-10">
+    <div class="page-header">
+      <h1><%= t('.title') %> </h1>
     </div>
-    <div class="panel-body">
-      <%= render :partial => 'general_settings_subform', locals: { f: f } %>
-    </div>
-    <div class="panel-footer">
-      <%= f.button :submit, value: t('buttons.save'), :class => 'btn-primary' %>
-    </div>
+    <%= simple_form_for @collection, :html => { :class => 'form-horizontal' } do |f| %>
+          <%= render :partial => 'general_settings_subform', locals: { f: f } %>
+          <%= f.button :submit, value: t('buttons.save'), :class => 'btn-primary' %>
+      </div>
+    <% end %>
   </div>
-<% end %>
+</div>

--- a/app/views/collections/site_setup.html.erb
+++ b/app/views/collections/site_setup.html.erb
@@ -1,26 +1,22 @@
-<% page_title(@collection.name) %>
+<%= page_title(t('.title')) %>
 <%= collection_nav(@collection, :website) %>
 
 <div class="row">
   <div class="col-md-10">
+    <div class="page-header">
+      <h1><%= params[:form] ? params[:form].to_s.titleize : "Homepage" %> <small>Site Setup</small></h1>
+    </div>
     <%= simple_form_for @collection, method: :put, :url => site_setup_update_form_collection_path(@collection, form: (params[:form] ? "#{params[:form]}" : 'homepage')) do |f| %>
-      <%= display_errors(f.object) %>
-
-      <div class="panel panel-default">
-        <div class="panel-heading">
-          <h3 class="panel-title">Site Setup</h3>
+      <!-- <%= display_errors(f.object) %> -->
+      <%= render partial: (params[:form] ? "#{params[:form]}_form" : 'homepage_form'), locals: { f: f } %>
+      <% if params[:form] != "site_path" %>
+        <div class="panel-footer">
+          <%= f.button :submit, "Save", class: 'btn btn-primary'%>
         </div>
-        <div class="panel-body">
-          <%= render partial: (params[:form] ? "#{params[:form]}_form" : 'homepage_form'), locals: { f: f } %>
-        </div>
-        <% if params[:form] != "site_path" %>
-          <div class="panel-footer">
-            <%= f.button :submit, "Save", class: 'btn btn-primary'%>
-          </div>
-        <% end %>
-      </div>
+      <% end %>
     <% end %>
   </div>
+
   <div class="col-md-2">
     <%= render "side_nav", collection: @collection, form: params[:form] %>
   </div>

--- a/app/views/editors/index.html.erb
+++ b/app/views/editors/index.html.erb
@@ -1,17 +1,21 @@
 <%= page_title(t('.title')) %>
 <%= collection_nav(@collection, :editors) %>
-<%= no_back_action_bar('#') %>
 
-<div class="panel panel-default">
-  <div class="panel-heading">
-    <%= t('.title') %>
+<div class="row">
+  <div class="col-md-10">
+    <div class="page-header">
+      <h1><%= t('.title') %></h1>
+    </div>
+    <%= react_component 'UserPanel', {
+        initialUsers: @editor_list.editor_hashes,
+        createUrl: collection_editors_path(@collection.id),
+        searchUrl: user_search_collection_editors_path(@collection.id),
+        title: t('.name_of_user_type'),
+      },
+      {prerender: false }
+    %>
   </div>
-  <%= react_component 'UserPanel', {
-      initialUsers: @editor_list.editor_hashes,
-      createUrl: collection_editors_path(@collection.id),
-      searchUrl: user_search_collection_editors_path(@collection.id),
-      title: t('.name_of_user_type'),
-    },
-    {prerender: false }
-  %>
+  <div class="col-md-2">
+    <%= no_back_action_bar('#') %>
+  </div>
 </div>

--- a/app/views/pages/new.html.erb
+++ b/app/views/pages/new.html.erb
@@ -1,16 +1,15 @@
 <% page_title(t('.title'), @collection) %>
 <%= collection_nav(@collection, :pages) %>
+<%= back_action_bar(collections_path, '#' ) %>
 
-<%= simple_form_for [@page.collection, @page], :html => { :class => 'form-horizontal' } do |f| %>
-  <div class="panel panel-default">
-    <div class="panel-heading">
-      <h3 class="panel-title">New Page</h3>
+<div class="row">
+  <div class="col-md-10">
+    <div class="page-header">
+      <h1><%= t('.title') %></h1>
     </div>
-    <div class="panel-body">
+    <%= simple_form_for [@page.collection, @page], :html => { :class => 'form-horizontal' } do |f| %>
       <%= render partial: 'form', locals: { f: f } %>
-    </div>
-    <div class="panel-footer">
       <%= f.button :submit, "Save", class: 'btn btn-primary'%>
-    </div>
+    <% end %>
   </div>
-<% end %>
+</div>

--- a/app/views/showcases/new.html.erb
+++ b/app/views/showcases/new.html.erb
@@ -1,16 +1,15 @@
 <% page_title(t('.title'), @collection) %>
 <%= collection_nav(@collection, :showcases) %>
+<%= back_action_bar(collections_path, '#' ) %>
 
-<%= simple_form_for [@showcase.collection, @showcase], :html => { :class => 'form-horizontal' } do |f| %>
-  <div class="panel panel-default">
-    <div class="panel-heading">
-      <h3 class="panel-title">New Showcase</h3>
+<div class="row">
+  <div class="col-md-10">
+    <div class="page-header">
+      <h1><%= t('.title') %></h1>
     </div>
-    <div class="panel-body">
+    <%= simple_form_for [@showcase.collection, @showcase], :html => { :class => 'form-horizontal' } do |f| %>
       <%= render partial: 'form', locals: { f: f } %>
-    </div>
-    <div class="panel-footer">
       <%= f.button :submit, "Save", class: 'btn btn-primary'%>
-    </div>
+    <% end %>
   </div>
-<% end %>
+</div>


### PR DESCRIPTION
Remove panels and add standard heading styles for Site Setup and Editors pages. 
Rename title on setup sidebar to be consistent with main menu option name.

Corresponds to JIRA tasks DEC-1138 and DEC-1139.