### PR TITLE
DEC-1148 Fix for missing name import bug

### DIFF
--- a/app/services/create_items.rb
+++ b/app/services/create_items.rb
@@ -31,7 +31,7 @@ class CreateItems
         item_props = yield(item_props, rewrite_errors).symbolize_keys if block_given?
         item_creator = FindOrCreateItem.call(props: { collection_id: collection_id, **item_props }, find_by: find_by)
         saved = rewrite_errors.present? ? false : item_creator.save
-        add_to_errors(errors: errors, index: index, new_errors: rewrite_errors | item_creator.item.errors.full_messages, item: item_creator.item)
+        add_to_errors(errors: errors, index: index, new_errors: rewrite_errors | item_creator.item.errors.full_messages | item_creator.item.item_metadata.errors.full_messages, item: item_creator.item)
         update_counts(save_successful: saved, item: item_creator, counts: counts)
       end
     end

--- a/app/services/create_items.rb
+++ b/app/services/create_items.rb
@@ -31,7 +31,12 @@ class CreateItems
         item_props = yield(item_props, rewrite_errors).symbolize_keys if block_given?
         item_creator = FindOrCreateItem.call(props: { collection_id: collection_id, **item_props }, find_by: find_by)
         saved = rewrite_errors.present? ? false : item_creator.save
-        add_to_errors(errors: errors, index: index, new_errors: rewrite_errors | item_creator.item.errors.full_messages | item_creator.item.item_metadata.errors.full_messages, item: item_creator.item)
+        add_to_errors(
+          errors: errors,
+          index: index,
+          new_errors: rewrite_errors | item_creator.item.errors.full_messages | item_creator.item.item_metadata.errors.full_messages,
+          item: item_creator.item
+        )
         update_counts(save_successful: saved, item: item_creator, counts: counts)
       end
     end

--- a/app/services/find_or_create_item.rb
+++ b/app/services/find_or_create_item.rb
@@ -66,6 +66,6 @@ class FindOrCreateItem
     end
     item.assign_attributes(props)
     CreateUniqueId.call(item)
-    @is_valid = item.valid?
+    @is_valid = item.valid? && item.item_metadata.valid?
   end
 end

--- a/spec/services/create_items_spec.rb
+++ b/spec/services/create_items_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe CreateItems, helpers: :item_meta_helpers do
     [
       item_meta_hash_remapped(item_id: 1),
       item_meta_hash_remapped(item_id: 2),
-      item_meta_hash_remapped(item_id: 3),
+      item_meta_hash_remapped(item_id: 3)
     ]
   end
   let(:item_errors) { instance_double(ActiveModel::Errors, full_messages: ["Item validation error"]) }
@@ -26,7 +26,7 @@ RSpec.describe CreateItems, helpers: :item_meta_helpers do
     }
   end
   let(:creator) { instance_double(FindOrCreateItem, using: item, new_record?: true, changed?: false, save: true, item: item) }
-  let(:metadata_fields)  { instance_double(Metadata::Fields, errors: item_errors) }
+  let(:metadata_fields) { instance_double(Metadata::Fields, errors: item_errors) }
   let(:item) { instance_double(Item, valid?: true, changed?: false, new_record?: false, errors: item_errors, item_metadata: metadata_fields) }
   let(:subject) do
     described_class.call(collection_id: 1, find_by: [], items_hash: items, counts: counts, errors: errors)
@@ -97,8 +97,10 @@ RSpec.describe CreateItems, helpers: :item_meta_helpers do
 
     context "that validate successfully as new items" do
       let(:item_errors) { instance_double(ActiveModel::Errors, full_messages: []) }
-      let(:metadata_fields)  { instance_double(Metadata::Fields, errors: item_errors) }
-      let(:item) { instance_double(Item, valid?: true, changed?: false, new_record?: false, errors: item_errors, item_metadata: metadata_fields, validate: true) }
+      let(:metadata_fields) { instance_double(Metadata::Fields, errors: item_errors) }
+      let(:item) do
+        instance_double(Item, valid?: true, changed?: false, new_record?: false, errors: item_errors, item_metadata: metadata_fields, validate: true)
+      end
 
       it "returns correct summary" do
         expected = { total_count: 3, valid_count: 3, new_count: 3, error_count: 0, changed_count: 0, unchanged_count: 0 }
@@ -115,8 +117,10 @@ RSpec.describe CreateItems, helpers: :item_meta_helpers do
     context "that validate successfully as changed items" do
       let(:item_errors) { instance_double(ActiveModel::Errors, full_messages: []) }
       let(:creator) { instance_double(FindOrCreateItem, using: item, new_record?: false, changed?: true, save: true, item: item) }
-      let(:metadata_fields)  { instance_double(Metadata::Fields, errors: item_errors) }
-      let(:item) { instance_double(Item, valid?: true, changed?: false, new_record?: false, errors: item_errors, item_metadata: metadata_fields, validate: true) }
+      let(:metadata_fields) { instance_double(Metadata::Fields, errors: item_errors) }
+      let(:item) do
+        instance_double(Item, valid?: true, changed?: false, new_record?: false, errors: item_errors, item_metadata: metadata_fields, validate: true)
+      end
 
       it "returns correct summary" do
         expected = { total_count: 3, valid_count: 3, new_count: 0, error_count: 0, changed_count: 3, unchanged_count: 0 }
