### PR TITLE
DEC-1156: Create audio video models

### DIFF
--- a/app/models/audio.rb
+++ b/app/models/audio.rb
@@ -1,0 +1,9 @@
+require "store_enum"
+
+class Audio < Media
+  store_accessor :data, :json_response
+  extend StoreEnum
+  store_enum :data, status: { allocated: 0, ready: 1 }
+
+  has_paper_trail
+end

--- a/app/models/audio.rb
+++ b/app/models/audio.rb
@@ -1,9 +1,7 @@
 require "store_enum"
 
 class Audio < Media
-  store_accessor :data, :json_response
   extend StoreEnum
   store_enum :data, status: { allocated: 0, ready: 1 }
-
-  has_paper_trail
+  store_accessor :data, :json_response
 end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,3 +1,5 @@
+require "store_enum"
+
 class Image < Media
   store_accessor :data,
                  :image_content_type,
@@ -7,67 +9,11 @@ class Image < Media
                  :image_meta,
                  :image_updated_at,
                  :json_response
+  extend StoreEnum
+  store_enum :data, status: { unprocessed: 0, processing: 1, ready: 2, unavailable: 3 }
 
   has_attached_file :image, restricted_characters: /[&$+,\/:;=?@<>\[\]{}\|\\^~%#]/
   validates_attachment_content_type :image, content_type: /\Aimage\/.*\Z/
 
-  # The following methods were added to recreate the behavior of enum status:
-  #   status, status=, unprocessed?, unprocessed!, processing?, processing!,
-  #   ready?, ready!, unavailable?, unavailable!
-  # These were added in order to resolve a conflict between store_accessor and enum.
-  # They both try to add status and status= methods, so reimplementing the enum methods
-  # to access the status inside of the data field
-  def status=(value)
-    if status_enum.has_key?(value) || value.blank?
-      data["status"] = status_enum[value]
-    elsif status_enum.has_value?(value)
-      data["status"] = value
-    else
-      raise ArgumentError, "'#{value}' is not a valid status"
-    end
-  end
-
-  def status
-    status_enum.key data["status"]
-  end
-
-  def unprocessed?
-    data["status"] == status_enum["unprocessed"]
-  end
-
-  def unprocessed!
-    data["status"] = status_enum["unprocessed"]
-  end
-
-  def processing?
-    data["status"] == status_enum["processing"]
-  end
-
-  def processing!
-    data["status"] = status_enum["processing"]
-  end
-
-  def ready?
-    data["status"] == status_enum["ready"]
-  end
-
-  def ready!
-    data["status"] = status_enum["ready"]
-  end
-
-  def unavailable?
-    data["status"] == status_enum["unavailable"]
-  end
-
-  def unavailable!
-    data["status"] = status_enum["unavailable"]
-  end
-
   has_paper_trail
-
-  private
-
-  def status_enum
-    { "unprocessed" => 0, "processing" => 1, "ready" => 2, "unavailable" => 3 }
-  end
 end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -14,6 +14,4 @@ class Image < Media
 
   has_attached_file :image, restricted_characters: /[&$+,\/:;=?@<>\[\]{}\|\\^~%#]/
   validates_attachment_content_type :image, content_type: /\Aimage\/.*\Z/
-
-  has_paper_trail
 end

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -2,4 +2,6 @@ class Media < ActiveRecord::Base
   belongs_to :collection
   has_many :items
   validates :collection, presence: true
+
+  has_paper_trail
 end

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -4,6 +4,4 @@ class Video < Media
   extend StoreEnum
   store_enum :data, status: { allocated: 0, ready: 1 }
   store_accessor :data, :json_response
-
-  has_paper_trail
 end

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -1,0 +1,9 @@
+require "store_enum"
+
+class Video < Media
+  extend StoreEnum
+  store_enum :data, status: { allocated: 0, ready: 1 }
+  store_accessor :data, :json_response
+
+  has_paper_trail
+end

--- a/db/migrate/20160805193022_add_unique_id_to_media.rb
+++ b/db/migrate/20160805193022_add_unique_id_to_media.rb
@@ -1,0 +1,6 @@
+class AddUniqueIdToMedia < ActiveRecord::Migration
+  def change
+    add_column :media, :uuid, :uuid
+    add_index :media, :uuid
+  end
+end

--- a/db/migrate/20160805194419_assign_media_unique_ids.rb
+++ b/db/migrate/20160805194419_assign_media_unique_ids.rb
@@ -1,0 +1,11 @@
+class AssignMediaUniqueIds < ActiveRecord::Migration
+  def up
+    Media.all.each do |media|
+      media.uuid = SecureRandom.uuid
+      media.save
+    end
+  end
+end
+
+class Media < ActiveRecord::Base
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160720143041) do
+ActiveRecord::Schema.define(version: 20160805194419) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -157,9 +157,11 @@ ActiveRecord::Schema.define(version: 20160720143041) do
     t.integer  "status_save",             default: 0
     t.jsonb    "data",                    default: {}, null: false
     t.string   "type"
+    t.uuid     "uuid"
   end
 
   add_index "media", ["image_fingerprint_save"], name: "index_media_on_image_fingerprint_save", using: :btree
+  add_index "media", ["uuid"], name: "index_media_on_uuid", using: :btree
 
   create_table "pages", force: :cascade do |t|
     t.string   "unique_id"

--- a/lib/store_enum.rb
+++ b/lib/store_enum.rb
@@ -1,0 +1,197 @@
+require 'active_support/core_ext/object/deep_dup'
+
+# Declare an enum attribute where the values map to integers in the database,
+# but can be queried by name. Example:
+#
+#   class Conversation < ActiveRecord::Base
+#     enum status: [ :active, :archived ]
+#   end
+#
+#   # conversation.update! status: 0
+#   conversation.active!
+#   conversation.active? # => true
+#   conversation.status  # => "active"
+#
+#   # conversation.update! status: 1
+#   conversation.archived!
+#   conversation.archived? # => true
+#   conversation.status    # => "archived"
+#
+#   # conversation.update! status: 1
+#   conversation.status = "archived"
+#
+#   # conversation.update! status: nil
+#   conversation.status = nil
+#   conversation.status.nil? # => true
+#   conversation.status      # => nil
+#
+# Scopes based on the allowed values of the enum field will be provided
+# as well. With the above example, it will create an +active+ and +archived+
+# scope.
+#
+# You can set the default value from the database declaration, like:
+#
+#   create_table :conversations do |t|
+#     t.column :status, :integer, default: 0
+#   end
+#
+# Good practice is to let the first declared status be the default.
+#
+# Finally, it's also possible to explicitly map the relation between attribute and
+# database integer with a +Hash+:
+#
+#   class Conversation < ActiveRecord::Base
+#     enum status: { active: 0, archived: 1 }
+#   end
+#
+# Note that when an +Array+ is used, the implicit mapping from the values to database
+# integers is derived from the order the values appear in the array. In the example,
+# <tt>:active</tt> is mapped to +0+ as it's the first element, and <tt>:archived</tt>
+# is mapped to +1+. In general, the +i+-th element is mapped to <tt>i-1</tt> in the
+# database.
+#
+# Therefore, once a value is added to the enum array, its position in the array must
+# be maintained, and new values should only be added to the end of the array. To
+# remove unused values, the explicit +Hash+ syntax should be used.
+#
+# In rare circumstances you might need to access the mapping directly.
+# The mappings are exposed through a class method with the pluralized attribute
+# name:
+#
+#   Conversation.statuses # => { "active" => 0, "archived" => 1 }
+#
+# Use that class method when you need to know the ordinal value of an enum:
+#
+#   Conversation.where("status <> ?", Conversation.statuses[:archived])
+#
+# Where conditions on an enum attribute must use the ordinal value of an enum.
+module StoreEnum
+  def self.extended(base) # :nodoc:
+    base.class_attribute(:defined_store_enums, instance_writer: false)
+    base.defined_store_enums = {}
+  end
+
+  def inherited(base) # :nodoc:
+    base.defined_store_enums = defined_store_enums.deep_dup
+    super
+  end
+
+  def store_enum(store, definitions)
+    klass = self
+    definitions.each do |name, values|
+      # statuses = { }
+      enum_values = ActiveSupport::HashWithIndifferentAccess.new
+      name        = name.to_sym
+
+      # def self.statuses statuses end
+      detect_enum_conflict!(name, name.to_s.pluralize, true)
+      klass.singleton_class.send(:define_method, name.to_s.pluralize) { enum_values }
+
+      _store_enum_methods_module.module_eval do
+        # def status=(value) self[:status] = statuses[value] end
+        klass.send(:detect_enum_conflict!, name, "#{name}=")
+        define_method("#{name}=") { |value|
+          if enum_values.has_key?(value) || value.blank?
+            self[store][name] = enum_values[value]
+          elsif enum_values.has_value?(value)
+            # Assigning a value directly is not a end-user feature, hence it's not documented.
+            # This is used internally to make building objects from the generated scopes work
+            # as expected, i.e. +Conversation.archived.build.archived?+ should be true.
+            self[store][name] = value
+          else
+            raise ArgumentError, "'#{value}' is not a valid #{name}"
+          end
+        }
+
+        # def status() statuses.key self[:status] end
+        klass.send(:detect_enum_conflict!, name, name)
+        define_method(name) { enum_values.key self[store][name] }
+
+        # def status_before_type_cast() statuses.key self[:status] end
+        klass.send(:detect_enum_conflict!, name, "#{name}_before_type_cast")
+        define_method("#{name}_before_type_cast") { enum_values.key self[store][name] }
+
+        pairs = values.respond_to?(:each_pair) ? values.each_pair : values.each_with_index
+        pairs.each do |value, i|
+          enum_values[value] = i
+
+          # def active?() status == 0 end
+          klass.send(:detect_enum_conflict!, name, "#{value}?")
+          define_method("#{value}?") { self[store][name] == i }
+
+          # def active!() update! status: :active end
+          klass.send(:detect_enum_conflict!, name, "#{value}!")
+          define_method("#{value}!") { update! name => value }
+
+          # scope :active, -> { where status: 0 }
+          klass.send(:detect_enum_conflict!, name, value, true)
+          klass.scope value, -> { klass.where name => i }
+        end
+      end
+      defined_store_enums[name.to_s] = enum_values
+    end
+  end
+
+  private
+    def _store_enum_methods_module
+      @_store_enum_methods_module ||= begin
+        mod = Module.new do
+          private
+            def save_changed_attribute(attr_name, value)
+              if (mapping = self.class.defined_store_enums[attr_name.to_s])
+                if attribute_changed?(attr_name)
+                  old = changed_attributes[attr_name]
+
+                  if mapping[old] == value
+                    changed_attributes.delete(attr_name)
+                  end
+                else
+                  old = clone_attribute_value(:read_attribute, attr_name)
+
+                  if old != value
+                    changed_attributes[attr_name] = mapping.key old
+                  end
+                end
+              else
+                super
+              end
+            end
+        end
+        include mod
+        mod
+      end
+    end
+
+    ENUM_CONFLICT_MESSAGE = \
+      "You tried to define an enum named \"%{enum}\" on the model \"%{klass}\", but " \
+      "this will generate a %{type} method \"%{method}\", which is already defined " \
+      "by %{source}."
+
+    def detect_enum_conflict!(enum_name, method_name, klass_method = false)
+      if klass_method && dangerous_class_method?(method_name)
+        raise ArgumentError, ENUM_CONFLICT_MESSAGE % {
+          enum: enum_name,
+          klass: self.name,
+          type: 'class',
+          method: method_name,
+          source: 'Active Record'
+        }
+      elsif !klass_method && dangerous_attribute_method?(method_name)
+        raise ArgumentError, ENUM_CONFLICT_MESSAGE % {
+          enum: enum_name,
+          klass: self.name,
+          type: 'instance',
+          method: method_name,
+          source: 'Active Record'
+        }
+      elsif !klass_method && method_defined_within?(method_name, _store_enum_methods_module, Module)
+        raise ArgumentError, ENUM_CONFLICT_MESSAGE % {
+          enum: enum_name,
+          klass: self.name,
+          type: 'instance',
+          method: method_name,
+          source: 'another enum'
+        }
+      end
+    end
+end

--- a/lib/store_enum.rb
+++ b/lib/store_enum.rb
@@ -1,4 +1,5 @@
 require 'active_support/core_ext/object/deep_dup'
+rubocop:disable all
 
 # Declare an enum attribute where the values map to integers in the database,
 # but can be queried by name. Example:
@@ -195,3 +196,4 @@ module StoreEnum
       end
     end
 end
+rubocop:enable all

--- a/lib/store_enum.rb
+++ b/lib/store_enum.rb
@@ -1,5 +1,4 @@
 require 'active_support/core_ext/object/deep_dup'
-rubocop:disable all
 
 # Declare an enum attribute where the values map to integers in the database,
 # but can be queried by name. Example:
@@ -196,4 +195,3 @@ module StoreEnum
       end
     end
 end
-rubocop:enable all

--- a/spec/models/audio_spec.rb
+++ b/spec/models/audio_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.describe Audio do
+  it "inherits Media" do
+    expect(described_class).to be < Media
+  end
+
+  [:allocated, :ready].each do |field|
+    it "has enum, #{field}" do
+      expect(subject).to respond_to("#{field}!")
+      expect(subject).to respond_to("#{field}?")
+    end
+  end
+end

--- a/spec/models/image_spec.rb
+++ b/spec/models/image_spec.rb
@@ -3,6 +3,10 @@ require "rails_helper"
 RSpec.describe Image do
   let(:image_with_spaces) { File.open(Rails.root.join("spec/fixtures", "test copy.jpg"), "r") }
 
+  it "inherits Media" do
+    expect(described_class).to be < Media
+  end
+
   [:image, :collection, :status, :json_response, :updated_at, :created_at].each do |field|
     it "has the field #{field}" do
       expect(subject).to respond_to(field)
@@ -26,11 +30,6 @@ RSpec.describe Image do
       expect(subject).to respond_to("#{field}!")
       expect(subject).to respond_to("#{field}?")
     end
-  end
-
-  it "has a papertrail" do
-    expect(subject).to respond_to(:paper_trail_enabled_for_model?)
-    expect(subject.paper_trail_enabled_for_model?).to be(true)
   end
 
   it "keeps spaces in the original filename" do

--- a/spec/models/media_spec.rb
+++ b/spec/models/media_spec.rb
@@ -1,10 +1,21 @@
 require "rails_helper"
 
 RSpec.describe Media do
-  [:collection, :items, :updated_at, :created_at].each do |field|
+  [:id, :uuid, :collection, :items, :updated_at, :created_at].each do |field|
     it "has the field #{field}" do
       expect(subject).to respond_to(field)
       expect(subject).to respond_to("#{field}=")
     end
+  end
+
+  [:collection].each do |field|
+    it "requires the field, #{field}" do
+      expect(subject).to have(1).error_on(field)
+    end
+  end
+
+  it "has a papertrail" do
+    expect(subject).to respond_to(:paper_trail_enabled_for_model?)
+    expect(subject.paper_trail_enabled_for_model?).to be(true)
   end
 end

--- a/spec/models/video_spec.rb
+++ b/spec/models/video_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.describe Video do
+  it "inherits Media" do
+    expect(described_class).to be < Media
+  end
+
+  [:allocated, :ready].each do |field|
+    it "has enum, #{field}" do
+      expect(subject).to respond_to("#{field}!")
+      expect(subject).to respond_to("#{field}?")
+    end
+  end
+end


### PR DESCRIPTION
This adds the Audio and Video models. I ended up making our own version of enum that works with store_accessors now that we have 3 different entities each with their own state system. It works just like rails enum, except you can pass a store accessor so that the enum value will be stored in that store instead of on the base of the model.