### PR TITLE
DEC-1153: Add media to database

### DIFF
--- a/app/decorators/v1/item_json_decorator.rb
+++ b/app/decorators/v1/item_json_decorator.rb
@@ -38,9 +38,8 @@ module V1
 
     def image_status
       if object.image
-        return object.image.status
+        object.image.status
       end
-      Image.default_status
     end
 
     def metadata

--- a/app/decorators/v1/item_json_decorator.rb
+++ b/app/decorators/v1/item_json_decorator.rb
@@ -40,7 +40,7 @@ module V1
       if object.image
         return object.image.status
       end
-      Image.statuses.keys.first
+      Image.default_status
     end
 
     def metadata

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -5,7 +5,7 @@ class Collection < ActiveRecord::Base
   has_many :showcases
   has_many :pages
   has_one :collection_configuration
-  belongs_to :image
+  belongs_to :image, class_name: "Image", foreign_key: :media_id
 
   validates :name_line_1, :unique_id, presence: true
   validates :url_slug, uniqueness: true, allow_nil: true

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,5 +1,11 @@
 class Image < ActiveRecord::Base
-  serialize :json_response, Hash
+  store_accessor :data, :image_content_type,
+                        :image_file_name,
+                        :image_file_size,
+                        :image_fingerprint,
+                        :image_meta,
+                        :image_updated_at,
+                        :json_response
 
   belongs_to :collection
   has_many :items
@@ -8,7 +14,55 @@ class Image < ActiveRecord::Base
   validates_attachment_content_type :image, content_type: /\Aimage\/.*\Z/
   validates :collection, presence: true
 
-  enum status: { unprocessed: 0, processing: 1, ready: 2, unavailable: 3 }
+  def status=(name)
+    data["status"] = status_enum[name]
+  end
+
+  def status
+    status_enum.key data["status"]
+  end
+
+  def default_status
+    "unprocessed"
+  end
+
+  def unprocessed?
+    data["status"] == status_enum["unprocessed"]
+  end
+
+  def unprocessed!
+    data["status"] = status_enum["unprocessed"]
+  end
+
+  def processing?
+    data["status"] == status_enum["processing"]
+  end
+
+  def processing!
+    data["status"] = status_enum["processing"]
+  end
+
+  def ready?
+    data["status"] == status_enum["ready"]
+  end
+
+  def ready!
+    data["status"] = status_enum["ready"]
+  end
+
+  def unavailable?
+    data["status"] == status_enum["unavailable"]
+  end
+
+  def unavailable!
+    data["status"] = status_enum["unavailable"]
+  end
 
   has_paper_trail
+
+  private
+
+  def status_enum
+    { "unprocessed" => 0, "processing" => 1, "ready" => 2, "unavailable" => 3 }
+  end
 end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,4 +1,4 @@
-class Image < ActiveRecord::Base
+class Image < Media
   store_accessor :data, :image_content_type,
                         :image_file_name,
                         :image_file_size,
@@ -7,12 +7,8 @@ class Image < ActiveRecord::Base
                         :image_updated_at,
                         :json_response
 
