### PR TITLE
Bugfix: Item not showing associated Pages when trying to delete

### DIFF
--- a/app/assets/javascripts/components/PagesPanel.jsx
+++ b/app/assets/javascripts/components/PagesPanel.jsx
@@ -32,7 +32,7 @@ var PagesPanel = React.createClass({
   },
 
   pageImageDiv: function (page) {
-    if(page.image) {
+    if(page.image && page.image.status == "ready") {
       return (
         <div className="image">
           <Avatar src={ page.image["thumbnail/small"]["contentUrl"] } />

--- a/app/assets/javascripts/components/ShowcasesPanel.jsx
+++ b/app/assets/javascripts/components/ShowcasesPanel.jsx
@@ -33,7 +33,7 @@ var ShowcasesPanel = React.createClass({
   },
 
   showcaseImageDiv: function (showcase) {
-    if(showcase.image) {
+    if(showcase.image && showcase.image.status == "ready") {
       return (
         <div className="image">
           <Avatar src={ showcase.image["thumbnail/small"]["contentUrl"] } />

--- a/app/assets/javascripts/components/showcase_editor/ShowcaseEditorTitle.jsx
+++ b/app/assets/javascripts/components/showcase_editor/ShowcaseEditorTitle.jsx
@@ -60,6 +60,19 @@ var ShowcaseEditorTitle = React.createClass({
     window.location = this.props.showcase.editUrl;
   },
 
+  image: function() {
+    if(this.props.showcase.image && this.props.showcase.image.status == "ready") {
+      return (
+        <div>
+          <h4>Background Image</h4>
+          <img src={ this.props.showcase.image["thumbnail/small"]["contentUrl"] } style={ this.imageStyle() } />
+        </div>
+      );
+    } else {
+      return null;
+    }
+  },
+
   render: function() {
     var description;
     if (this.props.showcase.description) {
@@ -73,10 +86,7 @@ var ShowcaseEditorTitle = React.createClass({
     return (
       <div className="showcase-title-page" style={this.style()} onMouseEnter={this.onMouseEnter} onMouseLeave={this.onMouseLeave}>
         <h2 style={this.titleStyle()}>{this.props.showcase.name_line_1} <small>{this.props.showcase.name_line_2}</small></h2>
-        <div>
-          <h4>Background Image</h4>
-          <img src={this.props.showcase.image } style={ this.imageStyle() } />
-        </div>
+        { this.image() }
         <EditLink clickHandler={this.editTitle} visible={this.state.hover} />
       </div>
     );

--- a/app/decorators/showcase_decorator.rb
+++ b/app/decorators/showcase_decorator.rb
@@ -5,11 +5,7 @@ class ShowcaseDecorator < Draper::Decorator
     SectionQuery.new(object.sections).ordered
   end
 
-  def honeypot_image_url
-    if object.image
-      object.image.json_response["thumbnail/small"]["contentUrl"]
-    else
-      {}
-    end
+  def image
+    SerializeMedia.to_hash(media: object.image) if object.image
   end
 end

--- a/app/decorators/v1/showcase_json_decorator.rb
+++ b/app/decorators/v1/showcase_json_decorator.rb
@@ -40,11 +40,7 @@ module V1
     end
 
     def image
-      if object.image
-        object.image.json_response
-      else
-        nil
-      end
+      SerializeMedia.to_hash(media: object.image) if object.image
     end
 
     def display(json)

--- a/app/views/showcases/show.json.jbuilder
+++ b/app/views/showcases/show.json.jbuilder
@@ -2,7 +2,7 @@ json.name_line_1 @showcase.name_line_1
 json.name_line_2 @showcase.name_line_2
 json.description @showcase.description
 json.editUrl title_showcase_path(@showcase.id)
-json.image @showcase.honeypot_image_url
+json.image @showcase.image
 json.set! :sections do
   json.array! @showcase.sections do |section|
     json.partial! "sections/show", section: section

--- a/spec/decorators/showcase_decorator_spec.rb
+++ b/spec/decorators/showcase_decorator_spec.rb
@@ -34,4 +34,19 @@ RSpec.describe ShowcaseDecorator do
       expect(subject.sections).to eq(["sections"])
     end
   end
+
+  describe "#image" do
+    let(:image) { instance_double(Image, status: "ready", json_response: {}) }
+
+    it "returns nil if there is no associated image" do
+      allow(showcase).to receive(:image).and_return(nil)
+      expect(subject.image).to eq(nil)
+    end
+
+    it "uses SerializeMedia to render the image from the showcase" do
+      allow(showcase).to receive(:image).and_return(image)
+      expect(SerializeMedia).to receive(:to_hash).with(media: image)
+      subject.image
+    end
+  end
 end

--- a/spec/decorators/v1/showcase_json_decorator_spec.rb
+++ b/spec/decorators/v1/showcase_json_decorator_spec.rb
@@ -68,13 +68,8 @@ RSpec.describe V1::ShowcaseJSONDecorator do
     let(:showcase) { double(Showcase, image: image) }
     let(:image) { double(Image, json_response: "json_response") }
 
-    it "gets the image json_response" do
-      expect(image).to receive(:json_response).and_return("json_response")
-      expect(subject.image).to eq("json_response")
-    end
-
-    it "gets the image from the showcase" do
-      expect(showcase).to receive(:image).and_return(image)
+    it "uses SerializeMedia to render the image from the showcase" do
+      expect(SerializeMedia).to receive(:to_hash).with(media: image)
       subject.image
     end
 


### PR DESCRIPTION
If a Page had an associated background image that was stuck in a "not ready" state, it would fail to render the associated pages. Found this to also occur for Showcases.

Summary of changes:
- Changed PagesPanel to not attempt to render an image if it's not ready to be rendered.
- The json renderers for Showcases were not following the same serialization path as in Pages/Items so the image status was not readily available. So in order to fix the ShowcasesPanel, and make things more consistent, I had to change the showcase json decorators to use the SerializeMedia service.
- ShowcaseEdtorTitle previously assumed that props.showcase.image would always contain a valid url (rendered by app/decorators/showcase_decorator#honeypot_image_url). This caused unnecessary calls to load an invalid image when the image was not ready. Changed this to expect an image object instead of just a url, and to only render an img tag if the associated image is ready.