### PR TITLE
Read credentials from aws config

### DIFF
--- a/app/services/allocate_s3_url.rb
+++ b/app/services/allocate_s3_url.rb
@@ -45,12 +45,15 @@ class AllocateS3Url
   end
 
   def s3
-    credentials = Aws::Credentials.new(configuration["access_key_id"], configuration["secret_access_key"])
+    # Force a reload of the shared config each time, otherwise we won't get any new rotated creds
+    # https://github.com/aws/aws-sdk-ruby/blob/e9276ee29af123384304848381698ffd307b1533/aws-sdk-core/lib/aws-sdk-core/shared_credentials.rb#L25
+    Aws.shared_config.fresh
+    credentials = Aws::SharedCredentials.new(profile_name: configuration["profile"])
     client = Aws::S3::Client.new(region: configuration["region"], credentials: credentials)
     @s3 ||= Aws::S3::Resource.new(client: client)
   end
 
   def configuration
-    @configuration ||= Rails.application.secrets.aws
+    @configuration ||= Rails.configuration.settings.aws
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -9,6 +9,10 @@ local: &local
   image_server_url: 'http://localhost:3019'
   beehive_url: 'http://localhost:3018'
   media_server_url: 'http://localhost:3023'
+  aws:
+    region: us-east-1
+    bucket: testlibnd-wse-honeycomb-dev
+    profile: honeycomb
 
 vm: &vm
   <<: *defaults
@@ -27,6 +31,10 @@ pre_production:
   image_server_url: https://honeypotpprd.library.nd.edu
   beehive_url: https://collections-pprd.library.nd.edu
   media_server_url: https://buzz-pprd.library.nd.edu
+  aws:
+    region: us-east-1
+    bucket: testlibnd-wse-honeycomb-pprd
+    profile: honeycomb
 
 production:
   <<: *vm
@@ -34,3 +42,7 @@ production:
   image_server_url: https://honeypot.library.nd.edu
   beehive_url: https://collections.library.nd.edu
   media_server_url: https://buzz.library.nd.edu
+  aws:
+    region: us-east-1
+    bucket: testlibnd-wse-honeycomb-prod
+    profile: honeycomb

--- a/spec/services/allocate_s3_url_spec.rb
+++ b/spec/services/allocate_s3_url_spec.rb
@@ -10,7 +10,7 @@ describe AllocateS3Url do
   let(:bucket_object) { double(presigned_url: "presigned url", public_url: "public url") }
 
   before(:each) do
-    allow(Aws::Credentials).to receive(:new).and_return(nil)
+    allow(Aws::SharedCredentials).to receive(:new).and_return(nil)
     allow(Aws::S3::Client).to receive(:new).and_return(nil)
     allow(Aws::S3::Resource).to receive(:new).and_return(s3)
   end


### PR DESCRIPTION
Changed the s3 url signing to read the credentials from the aws prescribed shared location and moved remaining settings out of secrets.