### PR TITLE
Dec 1174  Action to finish uploading an image

### DIFF
--- a/app/controllers/v1/media_controller.rb
+++ b/app/controllers/v1/media_controller.rb
@@ -14,10 +14,10 @@ module V1
     def finish_upload
       @media = MediaQuery.new.public_find
 
-      media = FinishMediaUpload.call(media: @media, params: finish_params)
+      FinishMediaUpload.call(media: @media)
 
-      status = media.valid? ? :ok : :unprocessable_entity
-      render json: media.to_json, status: status
+      status = @media.valid? ? :ok : :unprocessable_entity
+      render json: @media.to_json, status: status
     end
 
     private

--- a/app/controllers/v1/media_controller.rb
+++ b/app/controllers/v1/media_controller.rb
@@ -11,6 +11,15 @@ module V1
       render json: media.to_json, status: status
     end
 
+    def finish_upload
+      @media = MediaQuery.new.public_find
+
+      media = FinishMediaUpload.call(media: @media, params: finish_params)
+
+      status = media.valid? ? :ok : :unprocessable_entity
+      render json: media.to_json, status: status
+    end
+
     private
 
     def create_params

--- a/app/queries/media_query.rb
+++ b/app/queries/media_query.rb
@@ -1,0 +1,11 @@
+class MediaQuery
+  attr_reader :relation
+
+  def initialize(relation = Media.all)
+    @relation = relation
+  end
+
+  def public_find(id)
+    relation.find_by!(uuid: id)
+  end
+end

--- a/app/services/finish_media_upload.rb
+++ b/app/services/finish_media_upload.rb
@@ -12,7 +12,7 @@ class FinishMediaUpload
 
   def finish!
     media.status = :ready
-    media.save!
+    media.save
     media.serializer = SerializeMedia
 
     media

--- a/app/services/finish_media_upload.rb
+++ b/app/services/finish_media_upload.rb
@@ -1,0 +1,20 @@
+# Serves as a factory for creating media subtypes
+class FinishMediaUpload
+  attr_reader :media
+
+  def self.call(media:)
+    new(media: media).finish!
+  end
+
+  def initialize(media:)
+    @media = media
+  end
+
+  def finish!
+    media.status = :ready
+    media.save!
+    media.serializer = SerializeMedia
+
+    media
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -100,6 +100,11 @@ Rails.application.routes.draw do
       get :showcases, defaults: { format: :json }
       get :pages, defaults: { format: :json }
     end
+
+    resources :media, only: [] do
+      put "finish_upload", to: "media#finish_upload"
+    end
+
     resources :showcases, only: [:show], defaults: { format: :json }
     resources :pages, only: [:show], defaults: { format: :json }
     resources :sections, only: [:show], defaults: { format: :json }

--- a/spec/controllers/v1/media_controller_spec.rb
+++ b/spec/controllers/v1/media_controller_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe V1::MediaController, type: :controller do
     end
     subject { put :finish_upload, medium_id: media.id }
 
-    describe "finsih_upload" do
+    describe "finish_upload" do
       before(:each) do
         sign_in_admin
         allow_any_instance_of(MediaQuery).to receive(:public_find).and_return(media)

--- a/spec/queries/media_query_spec.rb
+++ b/spec/queries/media_query_spec.rb
@@ -1,0 +1,17 @@
+require "rails"
+
+describe MediaQuery do
+  subject { described_class.new(relation) }
+  let(:relation) { Media.all }
+
+  describe "public_find" do
+    it "calls public_find!" do
+      expect(relation).to receive(:find_by!).with(uuid: "asdf")
+      subject.public_find("asdf")
+    end
+
+    it "raises an error on not found" do
+      expect { subject.public_find("asdf") }.to raise_error ActiveRecord::RecordNotFound
+    end
+  end
+end

--- a/spec/services/finish_media_upload_spec.rb
+++ b/spec/services/finish_media_upload_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+require "support/item_meta_helpers"
+
+RSpec.describe FinishMediaUpload do
+  let(:media) { instance_double(Video, id: 1, save!: true, "serializer=" => true, "status=" => 1) }
+  let(:subject) { FinishMediaUpload.call(media: media) }
+
+  it "sets the status to ready" do
+    expect(media).to receive("status=").with(:ready)
+    subject
+  end
+
+  it "saves the media" do
+    expect(media).to receive(:save!).and_return(true)
+    subject
+  end
+
+  it "sets the serializer" do
+    expect(media).to receive("serializer=").with(SerializeMedia)
+    subject
+  end
+
+  it "returns the media object" do
+    expect(subject).to eq(media)
+  end
+end

--- a/spec/services/finish_media_upload_spec.rb
+++ b/spec/services/finish_media_upload_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 require "support/item_meta_helpers"
 
 RSpec.describe FinishMediaUpload do
-  let(:media) { instance_double(Video, id: 1, save!: true, "serializer=" => true, "status=" => 1) }
+  let(:media) { instance_double(Video, id: 1, save: true, "serializer=" => true, "status=" => 1) }
   let(:subject) { FinishMediaUpload.call(media: media) }
 
   it "sets the status to ready" do
@@ -11,7 +11,7 @@ RSpec.describe FinishMediaUpload do
   end
 
   it "saves the media" do
-    expect(media).to receive(:save!).and_return(true)
+    expect(media).to receive(:save).and_return(true)
     subject
   end
 


### PR DESCRIPTION
This PR does not cover post back to buzz if we decide to do the post back.   It only covers moving the state from allocated to ready.  We will need to discuss if we wish for post back to happen.  DEC-1175 references dealing with the buzz side of the transaction.  

Added an action to finish upload at 
/v1/media/#id/finish_upload. 

Added service class to perform the transition
Added Query object for media.  