@@ -133,8 +137,10 @@ RSpec.describe CreateItems, helpers: :item_meta_helpers do
     context "that validate successfully as unchanged items" do
       let(:item_errors) { instance_double(ActiveModel::Errors, full_messages: []) }
       let(:creator) { instance_double(FindOrCreateItem, using: item, new_record?: false, changed?: false, save: true, item: item) }
-      let(:metadata_fields)  { instance_double(Metadata::Fields, errors: item_errors) }
-      let(:item) { instance_double(Item, valid?: true, changed?: false, new_record?: false, errors: item_errors, item_metadata: metadata_fields, validate: true) }
+      let(:metadata_fields) { instance_double(Metadata::Fields, errors: item_errors) }
+      let(:item) do
+        instance_double(Item, valid?: true, changed?: false, new_record?: false, errors: item_errors, item_metadata: metadata_fields, validate: true)
+      end
 
       it "returns correct summary" do
         expected = { total_count: 3, valid_count: 3, new_count: 0, error_count: 0, changed_count: 0, unchanged_count: 3 }
@@ -151,7 +157,7 @@ RSpec.describe CreateItems, helpers: :item_meta_helpers do
     context "that do not validate successfully" do
       let(:creator) { instance_double(FindOrCreateItem, using: item, new_record?: true, changed?: false, valid?: false, save: false, item: item) }
       let(:item_errors) { instance_double(ActiveModel::Errors, full_messages: ["Item validation error"]) }
-      let(:metadata_fields)  { instance_double(Metadata::Fields, errors: item_errors) }
+      let(:metadata_fields) { instance_double(Metadata::Fields, errors: item_errors) }
       let(:item) { instance_double(Item, valid?: false, changed?: false, new_record?: false, item_metadata: metadata_fields, errors: item_errors) }
 
       it "returns a hash with correct summary" do

--- a/spec/services/create_items_spec.rb
+++ b/spec/services/create_items_spec.rb
@@ -26,7 +26,8 @@ RSpec.describe CreateItems, helpers: :item_meta_helpers do
     }
   end
   let(:creator) { instance_double(FindOrCreateItem, using: item, new_record?: true, changed?: false, save: true, item: item) }
-  let(:item) { instance_double(Item, valid?: true, changed?: false, new_record?: false, errors: item_errors) }
+  let(:metadata_fields)  { instance_double(Metadata::Fields, errors: item_errors) }
+  let(:item) { instance_double(Item, valid?: true, changed?: false, new_record?: false, errors: item_errors, item_metadata: metadata_fields) }
   let(:subject) do
     described_class.call(collection_id: 1, find_by: [], items_hash: items, counts: counts, errors: errors)
   end
@@ -96,7 +97,8 @@ RSpec.describe CreateItems, helpers: :item_meta_helpers do
 
     context "that validate successfully as new items" do
       let(:item_errors) { instance_double(ActiveModel::Errors, full_messages: []) }
-      let(:item) { instance_double(Item, valid?: true, changed?: false, new_record?: false, errors: item_errors, validate: true) }
+      let(:metadata_fields)  { instance_double(Metadata::Fields, errors: item_errors) }
+      let(:item) { instance_double(Item, valid?: true, changed?: false, new_record?: false, errors: item_errors, item_metadata: metadata_fields, validate: true) }
 
       it "returns correct summary" do
         expected = { total_count: 3, valid_count: 3, new_count: 3, error_count: 0, changed_count: 0, unchanged_count: 0 }
@@ -113,7 +115,8 @@ RSpec.describe CreateItems, helpers: :item_meta_helpers do
     context "that validate successfully as changed items" do
       let(:item_errors) { instance_double(ActiveModel::Errors, full_messages: []) }
       let(:creator) { instance_double(FindOrCreateItem, using: item, new_record?: false, changed?: true, save: true, item: item) }
-      let(:item) { instance_double(Item, valid?: true, changed?: false, new_record?: false, errors: item_errors, validate: true) }
+      let(:metadata_fields)  { instance_double(Metadata::Fields, errors: item_errors) }
+      let(:item) { instance_double(Item, valid?: true, changed?: false, new_record?: false, errors: item_errors, item_metadata: metadata_fields, validate: true) }
 
       it "returns correct summary" do
         expected = { total_count: 3, valid_count: 3, new_count: 0, error_count: 0, changed_count: 3, unchanged_count: 0 }
@@ -130,7 +133,8 @@ RSpec.describe CreateItems, helpers: :item_meta_helpers do
     context "that validate successfully as unchanged items" do
       let(:item_errors) { instance_double(ActiveModel::Errors, full_messages: []) }
       let(:creator) { instance_double(FindOrCreateItem, using: item, new_record?: false, changed?: false, save: true, item: item) }
