### PR TITLE
DEC-1115 Add thumbnail create / update for media

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -105,7 +105,7 @@ group :development, :test do
   gem "faker"
   gem "spring"
   gem "spring-commands-rspec"
-  gem "rake"
+  gem "rake", "< 11"
 
   gem "quiet_assets"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -380,7 +380,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rainbow (2.0.0)
-    rake (11.2.2)
+    rake (10.5.0)
     rb-fsevent (0.9.4)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
@@ -582,7 +582,7 @@ DEPENDENCIES
   rack-cache
   rails (~> 4.2.0)
   rails-erd
-  rake
+  rake (< 11)
   rb-readline
   react-rails
   responders (~> 2.0)

--- a/app/services/save_honeypot_image.rb
+++ b/app/services/save_honeypot_image.rb
@@ -51,7 +51,7 @@ class SaveHoneypotImage
   end
 
   def connection
-    @connection ||= Faraday.new(api_url) do |f|
+    @connection ||= Faraday.new(image_server_url) do |f|
       f.request :multipart
       f.request :url_encoded
       f.adapter :net_http
@@ -68,10 +68,10 @@ class SaveHoneypotImage
   end
 
   def post
-    { application_id: "honeycomb", group_id: image.collection.id, item_id: image.id, image: upload_image }
+    {application_id: "honeycomb", group_id: image.collection.id, item_id: image.id, image: upload_image}
   end
 
-  def api_url
-    Rails.configuration.settings.honeypot_url
+  def image_server_url
+    Rails.configuration.settings.image_server_url
   end
 end

--- a/app/services/save_honeypot_image.rb
+++ b/app/services/save_honeypot_image.rb
@@ -68,7 +68,7 @@ class SaveHoneypotImage
   end
 
   def post
-    {application_id: "honeycomb", group_id: image.collection.id, item_id: image.id, image: upload_image}
+    { application_id: "honeycomb", group_id: image.collection.id, item_id: image.id, image: upload_image }
   end
 
   def image_server_url

--- a/app/services/save_media_thumbnail.rb
+++ b/app/services/save_media_thumbnail.rb
@@ -1,0 +1,94 @@
+class SaveMediaThumbnail
+  attr_reader :image, :item, :media
+
+  def self.call(*args)
+    new(*args).save!
+  end
+
+  def initialize(image:, item:, media:)
+    @image = image
+    @item = item
+    @media = media
+  end
+
+  def save!
+    @image_response = send_image_request
+    return false unless @image_response
+    if update_media_record
+      @media_response.body
+    else
+      false
+    end
+  end
+
+  private
+
+  def send_image_request
+    response = image_server_connection.post("/api/images", image_post)
+    if response.success?
+      response
+    else
+      false
+    end
+  end
+
+  def send_media_request
+    response = media_server_connection.put("/v1/media_files/" + @media.uuid, media_post)
+    if response.success?
+      response
+    else
+      false
+    end
+  end
+
+  def update_media_record
+    @media_response = send_media_request
+    if @media_response
+      @media.data["json_response"] = @media_response.body["object"]
+      @media.save!
+    else
+      false
+    end
+  end
+
+  def image_server_connection
+    @image_server_connection ||= Faraday.new(image_server_url) do |f|
+      f.request :multipart
+      f.request :url_encoded
+      f.adapter :net_http
+      f.response :json, content_type: "application/json"
+    end
+  end
+
+  def media_server_connection
+    @media_server_connection ||= Faraday.new(media_server_url) do |f|
+      f.request :url_encoded
+      f.adapter :net_http
+      f.response :json, content_type: "application/json"
+    end
+  end
+
+  def media_image
+    media.thumbnail_url
+  end
+
+  def upload_image
+    Faraday::UploadIO.new(@image.path, "image")
+  end
+
+  def image_post
+    { application_id: "honeycomb", group_id: @item.collection.id, item_id: @item.id, image: upload_image }
+  end
+
+  def media_post
+    { application_id: "honeycomb", media_file: { thumbnail_url: @image_response.body["contentUrl"] } }
+  end
+
+  def image_server_url
+    Rails.configuration.settings.image_server_url
+  end
+
+  def media_server_url
+    Rails.configuration.settings.media_server_url
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -6,8 +6,9 @@ defaults: &defaults
 
 local: &local
   <<: *defaults
