### PR TITLE
Standardize honeycomb pages

### DIFF
--- a/app/assets/javascripts/components/forms/ExternalCollectionForm.jsx
+++ b/app/assets/javascripts/components/forms/ExternalCollectionForm.jsx
@@ -67,19 +67,12 @@ var ExternalCollectionForm = React.createClass({
   render: function () {
     return (
       <Form id="external_collection_form" url={this.props.url} authenticityToken={this.props.authenticityToken} method={this.props.method} >
-        <Panel>
-          <PanelHeading>External Collection</PanelHeading>
-          <PanelBody>
-              <StringField objectType={this.props.objectType} name="name_line_1" required={true} title="Name" value={this.state.formValues.name_line_1} handleFieldChange={this.handleFieldChange} errorMsg={this.fieldError('name_line_1')} />
-              <StringField objectType={this.props.objectType} name="url" required={true} title="URL" value={this.state.formValues.url} handleFieldChange={this.handleFieldChange} errorMsg={this.fieldError('url')} />
-              <HtmlField objectType={this.props.objectType} name="about" title="Description" value={this.state.formValues.about} handleFieldChange={this.handleFieldChange} errorMsg={this.fieldError('about')} placeholder="Example: This is an collection external to the honeycomb system" />
-              {this.thumbnailImage()}
-              <UploadFileField objectType={this.props.objectType} name="uploaded_image" title="Image" handleFieldChange={this.handleFieldChange} errorMsg={this.fieldError('image')} />
-          </PanelBody>
-          <PanelFooter>
-            <SubmitButton disabled={false} />
-          </PanelFooter>
-        </Panel>
+        <StringField objectType={this.props.objectType} name="name_line_1" required={true} title="Name" value={this.state.formValues.name_line_1} handleFieldChange={this.handleFieldChange} errorMsg={this.fieldError('name_line_1')} />
+        <StringField objectType={this.props.objectType} name="url" required={true} title="URL" value={this.state.formValues.url} handleFieldChange={this.handleFieldChange} errorMsg={this.fieldError('url')} />
+        <HtmlField objectType={this.props.objectType} name="about" title="Description" value={this.state.formValues.about} handleFieldChange={this.handleFieldChange} errorMsg={this.fieldError('about')} placeholder="Example: This is an collection external to the honeycomb system" />
+        {this.thumbnailImage()}
+        <UploadFileField objectType={this.props.objectType} name="uploaded_image" title="Image" handleFieldChange={this.handleFieldChange} errorMsg={this.fieldError('image')} />
+        <SubmitButton disabled={false} />
       </Form>
     );
   }

--- a/app/assets/javascripts/components/user_panel/UserPanel.jsx
+++ b/app/assets/javascripts/components/user_panel/UserPanel.jsx
@@ -50,15 +50,11 @@ var UserPanel = React.createClass({
   render: function() {
     return (
       <div>
-        <div className="panel-body">
-          <UserList users={this.state.users} />
-        </div>
-        <div className="panel-footer">
-          <PeopleSearch
-            createUrl={this.props.createUrl}
-            searchUrl={this.props.searchUrl}
-            selectPerson={this.addUser} />
-        </div>
+        <UserList users={this.state.users} />
+        <PeopleSearch
+          createUrl={this.props.createUrl}
+          searchUrl={this.props.searchUrl}
+          selectPerson={this.addUser} />
       </div>
     );
   }

--- a/app/views/admin/external_collections/edit.html.erb
+++ b/app/views/admin/external_collections/edit.html.erb
@@ -1,6 +1,13 @@
+<% page_title(t('.title')) %>
+
 <div class="col-md-2 col-sm-2" id="col1">
   <%= render partial: "admin/admin_left_nav" %>
 </div>
-<div class="col-md-10 col-sm-10" id="col2" style="">
-  <%= render partial: "form", locals: { form_method: "put" } %>
+<div class="row">
+  <div class="col-md-10">
+    <div class="page-header">
+      <h1>External Collection<small> <%= t('.title') %></small></h1>
+    </div>
+    <%= render partial: "form", locals: { form_method: "put" } %>
+  </div>
 </div>

--- a/app/views/admin/external_collections/new.html.erb
+++ b/app/views/admin/external_collections/new.html.erb
@@ -1,6 +1,13 @@
+<% page_title(t('.title')) %>
+
 <div class="col-md-2 col-sm-2" id="col1">
   <%= render partial: "admin/admin_left_nav" %>
 </div>
-<div class="col-md-10 col-sm-10" id="col2" style="">
-  <%= render partial: "form", locals: { form_method: "post" } %>
+<div class="row">
+  <div class="col-md-10">
+    <div class="page-header">
+      <h1>External Collection<small> <%= t('.title') %></small></h1>
+    </div>
+    <%= render partial: "form", locals: { form_method: "post" } %>
+  </div>
 </div>

--- a/app/views/collections/site_setup.html.erb
+++ b/app/views/collections/site_setup.html.erb
@@ -10,9 +10,7 @@
       <!-- <%= display_errors(f.object) %> -->
       <%= render partial: (params[:form] ? "#{params[:form]}_form" : 'homepage_form'), locals: { f: f } %>
       <% if params[:form] != "site_path" %>
-        <div class="panel-footer">
-          <%= f.button :submit, "Save", class: 'btn btn-primary'%>
-        </div>
+        <%= f.button :submit, "Save", class: 'btn btn-primary'%>
       <% end %>
     <% end %>
   </div>

--- a/app/views/pages/edit.html.erb
+++ b/app/views/pages/edit.html.erb
@@ -1,19 +1,16 @@
 <% page_title(@page.name, @page.collection) %>
 <%= collection_nav(@page.collection, :pages) %>
-
 <%= render partial: 'edit_action_bar' %>
 
-<%= simple_form_for @page, :html => { :class => 'form-horizontal' } do |f| %>
-  <div class="panel panel-default">
-    <div class="panel-heading">
-      <h3 class="panel-title"><%= @page.name %></h3>
+<div class="row">
+  <div class="col-md-10">
+    <div class="page-header">
+      <h1><%= @page.name %> <small><%= t('.title') %></small></h1>
     </div>
-    <div class="panel-body">
+    <%= simple_form_for @page, :html => { :class => 'form-horizontal' } do |f| %>
       <%= render partial: 'form', locals: { f: f } %>
-    </div>
-    <div class="panel-footer">
       <%= f.button :submit, "Save", class: 'btn btn-primary'%>
-    </div>
-  </div>
-<% end %>
+    <% end %>
     <%= DeletePanel.new(@page).display(PageQuery.new(@page)) %>
+  </div>
+</div>

--- a/app/views/pages/new.html.erb
+++ b/app/views/pages/new.html.erb
@@ -1,11 +1,11 @@
 <% page_title(t('.title'), @collection) %>
-<%= collection_nav(@collection, :pages) %>
-<%= back_action_bar(collections_path, '#' ) %>
+<%= collection_nav(@page.collection, :pages) %>
+<%= back_action_bar(collection_pages_path(@collection), '#' ) %>
 
 <div class="row">
   <div class="col-md-10">
     <div class="page-header">
-      <h1><%= t('.title') %></h1>
+      <h1><%= @collection.name %><small> <%= t('.title') %></small></h1>
     </div>
     <%= simple_form_for [@page.collection, @page], :html => { :class => 'form-horizontal' } do |f| %>
       <%= render partial: 'form', locals: { f: f } %>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,3 +1,3 @@
 <div class="alert alert-danger" role="alert">
-  <strong>Opps!!</strong> <%= pluralize(obj.errors.count, "error") %> prohibited this form being saved.
+  <strong>Oops!!</strong> <%= pluralize(obj.errors.count, "error") %> prohibited this form being saved.
 </div>

--- a/app/views/showcases/new.html.erb
+++ b/app/views/showcases/new.html.erb
@@ -1,6 +1,6 @@
 <% page_title(t('.title'), @collection) %>
 <%= collection_nav(@collection, :showcases) %>
-<%= back_action_bar(collections_path, '#' ) %>
+<%= back_action_bar(collection_showcases_path, '#' ) %>
 
 <div class="row">
   <div class="col-md-10">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -87,6 +87,8 @@ en:
       title: 'New Collection'
     settings:
       title: 'Settings'
+    site_setup:
+      title: 'Site Setup'
     settings_update:
       success: 'Collection updated'
     create:
@@ -217,6 +219,12 @@ en:
         manuscript_url: "Digitized Manuscript URL"
   admin:
     external_collections:
+      new:
+        name: "External Collection"
+        title: "Add"
+      edit:
+        name: "External Collection"
+        title: "Edit"
       create:
         success: 'Collection created'
       update:
@@ -231,11 +239,13 @@ en:
     create:
       success: "Page created! Go to %{href} to add the page to your site."
     new:
-      title: "New Page"
+      title: "Add new page"
     list:
       name: "Page"
       content: "Content"
       updated_at: 'Last Modified At'
+    edit:
+      title: "Edit page"
     update:
       success: "Page updated"
     destroy:


### PR DESCRIPTION
- Remove gray panels on remaining pages to standardize site format. 
- Correct misspelling in error message. 
- Correct back arrow paths on add pages and add showcases. 
- Add missing titles in en.yml to show on tabs and for page titles.

This is a continuation of DEC-1138 and DEC-1139... as I was making those changes, I also changed add and edit pages but missed a couple. 

This also includes item DEC-1141, a bug caused by the changes in DEC-1138.