-  belongs_to :collection
-  has_many :items
   has_attached_file :image, restricted_characters: /[&$+,\/:;=?@<>\[\]{}\|\\^~%#]/
-
   validates_attachment_content_type :image, content_type: /\Aimage\/.*\Z/
-  validates :collection, presence: true
 
   # The following methods were added to recreate the behavior of enum status:
   #   status, status=, unprocessed?, unprocessed!, processing?, processing!,

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,11 +1,12 @@
 class Image < Media
-  store_accessor :data, :image_content_type,
-                        :image_file_name,
-                        :image_file_size,
-                        :image_fingerprint,
-                        :image_meta,
-                        :image_updated_at,
-                        :json_response
+  store_accessor :data,
+                 :image_content_type,
+                 :image_file_name,
+                 :image_file_size,
+                 :image_fingerprint,
+                 :image_meta,
+                 :image_updated_at,
+                 :json_response
 
   has_attached_file :image, restricted_characters: /[&$+,\/:;=?@<>\[\]{}\|\\^~%#]/
   validates_attachment_content_type :image, content_type: /\Aimage\/.*\Z/

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -30,10 +30,6 @@ class Image < Media
     status_enum.key data["status"]
   end
 
-  def default_status
-    "unprocessed"
-  end
-
   def unprocessed?
     data["status"] == status_enum["unprocessed"]
   end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -8,7 +8,7 @@ class Item < ActiveRecord::Base
   has_many :showcases, -> { distinct }, through: :sections
   has_many :items_pages
   has_many :pages, through: :items_pages
-  belongs_to :image
+  belongs_to :image, class_name: "Image", foreign_key: :media_id
 
   validates :collection, :unique_id, :user_defined_id, presence: true
   validate :manuscript_url_is_valid_uri

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -1,0 +1,5 @@
+class Media < ActiveRecord::Base
+  belongs_to :collection
+  has_many :items
+  validates :collection, presence: true
+end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -1,6 +1,6 @@
 class Page < ActiveRecord::Base
   belongs_to :collection
-  belongs_to :image
+  belongs_to :image, class_name: "Image", foreign_key: :media_id
   has_many :items_pages
   has_many :items, through: :items_pages
 

--- a/app/models/showcase.rb
+++ b/app/models/showcase.rb
@@ -2,7 +2,7 @@ class Showcase < ActiveRecord::Base
   belongs_to :collection
   has_many :sections
   has_many :items, through: :sections
-  belongs_to :image
+  belongs_to :image, class_name: "Image", foreign_key: :media_id
 
   validates :name_line_1, :collection, :unique_id, presence: true
 

--- a/app/services/find_or_create_image.rb
+++ b/app/services/find_or_create_image.rb
@@ -14,7 +14,7 @@ class FindOrCreateImage
     # Not sure if there is a simpler way to get paperclip to generate the fingerprint without creating a new Image
     # and processing all of the styles
     new_image = Image.new(image: file, collection_id: collection_id, status: "processing", json_response: {})
-    found_image = Image.where(collection_id: collection_id, image_fingerprint: new_image.image_fingerprint).take
+    found_image = Image.where("collection_id = ? AND data->>'image_fingerprint' = ?", collection_id, new_image.image_fingerprint).take
 
     if found_image.nil?
       if new_image.save && process_image(image: new_image)

--- a/db/migrate/20160718190411_add_media_to_image.rb
+++ b/db/migrate/20160718190411_add_media_to_image.rb
@@ -1,10 +1,22 @@
 class AddMediaToImage < ActiveRecord::Migration
-  def change
+  def up
     add_column :images, :data, :jsonb, null: false, default: '{}'
-    add_column :images, :media_type, :text
+    add_column :images, :type, :string
     # Allowing nulls to make sure we can add new images using the new data field
     # prior to archiving the old columns
     change_column :images, :image_file_name, :text, null: true
     change_column :images, :image_fingerprint, :text, null: true
+  end
+
+  def down
+    remove_column :images, :data, :jsonb, null: false, default: '{}'
+    remove_column :images, :type, :string
+    # If this fails, it means there are records that were added with image data
+    # stored in the jsonb field. The only solutions are to:
+    #  a) delete those records
+    #  b) copy the data out of the jsonb back into these attributes
+    # Neither of these make sense to do automagically when rolling back this migration
+    change_column :images, :image_file_name, :text, null: false
+    change_column :images, :image_fingerprint, :text, null: false
   end
 end

--- a/db/migrate/20160718190411_add_media_to_image.rb
+++ b/db/migrate/20160718190411_add_media_to_image.rb
@@ -1,6 +1,10 @@
 class AddMediaToImage < ActiveRecord::Migration
   def change
     add_column :images, :data, :jsonb, null: false, default: '{}'
-    add_column :images, :type, :text
+    add_column :images, :media_type, :text
+    # Allowing nulls to make sure we can add new images using the new data field
+    # prior to archiving the old columns
+    change_column :images, :image_file_name, :text, null: true
+    change_column :images, :image_fingerprint, :text, null: true
   end
 end

--- a/db/migrate/20160718190411_add_media_to_image.rb
+++ b/db/migrate/20160718190411_add_media_to_image.rb
@@ -1,6 +1,6 @@
 class AddMediaToImage < ActiveRecord::Migration
   def up
-    add_column :images, :data, :jsonb, null: false, default: '{}'
+    add_column :images, :data, :jsonb, null: false, default: "{}"
     add_column :images, :type, :string
     # Allowing nulls to make sure we can add new images using the new data field
     # prior to archiving the old columns
@@ -9,7 +9,7 @@ class AddMediaToImage < ActiveRecord::Migration
   end
 
   def down
-    remove_column :images, :data, :jsonb, null: false, default: '{}'
+    remove_column :images, :data, :jsonb, null: false, default: "{}"
     remove_column :images, :type, :string
     # If this fails, it means there are records that were added with image data
     # stored in the jsonb field. The only solutions are to:

--- a/db/migrate/20160718190411_add_media_to_image.rb
+++ b/db/migrate/20160718190411_add_media_to_image.rb
@@ -1,0 +1,6 @@
+class AddMediaToImage < ActiveRecord::Migration
+  def change
+    add_column :images, :data, :jsonb, null: false, default: '{}'
+    add_column :images, :type, :text
+  end
+end

--- a/db/migrate/20160718193812_copy_image_fields_to_data.rb
+++ b/db/migrate/20160718193812_copy_image_fields_to_data.rb
@@ -2,11 +2,12 @@ class CopyImageFieldsToData < ActiveRecord::Migration
   def up
     Image.all.each do |image|
       image.data = image.to_json(except: [:id, :collection_id, :created_at, :updated_at, :data, :media_type])
-      image.media_type = 'image'
+      image.type = 'Image'
       image.save
     end
   end
 end
 
 class Image < ActiveRecord::Base
+  serialize :json_response, Hash
 end

--- a/db/migrate/20160718193812_copy_image_fields_to_data.rb
+++ b/db/migrate/20160718193812_copy_image_fields_to_data.rb
@@ -2,7 +2,7 @@ class CopyImageFieldsToData < ActiveRecord::Migration
   def up
     Image.all.each do |image|
       image.data = image.to_json(except: [:id, :collection_id, :created_at, :updated_at, :data, :media_type])
-      image.type = 'Image'
+      image.type = "Image"
       image.save
     end
   end

--- a/db/migrate/20160718193812_copy_image_fields_to_data.rb
+++ b/db/migrate/20160718193812_copy_image_fields_to_data.rb
@@ -1,0 +1,12 @@
+class CopyImageFieldsToData < ActiveRecord::Migration
+  def up
+    Image.all.each do |image|
+      image.data = image.to_json(except: [:id, :collection_id, :created_at, :updated_at, :data, :media_type])
+      image.media_type = 'image'
+      image.save
+    end
+  end
+end
+
+class Image < ActiveRecord::Base
+end

--- a/db/migrate/20160720142311_archive_image_media_fields.rb
+++ b/db/migrate/20160720142311_archive_image_media_fields.rb
@@ -1,0 +1,12 @@
+class ArchiveImageMediaFields < ActiveRecord::Migration
+  def change
+    rename_column :images, :image_content_type, :image_content_type_save
+    rename_column :images, :image_file_name, :image_file_name_save
+    rename_column :images, :image_file_size, :image_file_size_save
+    rename_column :images, :image_fingerprint, :image_fingerprint_save
+    rename_column :images, :image_meta, :image_meta_save
+    rename_column :images, :image_updated_at, :image_updated_at_save
+    rename_column :images, :json_response, :json_response_save
+    rename_column :images, :status, :status_save
+  end
+end

--- a/db/migrate/20160720143041_change_image_to_media.rb
+++ b/db/migrate/20160720143041_change_image_to_media.rb
@@ -1,0 +1,31 @@
+class ChangeImageToMedia < ActiveRecord::Migration
+  def up
+    remove_foreign_key :items, :images
+    remove_foreign_key :collections, :images
+    remove_foreign_key :showcases, :images
+
+    rename_column :items, :image_id, :media_id
+    rename_column :collections, :image_id, :media_id
+    rename_column :showcases, :image_id, :media_id
+    rename_table :images, :media
+
+    add_foreign_key :items, :media, column: :media_id
+    add_foreign_key :collections, :media, column: :media_id
+    add_foreign_key :showcases, :media, column: :media_id
+  end
+
+  def down
+    remove_foreign_key :items, column: :media_id
+    remove_foreign_key :collections, column: :media_id
+    remove_foreign_key :showcases, column: :media_id
+
+    rename_table :media, :images
+    rename_column :items, :media_id, :image_id
+    rename_column :collections, :media_id, :image_id
+    rename_column :showcases, :media_id, :image_id
+
+    add_foreign_key :items, :images
+    add_foreign_key :collections, :images
+    add_foreign_key :showcases, :images
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160718190411) do
+ActiveRecord::Schema.define(version: 20160718193812) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -107,18 +107,18 @@ ActiveRecord::Schema.define(version: 20160718190411) do
 
   create_table "images", force: :cascade do |t|
     t.integer  "collection_id",                   null: false
-    t.string   "image_file_name",                 null: false
+    t.text     "image_file_name"
     t.string   "image_content_type"
     t.integer  "image_file_size"
     t.datetime "image_updated_at"
-    t.string   "image_fingerprint",               null: false
+    t.text     "image_fingerprint"
     t.text     "image_meta"
     t.datetime "created_at",                      null: false
     t.datetime "updated_at",                      null: false
     t.text     "json_response"
     t.integer  "status",             default: 0
     t.jsonb    "data",               default: {}, null: false
-    t.text     "type"
+    t.text     "media_type"
   end
 
   add_index "images", ["image_fingerprint"], name: "index_images_on_image_fingerprint", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160706194509) do