-  honeypot_url: 'http://localhost:3019'
+  image_server_url: 'http://localhost:3019'
   beehive_url: 'http://localhost:3018'
+  media_server_url: 'http://localhost:3023'
 
 vm: &vm
   <<: *defaults
@@ -23,11 +24,13 @@ test:
 pre_production:
   <<: *vm
   cas_base: https://login.nd.edu/cas
-  honeypot_url: https://honeypotpprd.library.nd.edu
+  image_server_url: https://honeypotpprd.library.nd.edu
   beehive_url: https://collections-pprd.library.nd.edu
+  media_server_url: https://buzz-pprd.library.nd.edu
 
 production:
   <<: *vm
   cas_base: https://login.nd.edu/cas
-  honeypot_url: https://honeypot.library.nd.edu
+  image_server_url: https://honeypot.library.nd.edu
   beehive_url: https://collections.library.nd.edu
+  media_server_url: https://buzz.library.nd.edu

--- a/spec/fixtures/buzz_response.json
+++ b/spec/fixtures/buzz_response.json
@@ -1,0 +1,20 @@
+{
+  "@context":"http://schema.org",
+  "@type":"UpdateAction",
+  "actionStatus":"CompletedActionStatus",
+  "object":{
+    "@context":"http://schema.org",
+    "@type":"VideoObject",
+    "@id":"7af44cac-f418-4767-9371-58a6a6f2bd93",
+    "description":"bubba_smith.mp4",
+    "name":"bubba_smith.mp4",
+    "thumbnailUrl":"http://localhost:3019/images/honeycomb/000/001/000/004/grumpy_cat.jpeg",
+    "uploadDate":"2016-08-16T15:54:25.915Z",
+    "embedUrl":"http://localhost:3023/?id=7af44cac-f418-4767-9371-58a6a6f2bd93",
+    "contentUrl":[
+      "http://wowza.library.nd.edu:1935/buzz_wow/_definst_/mp4:amazons3/buzz-bucket.library.nd.edu/bubba_smit.mp4/playlist.m3u8",
+      "rtmp://wowza.library.nd.edu:1935/buzz_wow/_definst_/mp4:amazons3/buzz-bucket.library.nd.edu/bubba_smit.mp4"
+    ],
+    "url":"http://localhost:3023/v1/media_files/7af44cac-f418-4767-9371-58a6a6f2bd93"
+  }
+}

--- a/spec/services/save_honeypot_image_spec.rb
+++ b/spec/services/save_honeypot_image_spec.rb
@@ -117,9 +117,9 @@ RSpec.describe SaveHoneypotImage do
     end
   end
 
-  describe "#api_url" do
+  describe "#image_server_url" do
     it "returns a url to the honeypot application" do
-      expect(subject.send(:api_url)).to eq("http://localhost:3019")
+      expect(subject.send(:image_server_url)).to eq("http://localhost:3019")
     end
   end
 

