### PR TITLE
Selected tags sometimes were not returned

### DIFF
--- a/app/models/waggle/adapters/solr/search/result.rb
+++ b/app/models/waggle/adapters/solr/search/result.rb
@@ -64,20 +64,20 @@ module Waggle
           # There are cases where the facets marked by the user are not returned with a count
           # This function adds those counts back into the final list of facets returned
           def concat_facets
-            if !@requested_tags_results 
+            if !@requested_tags_results
               return
             end
-            
+
             query_counts = @result["facet_counts"]["facet_fields"]
             requested_counts = @requested_tags_results["facet_counts"]["facet_fields"]
 
             requested_counts.each do |facet, tags|
-              tags.each_slice(2) { |tag_with_val|
+              tags.each_slice(2) do |tag_with_val|
                 # Since these are arrays, we'll only append the values ([tag, val]) if they're not present
                 unless query_counts[facet].include? tag_with_val[0]
                   query_counts[facet] += tag_with_val
                 end
-              }
+              end
             end
           end
 

--- a/config/style_guides/.ruby-style.yml
+++ b/config/style_guides/.ruby-style.yml
@@ -140,3 +140,6 @@ Style/MethodDefParentheses:
 
 Style/FrozenStringLiteralComment:
   Enabled: false
+
+Style/NegatedIf:
+  Enabled: false

--- a/spec/models/waggle/adapters/solr/search/result_spec.rb
+++ b/spec/models/waggle/adapters/solr/search/result_spec.rb
@@ -50,9 +50,9 @@ RSpec.describe Waggle::Adapters::Solr::Search::Result do
 
   describe "result" do
     it "sends the expected arguments to solr" do
-      expect(subject).to receive(:page).and_return(2)
+      expect(subject).to receive(:page).exactly(2).times.and_return(2)
       expect(subject).to receive(:per_page).and_return(15)
-      expect(subject).to receive(:solr_params).and_return(q: "a query")
+      expect(subject).to receive(:solr_params).exactly(2).times.and_return(q: "a query")
       expect(subject.send(:connection)).to receive(:paginate).with(
         2,
         15,
@@ -61,6 +61,14 @@ RSpec.describe Waggle::Adapters::Solr::Search::Result do
           q: "a query"
         },
       ).and_return("solr_response")
+      expect(subject.send(:connection)).to receive(:paginate).with(
+        2,
+        0,
+        "select",
+        params: {
+          q: "a query"
+        },
+      ).and_return(nil)
       expect(subject.result).to eq("solr_response")
     end
   end


### PR DESCRIPTION
DEC-1133
Tags selected in the UI were sometimes not returned in the results, and thus could not be rendered in the UI - making it impossible to deselect them.

I added a new query that _only_ retrieves these tag values, no results, and appends the tags to the tag list if not already present. 