### PR TITLE
Post to Buzz

### DIFF
--- a/app/controllers/v1/media_controller.rb
+++ b/app/controllers/v1/media_controller.rb
@@ -12,7 +12,7 @@ module V1
     end
 
     def finish_upload
-      @media = MediaQuery.new.public_find
+      @media = MediaQuery.new.public_find(params[:medium_id])
 
       FinishMediaUpload.call(media: @media)
 

--- a/app/errors/buzz/internal_server_error.rb
+++ b/app/errors/buzz/internal_server_error.rb
@@ -1,0 +1,3 @@
+module Buzz
+  class InternalServerError < StandardError; end
+end

--- a/app/errors/buzz/unprocessable_entity.rb
+++ b/app/errors/buzz/unprocessable_entity.rb
@@ -1,0 +1,3 @@
+module Buzz
+  class UnprocessableEntity < StandardError; end
+end

--- a/app/models/audio.rb
+++ b/app/models/audio.rb
@@ -3,5 +3,5 @@ require "store_enum"
 class Audio < Media
   extend StoreEnum
   store_enum :data, status: { allocated: 0, ready: 1 }
-  store_accessor :data, :file_name, :json_response
+  store_accessor :data, :file_name, :thumbnail_url, :json_response
 end

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -3,5 +3,5 @@ require "store_enum"
 class Video < Media
   extend StoreEnum
   store_enum :data, status: { allocated: 0, ready: 1 }
-  store_accessor :data, :file_name, :json_response
+  store_accessor :data, :file_name, :thumbnail_url, :json_response
 end

--- a/app/services/allocate_s3_url.rb
+++ b/app/services/allocate_s3_url.rb
@@ -1,17 +1,25 @@
 class AllocateS3Url
   attr_reader :uid, :filename
 
-  def self.call(uid, filename)
-    new(uid, filename).generate
-  end
-
   def initialize(uid, filename)
     @filename = filename
     @uid = uid
   end
 
-  def generate
+  def self.presigned_url(uid, filename)
+    new(uid, filename).generate_presigned_url
+  end
+
+  def self.public_url(uid, filename)
+    new(uid, filename).generate_public_url
+  end
+
+  def generate_presigned_url
     bucket_object.presigned_url(:put, expires_in: 3600)
+  end
+
+  def generate_public_url
+    bucket_object.public_url
   end
 
   private

--- a/app/services/allocate_s3_url.rb
+++ b/app/services/allocate_s3_url.rb
@@ -41,7 +41,9 @@ class AllocateS3Url
   end
 
   def s3
-    @s3 ||= Aws::S3::Resource.new
+    credentials = Aws::Credentials.new(configuration["access_key_id"], configuration["secret_access_key"])
+    client = Aws::S3::Client.new(region: configuration["region"], credentials: credentials)
+    @s3 ||= Aws::S3::Resource.new(client: client)
   end
 
   def configuration

--- a/app/services/buzz_media.rb
+++ b/app/services/buzz_media.rb
@@ -1,0 +1,75 @@
+# Handles CRUD operations on the media server Buzz for the associated
+# media object
+class BuzzMedia
+  attr_reader :media
+
+  def initialize(media:)
+    @media = media
+  end
+
+  def self.call_create(media:)
+    new(media: media).create
+  end
+
+  def self.call_update(media:)
+    new(media: media).update
+  end
+
+  def create
+    response = media_server_connection.post("/v1/media_files", create_json)
+    if response.success?
+      response.body["object"]
+    else
+      raise_exception(faraday_response: response)
+    end
+  end
+
+  def update
+    response = media_server_connection.put("/v1/media_files/" + @media.json_response["@id"], update_json)
+    if response.success?
+      response.body["object"]
+    else
+      raise_exception(faraday_response: response)
+    end
+  end
+
+  private
+
+  def create_json
+    {
+      media_file: {
+        file_path: AllocateS3Url.public_url(media.uuid, media.file_name),
+        media_type: @media.type.downcase
+      }
+    }
+  end
+
+  def update_json
+    {
+      media_file: {
+        thumbnail_url: @media.thumbnail_url
+      }
+    }
+  end
+
+  def raise_exception(faraday_response:)
+    case faraday_response.status
+    when 422
+      raise Buzz::UnprocessableEntity, faraday_response.body
+    else
+      raise Buzz::InternalServerError
+    end
+  end
+
+  def media_server_connection
+    @media_server_connection ||= Faraday.new(media_server_url) do |f|
+      f.request :url_encoded
+      f.adapter :net_http
+      f.response :json, content_type: "application/json"
+    end
+  end
+
+  def media_server_url
+    Rails.configuration.settings.media_server_url
+  end
+end