-      let(:item) { instance_double(Item, valid?: true, changed?: false, new_record?: false, errors: item_errors, validate: true) }
+      let(:metadata_fields)  { instance_double(Metadata::Fields, errors: item_errors) }
+      let(:item) { instance_double(Item, valid?: true, changed?: false, new_record?: false, errors: item_errors, item_metadata: metadata_fields, validate: true) }
 
       it "returns correct summary" do
         expected = { total_count: 3, valid_count: 3, new_count: 0, error_count: 0, changed_count: 0, unchanged_count: 3 }
@@ -147,7 +151,8 @@ RSpec.describe CreateItems, helpers: :item_meta_helpers do
     context "that do not validate successfully" do
       let(:creator) { instance_double(FindOrCreateItem, using: item, new_record?: true, changed?: false, valid?: false, save: false, item: item) }
       let(:item_errors) { instance_double(ActiveModel::Errors, full_messages: ["Item validation error"]) }
-      let(:item) { instance_double(Item, valid?: false, changed?: false, new_record?: false, errors: item_errors) }
+      let(:metadata_fields)  { instance_double(Metadata::Fields, errors: item_errors) }
+      let(:item) { instance_double(Item, valid?: false, changed?: false, new_record?: false, item_metadata: metadata_fields, errors: item_errors) }
 
       it "returns a hash with correct summary" do
         expected = { total_count: 3, valid_count: 0, new_count: 0, error_count: 3, changed_count: 0, unchanged_count: 0 }

--- a/spec/services/find_or_create_item_spec.rb
+++ b/spec/services/find_or_create_item_spec.rb
@@ -3,12 +3,15 @@ require "rails_helper"
 describe FindOrCreateItem do
   let(:subject) { described_class.new(props: item_hash) }
   let(:item_hash) { { collection_id: 1, name: "item", unique_id: "item", user_defined_id: "item" } }
+  let(:item_errors) { instance_double(ActiveModel::Errors, full_messages: []) }
+  let(:metadata_fields)  { instance_double(Metadata::Fields, errors: item_errors, valid?: true) }
   let(:item) do
     instance_double(Item, save: true,
                           new_record?: true,
                           changed?: false,
                           assign_attributes: true,
                           "unique_id=" => true,
+                          item_metadata: metadata_fields,
                           valid?: true,
                           **item_hash)
   end

--- a/spec/services/find_or_create_item_spec.rb
+++ b/spec/services/find_or_create_item_spec.rb
@@ -4,7 +4,7 @@ describe FindOrCreateItem do
   let(:subject) { described_class.new(props: item_hash) }
   let(:item_hash) { { collection_id: 1, name: "item", unique_id: "item", user_defined_id: "item" } }
   let(:item_errors) { instance_double(ActiveModel::Errors, full_messages: []) }
-  let(:metadata_fields)  { instance_double(Metadata::Fields, errors: item_errors, valid?: true) }
+  let(:metadata_fields) { instance_double(Metadata::Fields, errors: item_errors, valid?: true) }
   let(:item) do
     instance_double(Item, save: true,
                           new_record?: true,

--- a/spec/services/google_create_items_spec.rb
+++ b/spec/services/google_create_items_spec.rb
@@ -21,7 +21,8 @@ RSpec.describe GoogleCreateItems, helpers: :item_meta_helpers do
     ]
   end
   let(:errors) { instance_double(ActiveModel::Errors, full_messages: []) }
-  let(:item) { instance_double(Item, valid?: true, changed?: false, new_record?: false, errors: errors, validate: true) }
+  let(:metadata_fields)  { instance_double(Metadata::Fields, errors: errors) }
+  let(:item) { instance_double(Item, valid?: true, changed?: false, new_record?: false, errors: errors, item_metadata: metadata_fields, validate: true) }
   let(:item_creator) { instance_double(FindOrCreateItem, using: item, save: true, new_record?: true, item: item) }
   let(:worksheet) { instance_double(GoogleDrive::Worksheet) }
   let(:param_hash) { { auth_code: "auth", callback_uri: "callback", collection_id: 1, file: "file", sheet: "sheet" } }

--- a/spec/services/google_create_items_spec.rb
+++ b/spec/services/google_create_items_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe GoogleCreateItems, helpers: :item_meta_helpers do
     ]
   end
   let(:errors) { instance_double(ActiveModel::Errors, full_messages: []) }
-  let(:metadata_fields)  { instance_double(Metadata::Fields, errors: errors) }
+  let(:metadata_fields) { instance_double(Metadata::Fields, errors: errors) }
   let(:item) { instance_double(Item, valid?: true, changed?: false, new_record?: false, errors: errors, item_metadata: metadata_fields, validate: true) }
   let(:item_creator) { instance_double(FindOrCreateItem, using: item, save: true, new_record?: true, item: item) }
   let(:worksheet) { instance_double(GoogleDrive::Worksheet) }


### PR DESCRIPTION
Bug: Import routine was raising exception when name was missing from import spreadsheet
Fix: Added check for the validity of item metadata since the name property was moved into the metadata attribute