### PR TITLE
Post to Buzz

### DIFF
--- a/app/services/allocate_s3_url.rb
+++ b/app/services/allocate_s3_url.rb
@@ -22,10 +22,14 @@ class AllocateS3Url
     bucket_object.public_url
   end
 
+  def file_name
+    "#{uid}#{file_extension}"
+  end
+
   private
 
   def bucket_object
-    bucket.object("#{uid}#{file_extension}")
+    bucket.object(file_name)
   end
 
   def bucket

--- a/app/services/buzz_media.rb
+++ b/app/services/buzz_media.rb
@@ -38,7 +38,7 @@ class BuzzMedia
   def create_json
     {
       media_file: {
-        file_path: AllocateS3Url.public_url(media.uuid, media.file_name),
+        file_path: AllocateS3Url.new(media.uuid, media.file_name).file_name,
         media_type: @media.type.downcase
       }
     }

--- a/spec/services/allocate_s3_url_spec.rb
+++ b/spec/services/allocate_s3_url_spec.rb
@@ -15,6 +15,10 @@ describe AllocateS3Url do
     allow(Aws::S3::Resource).to receive(:new).and_return(s3)
   end
 
+  it "preserves the extension of the original file name but uses the uuid" do
+    expect(described_class.new(uid, filename).file_name).to eq("abcdefg.jpg")
+  end
+
   describe "presigned_url" do
     subject { described_class.presigned_url(uid, filename) }
 

--- a/spec/services/buzz_media_spec.rb
+++ b/spec/services/buzz_media_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe BuzzMedia do
       it "sends a create request to the media server" do
         expect(media_server_connection).to receive(:post).with(
           "/v1/media_files",
-          media_file: { file_path: "public url", media_type: "video" }
+          media_file: { file_path: "xxxx-yyyy-zzzz.jpeg", media_type: "video" }
         ).and_return(media_response)
 
         subject.create


### PR DESCRIPTION
Buzz expects file name only, not the full url, when creating new media. Changed this in the create action.