--- a/app/services/finish_media_upload.rb
+++ b/app/services/finish_media_upload.rb
@@ -11,10 +11,14 @@ class FinishMediaUpload
   end
 
   def finish!
-    media.status = :ready
-    media.save
-    media.serializer = SerializeMedia
+    result = BuzzMedia.call_create(media: media)
+    if result
+      media.json_response = result
+      media.status = :ready
+      media.save
+    end
 
+    media.serializer = SerializeMedia
     media
   end
 end

--- a/app/services/save_media_thumbnail.rb
+++ b/app/services/save_media_thumbnail.rb
@@ -15,7 +15,7 @@ class SaveMediaThumbnail
     @image_response = send_image_request
     return false unless @image_response
     if update_media_record
-      @media_response.body
+      true
     else
       false
     end
@@ -32,19 +32,11 @@ class SaveMediaThumbnail
     end
   end
 
-  def send_media_request
-    response = media_server_connection.put("/v1/media_files/" + @media.uuid, media_post)
-    if response.success?
-      response
-    else
-      false
-    end
-  end
-
   def update_media_record
-    @media_response = send_media_request
+    @media.thumbnail_url = @image_response.body["contentUrl"]
+    @media_response = BuzzMedia.call_update(media: @media)
     if @media_response
-      @media.data["json_response"] = @media_response.body["object"]
+      @media.data["json_response"] = @media_response
       @media.save!
     else
       false
@@ -54,14 +46,6 @@ class SaveMediaThumbnail
   def image_server_connection
     @image_server_connection ||= Faraday.new(image_server_url) do |f|
       f.request :multipart
-      f.request :url_encoded
-      f.adapter :net_http
-      f.response :json, content_type: "application/json"
-    end
-  end
-
-  def media_server_connection
-    @media_server_connection ||= Faraday.new(media_server_url) do |f|
       f.request :url_encoded
       f.adapter :net_http
       f.response :json, content_type: "application/json"
@@ -80,15 +64,7 @@ class SaveMediaThumbnail
     { application_id: "honeycomb", group_id: @item.collection.id, item_id: @item.id, image: upload_image }
   end
 
-  def media_post
-    { application_id: "honeycomb", media_file: { thumbnail_url: @image_response.body["contentUrl"] } }
-  end
-
   def image_server_url
     Rails.configuration.settings.image_server_url
-  end
-
-  def media_server_url
-    Rails.configuration.settings.media_server_url
   end
 end

--- a/app/services/save_media_thumbnail.rb
+++ b/app/services/save_media_thumbnail.rb
@@ -33,7 +33,7 @@ class SaveMediaThumbnail
   end
 
   def update_media_record
-    @media.thumbnail_url = @image_response.body["contentUrl"]
+    @media.thumbnail_url = @image_response.body["thumbnail/medium"]["contentUrl"]
     @media_response = BuzzMedia.call_update(media: @media)
     if @media_response
       @media.data["json_response"] = @media_response

--- a/app/services/save_media_thumbnail.rb
+++ b/app/services/save_media_thumbnail.rb
@@ -52,10 +52,6 @@ class SaveMediaThumbnail
     end
   end
 
-  def media_image
-    media.thumbnail_url
-  end
-
   def upload_image
     Faraday::UploadIO.new(@image.path, "image")
   end

--- a/app/services/serialize_new_s3_media.rb
+++ b/app/services/serialize_new_s3_media.rb
@@ -1,7 +1,7 @@
 class SerializeNewS3Media
   def self.to_hash(media:)
     result = SerializeMedia.to_hash(media: media)
-    result[:upload_url] = AllocateS3Url.call(media.uuid, media.file_name)
+    result[:upload_url] = AllocateS3Url.presigned_url(media.uuid, media.file_name)
     result
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,6 +12,7 @@ module ItemAdmin
       Rails.root.join("lib"),
       Rails.root.join("app", "queries"),
       Rails.root.join("app", "decorators"),