+ActiveRecord::Schema.define(version: 20160718190411) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -106,17 +106,19 @@ ActiveRecord::Schema.define(version: 20160706194509) do
   add_index "honeypot_images", ["item_id"], name: "index_honeypot_images_on_item_id", using: :btree
 
   create_table "images", force: :cascade do |t|
-    t.integer  "collection_id",                  null: false
-    t.string   "image_file_name",                null: false
+    t.integer  "collection_id",                   null: false
+    t.string   "image_file_name",                 null: false
     t.string   "image_content_type"
     t.integer  "image_file_size"
     t.datetime "image_updated_at"
-    t.string   "image_fingerprint",              null: false
+    t.string   "image_fingerprint",               null: false
     t.text     "image_meta"
-    t.datetime "created_at",                     null: false
-    t.datetime "updated_at",                     null: false
+    t.datetime "created_at",                      null: false
+    t.datetime "updated_at",                      null: false
     t.text     "json_response"
     t.integer  "status",             default: 0
+    t.jsonb    "data",               default: {}, null: false
+    t.text     "type"
   end
 
   add_index "images", ["image_fingerprint"], name: "index_images_on_image_fingerprint", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160718193812) do
+ActiveRecord::Schema.define(version: 20160720143041) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -61,7 +61,7 @@ ActiveRecord::Schema.define(version: 20160718193812) do
     t.boolean  "hide_title_on_home_page"
     t.text     "site_path"
     t.string   "url_slug"