--- a/spec/services/save_media_thumbnail_spec.rb
+++ b/spec/services/save_media_thumbnail_spec.rb
@@ -1,0 +1,175 @@
+require "rails_helper"
+
+RSpec.describe SaveMediaThumbnail do
+  subject { described_class.new(image: image, item: item, media: video) }
+
+  let(:image_server_json) { JSON.parse(File.read(File.join(Rails.root, "spec/fixtures/honeypot_response.json"))) }
+  let(:media_server_json) { JSON.parse(File.read(File.join(Rails.root, "spec/fixtures/buzz_response.json"))) }
+  let(:image) { File.new(File.join(Rails.root, "spec/fixtures/test.jpg"), "r") }
+
+  let(:image_server_connection) do
+    Faraday.new do |builder|
+      builder.adapter :test do |stub|
+        stub.post("/api/images") { |_env| [200, { content_type: "application/json" }, image_server_json] }
+      end
+    end
+  end
+
+  let(:media_server_connection) do
+    Faraday.new do |builder|
+      builder.adapter :test do |stub|
+        stub.put("/v1/media_files/xxxx-yyyy-zzzz") do |_env|
+          [
+            200,
+            { content_type: "application/json" },
+            media_server_json
+          ]
+        end
+      end
+    end
+  end
+
+  let(:failed_image_connection) do
+    Faraday.new do |builder|
+      builder.adapter :test do |stub|
+        stub.post("/api/images") { |_env| [500, { content_type: "application/json" }, "failed"] }
+      end
+    end
+  end
+
+  let(:failed_media_connection) do
+    Faraday.new do |builder|
+      builder.adapter :test do |stub|
+        stub.put("/v1/media_files/xxxx-yyyy-zzzz") { |_env| [500, { content_type: "application/json" }, "failed"] }
+      end
+    end
+  end
+
+  let(:item) { instance_double(Item, id: 1, collection: collection) }
+
+  let(:video) do
+    instance_double(Video,
+                    id: 10,
+                    collection: collection,
+                    "json_response=" => true,
+                    data: { object: "test" },
+                    save!: true,
+                    uuid: "xxxx-yyyy-zzzz",
+                    items: [item])
+  end
+
+  let(:collection) { double(Collection, id: 100, image: image_file, save: true) }
+  let(:image_file) { Rack::Test::UploadedFile.new(Rails.root.join("spec/fixtures/test.jpg"), "image/jpeg") }
+  let(:image_response) { double(success?: true, body: image_server_json) }
+  let(:media_response) { double(success?: true, body: media_server_json) }
+
+  describe "successful request" do
+    before(:each) do
+      expect_any_instance_of(described_class).to receive(:image_server_connection).and_return(image_server_connection)
+      expect_any_instance_of(described_class).to receive(:media_server_connection).and_return(media_server_connection)
+    end
+
+    it "sends a request to the image server" do
+      expect(image_server_connection).to receive(:post).with(
+        "/api/images",
+        application_id: "honeycomb",
+        group_id: 100,
+        item_id: 1,
+        image: kind_of(Faraday::UploadIO)
+      ).and_return(image_response)
+
+      subject.save!
+    end
+
+    it "sends an update request to the media server" do
+      expect(media_server_connection).to receive(:put).with(
+        "/v1/media_files/xxxx-yyyy-zzzz",
+        application_id: "honeycomb",
+        media_file: { thumbnail_url: "http://localhost:3019/images/test/000/001/000/001/1920x1200.jpeg" }
+      )
+        .and_return(media_response)
+
+      subject.save!
+    end
+  end
+
+  describe "#save!" do
+    before(:each) do
+      expect_any_instance_of(described_class).to receive(:image_server_connection).and_return(image_server_connection)
+      expect_any_instance_of(described_class).to receive(:media_server_connection).and_return(media_server_connection)
+    end
+
+    it "returns the image when the request is successful" do
+      expect(subject.save!).to eq(media_response.body)
+    end
+
+    it "returns false when the media does not save" do
+      expect(video).to receive(:save!).and_return(false)
+      expect(subject.save!).to be(false)
+    end
+  end
+
+  describe "when request fails" do
+    it "returns false when the image request fails" do
+      expect_any_instance_of(described_class).to receive(:image_server_connection).and_return(failed_image_connection)
+      expect(subject.save!).to eq(false)
+    end
+
+    it "returns false when the media request fails" do
+      expect_any_instance_of(described_class).to receive(:media_server_connection).and_return(failed_media_connection)
+      expect(subject.save!).to eq(false)
+    end
+  end
+
+  describe "self" do
+    subject { described_class }
+
+    describe "#call" do
+      it "calls save! on a new instance" do
+        expect(subject).to receive(:new).with(image: image, item: item, media: video).and_call_original
+        expect_any_instance_of(described_class).to receive(:save!).and_return("saved!")
+        expect(subject.call(image: image, item: item, media: video)).to eq("saved!")
+      end
+    end
+  end
+
+  describe "#image_server_connection" do
+    it "is a Faraday connection" do
+      connection = subject.send(:image_server_connection)
+      expect(connection).to be_kind_of(Faraday::Connection)
+      expect(connection.url_prefix.to_s).to eq("http://localhost:3019/")
+    end
+  end
+
+  describe "#media_server_connection" do
+    it "is a Faraday connection" do
+      connection = subject.send(:media_server_connection)
+      expect(connection).to be_kind_of(Faraday::Connection)
+      expect(connection.url_prefix.to_s).to eq("http://localhost:3023/")
+    end
+  end
+
+  describe "#image_server_url" do
+    it "uses the collection id as the group id" do
+      allow_any_instance_of(described_class).to receive(:image_server_connection).and_return(image_server_connection)
+      subject = described_class.new(image: image, item: item, media: video)
+      expect(image_server_connection).to receive(:post).with(
+        "/api/images",
+        hash_including(group_id: collection.id)
+      ).and_return(image_response)
+      subject.save!
+    end
+  end
+
+  describe "#media_server_url" do
+    it "presents correct media_file data as put param" do
+      allow_any_instance_of(described_class).to receive(:media_server_connection).and_return(media_server_connection)
+      subject = described_class.new(image: image, item: item, media: video)
+      expect(media_server_connection).to receive(:put).with(
+        "/v1/media_files/xxxx-yyyy-zzzz",
+        hash_including(media_file: { thumbnail_url: "http://localhost:3019/images/honeycomb/000/100/000/001/test.jpg" })
+      ).and_return(media_response)
+      subject.save!
+    end
+  end
+end