+      Rails.root.join("app", "errors"),
       Rails.root.join("app", "policy"),
       Rails.root.join("app", "services"),
       Rails.root.join("app", "forms"),

--- a/spec/controllers/v1/media_controller_spec.rb
+++ b/spec/controllers/v1/media_controller_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe V1::MediaController, type: :controller do
     describe "finish_upload" do
       before(:each) do
         sign_in_admin
-        allow_any_instance_of(MediaQuery).to receive(:public_find).and_return(media)
+        allow_any_instance_of(MediaQuery).to receive(:public_find).with(media.id).and_return(media)
       end
 
       it "uses the FinishMediaUpload service" do

--- a/spec/models/audio_spec.rb
+++ b/spec/models/audio_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Audio do
     expect(described_class).to be < Media
   end
 
-  [:file_name, :json_response].each do |field|
+  [:file_name, :thumbnail_url, :json_response].each do |field|
     it "has field, #{field}" do
       expect(subject).to respond_to(field)
       expect(subject).to respond_to("#{field}=")

--- a/spec/models/video_spec.rb
+++ b/spec/models/video_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Video do
     expect(described_class).to be < Media
   end
 
-  [:file_name, :json_response].each do |field|
+  [:file_name, :thumbnail_url, :json_response].each do |field|
     it "has field, #{field}" do
       expect(subject).to respond_to(field)
       expect(subject).to respond_to("#{field}=")

--- a/spec/services/allocate_s3_url_spec.rb
+++ b/spec/services/allocate_s3_url_spec.rb
@@ -1,42 +1,68 @@
 require "rails_helper"
 
 describe AllocateS3Url do
-  subject { described_class.call(uid, filename) }
   let(:uid) { "abcdefg" }
   let(:filename) { "filename.jpg" }
 
   # mocks for aws api
   let(:s3) { double(bucket: bucket) }
   let(:bucket) { double(object: bucket_object) }
-  let(:bucket_object) { double(presigned_url: url) }
-  let(:url) { "url" }
+  let(:bucket_object) { double(presigned_url: "presigned url", public_url: "public url") }
 
   before(:each) do
     allow_any_instance_of(described_class).to receive(:s3).and_return(s3)
   end
 
-  it "generates a url from the s3 bucket" do
-    expect(bucket_object).to receive(:presigned_url).and_return(url)
-    subject
+  describe "presigned_url" do
+    subject { described_class.presigned_url(uid, filename) }
+
+    it "generates a url from the s3 bucket" do
+      expect(bucket_object).to receive(:presigned_url).and_return("presigned url")
+      subject
+    end
+
+    it "returns the url from the s3 bucket" do
+      expect(subject).to eq("presigned url")
+    end
+
+    it "passes a new filename based on the uid and the filename" do
+      expect(bucket).to receive(:object).with("abcdefg.jpg").and_return(bucket_object)
+      subject
+    end
+
+    it "tells s3 which bucket to use" do
+      allow_any_instance_of(described_class).to receive(:bucket_name).and_return("buckety")
+      expect(s3).to receive(:bucket).with("buckety").and_return(bucket)
+      subject
+    end
+
+    it "sets the time limit to 1 hour" do
+      expect(bucket_object).to receive(:presigned_url).with(:put, expires_in: 3600)
+      subject
+    end
   end
 
-  it "returns the url from the s3 bucket" do
-    expect(subject).to eq(url)
-  end
+  describe "public_url" do
+    subject { described_class.public_url(uid, filename) }
 
-  it "passes a new filename based on the uid and the filename" do
-    expect(bucket).to receive(:object).with("abcdefg.jpg").and_return(bucket_object)
-    subject
-  end
+    it "generates a url from the s3 bucket" do
+      expect(bucket_object).to receive(:public_url).and_return("public url")
+      subject
+    end
 
-  it "tells s3 which bucket to use" do
-    allow_any_instance_of(described_class).to receive(:bucket_name).and_return("buckety")
-    expect(s3).to receive(:bucket).with("buckety").and_return(bucket)
-    subject
-  end
+    it "returns the url from the s3 bucket" do
+      expect(subject).to eq("public url")
+    end
 