-    t.integer  "image_id"
+    t.integer  "media_id"
   end
 
   add_index "collections", ["preview_mode"], name: "index_collections_on_preview_mode", using: :btree
@@ -105,24 +105,6 @@ ActiveRecord::Schema.define(version: 20160718193812) do
 
   add_index "honeypot_images", ["item_id"], name: "index_honeypot_images_on_item_id", using: :btree
 
-  create_table "images", force: :cascade do |t|
-    t.integer  "collection_id",                   null: false
-    t.text     "image_file_name"
-    t.string   "image_content_type"
-    t.integer  "image_file_size"
-    t.datetime "image_updated_at"
-    t.text     "image_fingerprint"
-    t.text     "image_meta"
-    t.datetime "created_at",                      null: false
-    t.datetime "updated_at",                      null: false
-    t.text     "json_response"
-    t.integer  "status",             default: 0
-    t.jsonb    "data",               default: {}, null: false
-    t.text     "media_type"
-  end
-
-  add_index "images", ["image_fingerprint"], name: "index_images_on_image_fingerprint", using: :btree
-
   create_table "items", force: :cascade do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -144,7 +126,7 @@ ActiveRecord::Schema.define(version: 20160718193812) do
     t.integer  "image_status_save",                default: 0
     t.string   "user_defined_id",                               null: false
     t.jsonb    "metadata",                         default: {}, null: false
-    t.integer  "image_id"
+    t.integer  "media_id"
   end
 
   add_index "items", ["collection_id", "user_defined_id"], name: "index_items_on_collection_id_and_user_defined_id", unique: true, using: :btree
@@ -160,6 +142,24 @@ ActiveRecord::Schema.define(version: 20160718193812) do
 
   add_index "items_pages", ["item_id", "page_id"], name: "index_items_pages_on_item_id_and_page_id", using: :btree
   add_index "items_pages", ["page_id", "item_id"], name: "index_items_pages_on_page_id_and_item_id", using: :btree