--- a/spec/services/save_media_thumbnail_spec.rb
+++ b/spec/services/save_media_thumbnail_spec.rb
@@ -86,8 +86,8 @@ RSpec.describe SaveMediaThumbnail do
         "/v1/media_files/xxxx-yyyy-zzzz",
         application_id: "honeycomb",
         media_file: { thumbnail_url: "http://localhost:3019/images/test/000/001/000/001/1920x1200.jpeg" }
-      )
-        .and_return(media_response)
+      ).
+        and_return(media_response)
 
       subject.save!
     end

--- a/spec/services/save_media_thumbnail_spec.rb
+++ b/spec/services/save_media_thumbnail_spec.rb
@@ -112,10 +112,12 @@ RSpec.describe SaveMediaThumbnail do
   describe "when request fails" do
     it "returns false when the image request fails" do
       expect_any_instance_of(described_class).to receive(:image_server_connection).and_return(failed_image_connection)
+      allow_any_instance_of(described_class).to receive(:media_server_connection).and_return(media_server_connection)
       expect(subject.save!).to eq(false)
     end
 
     it "returns false when the media request fails" do
+      allow_any_instance_of(described_class).to receive(:image_server_connection).and_return(image_server_connection)
       expect_any_instance_of(described_class).to receive(:media_server_connection).and_return(failed_media_connection)
       expect(subject.save!).to eq(false)
     end
@@ -152,6 +154,7 @@ RSpec.describe SaveMediaThumbnail do
   describe "#image_server_url" do
     it "uses the collection id as the group id" do
       allow_any_instance_of(described_class).to receive(:image_server_connection).and_return(image_server_connection)
+      allow_any_instance_of(described_class).to receive(:media_server_connection).and_return(media_server_connection)
       subject = described_class.new(image: image, item: item, media: video)
       expect(image_server_connection).to receive(:post).with(
         "/api/images",
@@ -163,11 +166,12 @@ RSpec.describe SaveMediaThumbnail do
 
   describe "#media_server_url" do
     it "presents correct media_file data as put param" do
+      allow_any_instance_of(described_class).to receive(:image_server_connection).and_return(image_server_connection)
       allow_any_instance_of(described_class).to receive(:media_server_connection).and_return(media_server_connection)
       subject = described_class.new(image: image, item: item, media: video)
       expect(media_server_connection).to receive(:put).with(
         "/v1/media_files/xxxx-yyyy-zzzz",
-        hash_including(media_file: { thumbnail_url: "http://localhost:3019/images/honeycomb/000/100/000/001/test.jpg" })
+        hash_including(media_file: { thumbnail_url: "http://localhost:3019/images/test/000/001/000/001/1920x1200.jpeg" })
       ).and_return(media_response)
       subject.save!
     end


### PR DESCRIPTION
**Goal**: Add functionality that supports adding a thumbnail / still image for a media file (audio or video).
**Work**: Implemented new service class, renamed some methods to make them more generic, and added configs