-  it "sets the time limit to 1 hour" do
-    expect(bucket_object).to receive(:presigned_url).with(:put, expires_in: 3600)
-    subject
+    it "passes a new filename based on the uid and the filename" do
+      expect(bucket).to receive(:object).with("abcdefg.jpg").and_return(bucket_object)
+      subject
+    end
+
+    it "tells s3 which bucket to use" do
+      allow_any_instance_of(described_class).to receive(:bucket_name).and_return("buckety")
+      expect(s3).to receive(:bucket).with("buckety").and_return(bucket)
+      subject
+    end
   end
 end

--- a/spec/services/allocate_s3_url_spec.rb
+++ b/spec/services/allocate_s3_url_spec.rb
@@ -10,7 +10,9 @@ describe AllocateS3Url do
   let(:bucket_object) { double(presigned_url: "presigned url", public_url: "public url") }
 
   before(:each) do
-    allow_any_instance_of(described_class).to receive(:s3).and_return(s3)
+    allow(Aws::Credentials).to receive(:new).and_return(nil)
+    allow(Aws::S3::Client).to receive(:new).and_return(nil)
+    allow(Aws::S3::Resource).to receive(:new).and_return(s3)
   end
 
   describe "presigned_url" do

--- a/spec/services/buzz_media_spec.rb
+++ b/spec/services/buzz_media_spec.rb
@@ -6,12 +6,8 @@ RSpec.describe BuzzMedia do
   let(:media_server_json) { JSON.parse(File.read(File.join(Rails.root, "spec/fixtures/buzz_response.json"))) }
   let(:collection) { instance_double(Collection, id: 100) }
 
-  let(:s3) { double(bucket: bucket) }
-  let(:bucket) { double(object: bucket_object) }
-  let(:bucket_object) { double(presigned_url: "presigned url", public_url: "public url") }
-
   before(:each) do
-    allow_any_instance_of(AllocateS3Url).to receive(:s3).and_return(s3)
+    allow(AllocateS3Url).to receive(:public_url).and_return("public url")
   end
 
   let(:video) do
@@ -70,7 +66,7 @@ RSpec.describe BuzzMedia do
       it "sends a create request to the media server" do
         expect(media_server_connection).to receive(:post).with(
           "/v1/media_files",
-          media_file: { file_path: bucket_object.public_url, media_type: "video" }
+          media_file: { file_path: "public url", media_type: "video" }
         ).and_return(media_response)
 
         subject.create

--- a/spec/services/buzz_media_spec.rb
+++ b/spec/services/buzz_media_spec.rb
@@ -6,6 +6,14 @@ RSpec.describe BuzzMedia do
   let(:media_server_json) { JSON.parse(File.read(File.join(Rails.root, "spec/fixtures/buzz_response.json"))) }
   let(:collection) { instance_double(Collection, id: 100) }
 