+
+  create_table "media", force: :cascade do |t|
+    t.integer  "collection_id",                        null: false
+    t.text     "image_file_name_save"
+    t.string   "image_content_type_save"
+    t.integer  "image_file_size_save"
+    t.datetime "image_updated_at_save"
+    t.text     "image_fingerprint_save"
+    t.text     "image_meta_save"
+    t.datetime "created_at",                           null: false
+    t.datetime "updated_at",                           null: false
+    t.text     "json_response_save"
+    t.integer  "status_save",             default: 0
+    t.jsonb    "data",                    default: {}, null: false
+    t.string   "type"
+  end
+
+  add_index "media", ["image_fingerprint_save"], name: "index_media_on_image_fingerprint_save", using: :btree
 
   create_table "pages", force: :cascade do |t|
     t.string   "unique_id"
@@ -205,7 +205,7 @@ ActiveRecord::Schema.define(version: 20160718193812) do
     t.integer  "uploaded_image_file_size_save"
     t.datetime "uploaded_image_updated_at_save"
     t.integer  "collection_id"
-    t.integer  "image_id"
+    t.integer  "media_id"
   end
 
   add_index "showcases", ["collection_id"], name: "index_showcases_on_collection_id", using: :btree
@@ -246,16 +246,16 @@ ActiveRecord::Schema.define(version: 20160718193812) do
   add_foreign_key "collection_configurations", "collections"
   add_foreign_key "collection_users", "collections"
   add_foreign_key "collection_users", "users"
-  add_foreign_key "collections", "images"
+  add_foreign_key "collections", "media", column: "media_id"
   add_foreign_key "items", "collections"
-  add_foreign_key "items", "images"
   add_foreign_key "items", "items", column: "parent_id"
+  add_foreign_key "items", "media", column: "media_id"
   add_foreign_key "items_pages", "items"
   add_foreign_key "items_pages", "pages"
   add_foreign_key "pages", "collections"
-  add_foreign_key "pages", "images"
+  add_foreign_key "pages", "media", column: "image_id"
   add_foreign_key "sections", "items"
   add_foreign_key "sections", "showcases"
   add_foreign_key "showcases", "collections"
-  add_foreign_key "showcases", "images"
+  add_foreign_key "showcases", "media", column: "media_id"
 end

--- a/spec/models/image_spec.rb
+++ b/spec/models/image_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Image do
   let(:image_with_spaces) { File.open(Rails.root.join("spec/fixtures", "test copy.jpg"), "r") }
 
-  [:image, :collection, :updated_at, :created_at].each do |field|
+  [:image, :collection, :status, :json_response, :updated_at, :created_at].each do |field|
     it "has the field #{field}" do
       expect(subject).to respond_to(field)
       expect(subject).to respond_to("#{field}=")

--- a/spec/models/media_spec.rb
+++ b/spec/models/media_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+
+RSpec.describe Media do
+  [:collection, :items, :updated_at, :created_at].each do |field|
+    it "has the field #{field}" do
+      expect(subject).to respond_to(field)
+      expect(subject).to respond_to("#{field}=")
+    end
+  end
+end

--- a/spec/services/find_or_create_image_spec.rb
+++ b/spec/services/find_or_create_image_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe FindOrCreateImage do
     allow(Image).to receive(:new) do |params|
       new_images[params[:image]]
     end
-    allow(Image).to receive(:where) do |clause, collection_id, image_fingerprint|
+    allow(Image).to receive(:where) do |_clause, collection_id, image_fingerprint|
       image_records.detect { |image| image.collection_id == collection_id && image.image_fingerprint == image_fingerprint }
     end
   end

--- a/spec/services/find_or_create_image_spec.rb
+++ b/spec/services/find_or_create_image_spec.rb
@@ -37,8 +37,8 @@ RSpec.describe FindOrCreateImage do
     allow(Image).to receive(:new) do |params|
       new_images[params[:image]]
     end
-    allow(Image).to receive(:where) do |params|
-      image_records.detect { |image| image.collection_id == params[:collection_id] && image.image_fingerprint == params[:image_fingerprint] }
+    allow(Image).to receive(:where) do |clause, collection_id, image_fingerprint|
+      image_records.detect { |image| image.collection_id == collection_id && image.image_fingerprint == image_fingerprint }
     end
   end
 

--- a/spec/services/save_collection_spec.rb
+++ b/spec/services/save_collection_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe SaveCollection, type: :model do
   subject { described_class.call(collection, params) }
   let(:collection) do
     instance_double(Collection,
-                    id: "id",
+                    id: 9,
                     "attributes=" => true,
                     save: true,
                     url: nil,


### PR DESCRIPTION
This changes the Image model into a more general Media model with a type and json data field to store the information about the image media. This will be used to also store other media types such as audio and video. This does not implement the actual Audio or Video models.