+  let(:s3) { double(bucket: bucket) }
+  let(:bucket) { double(object: bucket_object) }
+  let(:bucket_object) { double(presigned_url: "presigned url", public_url: "public url") }
+
+  before(:each) do
+    allow_any_instance_of(AllocateS3Url).to receive(:s3).and_return(s3)
+  end
+
   let(:video) do
     instance_double(Video,
                     type: "Video",
@@ -62,7 +70,7 @@ RSpec.describe BuzzMedia do
       it "sends a create request to the media server" do
         expect(media_server_connection).to receive(:post).with(
           "/v1/media_files",
-          media_file: { file_path: "https://s3.amazonaws.com/aws_bucket/xxxx-yyyy-zzzz.jpeg", media_type: "video" }
+          media_file: { file_path: bucket_object.public_url, media_type: "video" }
         ).and_return(media_response)
 
         subject.create

--- a/spec/services/buzz_media_spec.rb
+++ b/spec/services/buzz_media_spec.rb
@@ -1,0 +1,165 @@
+require "rails_helper"
+
+RSpec.describe BuzzMedia do
+  subject { described_class.new(media: video) }
+  let(:buzz_media_id) { "aaaa-bbbb-cccc" }
+  let(:media_server_json) { JSON.parse(File.read(File.join(Rails.root, "spec/fixtures/buzz_response.json"))) }
+  let(:collection) { instance_double(Collection, id: 100) }
+
+  let(:video) do
+    instance_double(Video,
+                    type: "Video",
+                    id: 10,
+                    collection: collection,
+                    json_response: { "@id" => buzz_media_id },
+                    "json_response=" => true,
+                    file_name: "1920x1200.jpeg",
+                    thumbnail_url: "http://localhost:3019/images/test/000/001/000/001/1920x1200.jpeg",
+                    "thumbnail_url=" => true,
+                    data: { object: "test" },
+                    save!: true,
+                    uuid: "xxxx-yyyy-zzzz")
+  end
+
+  describe "create" do
+    let(:media_server_connection) do
+      Faraday.new do |builder|
+        builder.adapter :test do |stub|
+          stub.post("/v1/media_files") do |_env|
+            [
+              200,
+              { content_type: "application/json" },
+              media_server_json
+            ]
+          end
+        end
+      end
+    end
+
+    let(:unprocessable_media_connection) do
+      Faraday.new do |builder|
+        builder.adapter :test do |stub|
+          stub.post("/v1/media_files") { |_env| [422, { content_type: "application/json" }, "failed"] }
+        end
+      end
+    end
+
+    let(:failed_media_connection) do
+      Faraday.new do |builder|
+        builder.adapter :test do |stub|
+          stub.post("/v1/media_files") { |_env| [500, { content_type: "application/json" }, "failed"] }
+        end
+      end
+    end
+
+    describe "successful request" do
+      let(:media_response) { double(success?: true, body: media_server_json) }
+
+      before(:each) do
+        allow_any_instance_of(described_class).to receive(:media_server_connection).and_return(media_server_connection)
+      end
+
+      it "sends a create request to the media server" do
+        expect(media_server_connection).to receive(:post).with(
+          "/v1/media_files",
+          media_file: { file_path: "https://s3.amazonaws.com/aws_bucket/xxxx-yyyy-zzzz.jpeg", media_type: "video" }
+        ).and_return(media_response)
+
+        subject.create
+      end
+    end
+
+    describe "when request fails" do
+      it "throws an Buzz::UnprocessableEntity exception when Buzz returns a 422" do
+        allow_any_instance_of(described_class).to receive(:media_server_connection).and_return(unprocessable_media_connection)
+        expect{ subject.create }.to raise_error(Buzz::UnprocessableEntity)
+      end
+
+      it "throws an Buzz::InternalServerError exception when Buzz returns a 422" do
+        allow_any_instance_of(described_class).to receive(:media_server_connection).and_return(failed_media_connection)
+        expect{ subject.create }.to raise_error(Buzz::InternalServerError)
+      end
+    end
+  end
+
+  describe "update" do
+    let(:media_server_connection) do
+      Faraday.new do |builder|
+        builder.adapter :test do |stub|
+          stub.put("/v1/media_files/#{buzz_media_id}") do |_env|
+            [
+              200,
+              { content_type: "application/json" },
+              media_server_json
+            ]
+          end
+        end
+      end
+    end
+
+    let(:unprocessable_media_connection) do
+      Faraday.new do |builder|
+        builder.adapter :test do |stub|
+          stub.put("/v1/media_files/#{buzz_media_id}") { |_env| [422, { content_type: "application/json" }, "failed"] }
+        end
+      end
+    end
+
+    let(:failed_media_connection) do
+      Faraday.new do |builder|
+        builder.adapter :test do |stub|
+          stub.put("/v1/media_files/#{buzz_media_id}") { |_env| [500, { content_type: "application/json" }, "failed"] }
+        end
+      end
+    end
+
+    describe "successful request" do
+      let(:media_response) { double(success?: true, body: media_server_json) }
+
+      before(:each) do
+        allow_any_instance_of(described_class).to receive(:media_server_connection).and_return(media_server_connection)
+      end
+
+      it "sends an update request to the media server" do
+        expect(media_server_connection).to receive(:put).with(
+          "/v1/media_files/#{buzz_media_id}",
+          media_file: { thumbnail_url: "http://localhost:3019/images/test/000/001/000/001/1920x1200.jpeg" }
+        ).and_return(media_response)
+
+        subject.update
+      end
+    end
+
+    describe "when request fails" do
+      it "throws an Buzz::UnprocessableEntity exception when Buzz returns a 422" do
+        allow_any_instance_of(described_class).to receive(:media_server_connection).and_return(unprocessable_media_connection)
+        expect{ subject.update }.to raise_error(Buzz::UnprocessableEntity)
+      end
+
+      it "throws an Buzz::InternalServerError exception when Buzz returns a 422" do
+        allow_any_instance_of(described_class).to receive(:media_server_connection).and_return(failed_media_connection)
+        expect{ subject.update }.to raise_error(Buzz::InternalServerError)
+      end
+    end
+  end
+
+  describe "self" do
+    subject { described_class }
+
+    describe "#call_update" do
+      it "calls update on a new instance" do
+        allow(subject).to receive(:new).with(media: video).and_call_original
+        allow_any_instance_of(described_class).to receive(:update).and_return("update")
+        expect(subject.call_update(media: video)).to eq("update")
+      end
+    end
+
+    describe "#call_create" do
+      it "calls update on a new instance" do
+        allow(subject).to receive(:new).with(media: video).and_call_original
+        allow_any_instance_of(described_class).to receive(:create).and_return("create")
+        expect(subject.call_create(media: video)).to eq("create")
+      end
+    end
+  end
+end

--- a/spec/services/buzz_media_spec.rb
+++ b/spec/services/buzz_media_spec.rb
@@ -76,12 +76,12 @@ RSpec.describe BuzzMedia do
     describe "when request fails" do
       it "throws an Buzz::UnprocessableEntity exception when Buzz returns a 422" do
         allow_any_instance_of(described_class).to receive(:media_server_connection).and_return(unprocessable_media_connection)
-        expect{ subject.create }.to raise_error(Buzz::UnprocessableEntity)
+        expect { subject.create }.to raise_error(Buzz::UnprocessableEntity)
       end
 
       it "throws an Buzz::InternalServerError exception when Buzz returns a 422" do
         allow_any_instance_of(described_class).to receive(:media_server_connection).and_return(failed_media_connection)
-        expect{ subject.create }.to raise_error(Buzz::InternalServerError)
+        expect { subject.create }.to raise_error(Buzz::InternalServerError)
       end
     end
   end
@@ -137,12 +137,12 @@ RSpec.describe BuzzMedia do
     describe "when request fails" do
       it "throws an Buzz::UnprocessableEntity exception when Buzz returns a 422" do
         allow_any_instance_of(described_class).to receive(:media_server_connection).and_return(unprocessable_media_connection)
-        expect{ subject.update }.to raise_error(Buzz::UnprocessableEntity)
+        expect { subject.update }.to raise_error(Buzz::UnprocessableEntity)
       end
 
       it "throws an Buzz::InternalServerError exception when Buzz returns a 422" do
         allow_any_instance_of(described_class).to receive(:media_server_connection).and_return(failed_media_connection)
-        expect{ subject.update }.to raise_error(Buzz::InternalServerError)
+        expect { subject.update }.to raise_error(Buzz::InternalServerError)
       end
     end
   end

--- a/spec/services/finish_media_upload_spec.rb
+++ b/spec/services/finish_media_upload_spec.rb
@@ -2,8 +2,18 @@ require "rails_helper"
 require "support/item_meta_helpers"
 
 RSpec.describe FinishMediaUpload do
-  let(:media) { instance_double(Video, id: 1, save: true, "serializer=" => true, "status=" => 1, uuid: "uuid", file_name: "file name", type: "Video", "json_response=" => true) }
   let(:subject) { FinishMediaUpload.call(media: media) }
+  let(:media) do
+    instance_double(Video,
+                    id: 1,
+                    save: true, 
+                    "serializer=" => true,
+                    "status=" => 1,
+                    uuid: "uuid",
+                    file_name: "file name",
+                    type: "Video",
+                    "json_response=" => true)
+  end
 
   before(:each) do
     allow(BuzzMedia).to receive(:call_create).and_return(media)

--- a/spec/services/finish_media_upload_spec.rb
+++ b/spec/services/finish_media_upload_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 require "support/item_meta_helpers"
 
 RSpec.describe FinishMediaUpload do
-  let(:media) { instance_double(Video, id: 1, save: true, "serializer=" => true, "status=" => 1) }
+  let(:media) { instance_double(Video, id: 1, save: true, "serializer=" => true, "status=" => 1, uuid: "uuid", file_name: "file name", type: "Video", "json_response=" => true) }
   let(:subject) { FinishMediaUpload.call(media: media) }
 
   it "sets the status to ready" do
@@ -17,6 +17,17 @@ RSpec.describe FinishMediaUpload do
 
   it "sets the serializer" do
     expect(media).to receive("serializer=").with(SerializeMedia)
+    subject
+  end
+
+  it "uses BuzzMedia to create the media on the buzz server" do
+    expect(BuzzMedia).to receive(:call_create)
+    subject
+  end
+
+  it "uses BuzzMedia to create the media on the buzz server" do
+    allow(BuzzMedia).to receive(:call_create).and_return(false)
+    expect(media).not_to receive("status=").with(:ready)
     subject
   end
 

--- a/spec/services/finish_media_upload_spec.rb
+++ b/spec/services/finish_media_upload_spec.rb
@@ -5,6 +5,14 @@ RSpec.describe FinishMediaUpload do
   let(:media) { instance_double(Video, id: 1, save: true, "serializer=" => true, "status=" => 1, uuid: "uuid", file_name: "file name", type: "Video", "json_response=" => true) }
   let(:subject) { FinishMediaUpload.call(media: media) }
 
+  let(:s3) { double(bucket: bucket) }
+  let(:bucket) { double(object: bucket_object) }
+  let(:bucket_object) { double(presigned_url: "presigned url", public_url: "public url") }
+
+  before(:each) do
+    allow_any_instance_of(AllocateS3Url).to receive(:s3).and_return(s3)
+  end
+
   it "sets the status to ready" do
     expect(media).to receive("status=").with(:ready)
     subject

--- a/spec/services/finish_media_upload_spec.rb
+++ b/spec/services/finish_media_upload_spec.rb
@@ -5,12 +5,8 @@ RSpec.describe FinishMediaUpload do
   let(:media) { instance_double(Video, id: 1, save: true, "serializer=" => true, "status=" => 1, uuid: "uuid", file_name: "file name", type: "Video", "json_response=" => true) }
   let(:subject) { FinishMediaUpload.call(media: media) }
 
-  let(:s3) { double(bucket: bucket) }
-  let(:bucket) { double(object: bucket_object) }
-  let(:bucket_object) { double(presigned_url: "presigned url", public_url: "public url") }
-
   before(:each) do
-    allow_any_instance_of(AllocateS3Url).to receive(:s3).and_return(s3)
+    allow(BuzzMedia).to receive(:call_create).and_return(media)
   end
 
   it "sets the status to ready" do

--- a/spec/services/finish_media_upload_spec.rb
+++ b/spec/services/finish_media_upload_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe FinishMediaUpload do
   let(:media) do
     instance_double(Video,
                     id: 1,
-                    save: true, 
+                    save: true,
                     "serializer=" => true,
                     "status=" => 1,
                     uuid: "uuid",

--- a/spec/services/serialize_new_s3_media_spec.rb
+++ b/spec/services/serialize_new_s3_media_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe SerializeNewS3Media do
   end
 
   before(:each) do
-    allow(AllocateS3Url).to receive(:call).and_return("upload url")
+    allow(AllocateS3Url).to receive(:presigned_url).and_return("upload url")
   end
 
   describe "to_hash" do
@@ -25,7 +25,7 @@ RSpec.describe SerializeNewS3Media do
     end
 
     it "uses AllocateS3Url to create the upload_url" do
-      allow(AllocateS3Url).to receive(:call).and_return("upload url")
+      allow(AllocateS3Url).to receive(:presigned_url).and_return("upload url")
       expect(subject).to include(upload_url: "upload url")
     end
   end
@@ -39,7 +39,7 @@ RSpec.describe SerializeNewS3Media do
     end
 
     it "uses AllocateS3Url to create the upload_url" do
-      allow(AllocateS3Url).to receive(:call).and_return("upload url")
+      allow(AllocateS3Url).to receive(:presigned_url).and_return("upload url")
       expect(subject).to include(upload_url: "upload url")
     end
   end


### PR DESCRIPTION
Adds an action that will create the media object on Buzz. This will typically be called once the user has finished uploading to the designated s3 location. To do this I added a service class that will ideally handle all of the communication to the Buzz server and refactored the save_media_thumbnail service to use this instead of directly handling this communication.