### PR TITLE
Item deletion had bad links for associated pages/showcases

### DIFF
--- a/app/assets/javascripts/components/PagesPanel.jsx
+++ b/app/assets/javascripts/components/PagesPanel.jsx
@@ -61,9 +61,17 @@ var PagesPanel = React.createClass({
 
     return this.state.pages.map(function(page, index) {
       key = "page-" + page.id;
+      reg = new RegExp( '^(.*/)v1/(.*)$', 'i' );
+      strings = reg.exec(page["@id"]);
+
+      url = strings[0];
+      if(strings && strings.length == 3) {
+        url = strings[1] + strings[2] + "/edit";
+      }
+
       return (
         <div key={key} className="row">
-          <a href={page["@id"]}>
+          <a href={url}>
             { this.pageImageDiv(page) }
             { this.pageNameDiv(page) }
           </a>

--- a/app/assets/javascripts/components/ShowcasesPanel.jsx
+++ b/app/assets/javascripts/components/ShowcasesPanel.jsx
@@ -62,9 +62,17 @@ var ShowcasesPanel = React.createClass({
 
     return this.state.showcases.map(function(showcase, index) {
       key = "showcase-" + showcase.id;
+      reg = new RegExp( '^(.*/)v1/(.*)$', 'i' );
+      strings = reg.exec(showcase["@id"]);
+
+      url = strings[0];
+      if(strings && strings.length == 3) {
+        url = strings[1] + strings[2];
+      }
+
       return (
         <div key={key} className="row">
-          <a href={showcase["@id"]}>
+          <a href={url}>
             { this.showcaseImageDiv(showcase) }
             { this.showcaseNameDiv(showcase) }
           </a>

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -19,14 +19,14 @@ class PagesController < ApplicationController
 
     if SavePage.call(@page, save_params)
       flash[:html_safe] = t(".success", href: view_context.link_to("Site Setup", site_setup_form_collection_path(collection, form: :site_path))).html_safe
-      redirect_to edit_page_path(@page)
+      redirect_to edit_page_path(@page.unique_id)
     else
       render :new
     end
   end
 
   def edit
-    @page = PageQuery.new.find(params[:id])
+    @page = PageQuery.new.public_find(params[:id])
     check_user_edits!(@page.collection)
     cache_key = CacheKeys::Generator.new(key_generator: CacheKeys::Custom::Pages,
                                          action: "edit",
@@ -40,7 +40,7 @@ class PagesController < ApplicationController
 
     if SavePage.call(@page, save_params)
       flash[:notice] = t(".success")
-      redirect_to edit_page_path(@page)
+      redirect_to edit_page_path(@page.unique_id)
     else
       render :edit
     end
@@ -63,10 +63,6 @@ class PagesController < ApplicationController
       :content,
       :uploaded_image
     ])
-  end
-
-  def page
-    @page ||= PageQuery.new.find(params[:id])
   end
 
   def collection

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -14,7 +14,7 @@ class SectionsController < ApplicationController
 
     respond_to do |format|
       if SaveSection.call(@section, section_params)
-        format.html { redirect_to edit_showcase_path(showcase.id), notice: t(".success") }
+        format.html { redirect_to edit_showcase_path(showcase.unique_id), notice: t(".success") }
         format.json { render json: {} }
       else
         format.html { render :new }
@@ -38,7 +38,7 @@ class SectionsController < ApplicationController
 
     respond_to do |format|
       if SaveSection.call(@section, section_params)
-        format.html { redirect_to edit_showcase_path(@section.showcase.id), notice: t(".success") }
+        format.html { redirect_to edit_showcase_path(@section.showcase.unique_id), notice: t(".success") }
         format.json { render json: {} }
       else
         format.html { render :edit }
@@ -53,7 +53,7 @@ class SectionsController < ApplicationController
     Destroy::Section.new.cascade!(section: @section)
 
     flash[:notice] = t(".success")
-    redirect_to edit_showcase_path(@section.showcase.id)
+    redirect_to edit_showcase_path(@section.showcase.unique_id)
   end
 
   protected

--- a/app/controllers/showcases_controller.rb
+++ b/app/controllers/showcases_controller.rb
@@ -19,28 +19,28 @@ class ShowcasesController < ApplicationController
 
     if SaveShowcase.call(@showcase, save_params)
       flash[:html_safe] = t(".success", href: view_context.link_to("Site Setup", site_setup_form_collection_path(collection, form: :site_path))).html_safe
-      redirect_to showcase_path(@showcase)
+      redirect_to showcase_path(@showcase.unique_id)
     else
       render :new
     end
   end
 
   def show
-    showcase = ShowcaseQuery.new.find(params[:id])
+    showcase = ShowcaseQuery.new.public_find(params[:id])
     check_user_edits!(showcase.collection)
     @showcase = ShowcaseDecorator.new(showcase)
     if request.xhr?
       render format: :json
     else
       respond_to do |format|
-        format.html { redirect_to edit_showcase_path(showcase.id) }
+        format.html { redirect_to edit_showcase_path(showcase.unique_id) }
         format.json
       end
     end
   end
 
   def edit
-    @showcase = ShowcaseQuery.new.find(params[:id])
+    @showcase = ShowcaseQuery.new.public_find(params[:id])
     check_user_edits!(@showcase.collection)
     cache_key = CacheKeys::Generator.new(key_generator: CacheKeys::Custom::Showcases,
                                          action: "edit",
@@ -54,14 +54,14 @@ class ShowcasesController < ApplicationController
 
     if SaveShowcase.call(@showcase, save_params)
       flash[:notice] = t(".success")
-      redirect_to showcase_path(@showcase)
+      redirect_to showcase_path(@showcase.unique_id)
     else
       render :edit
     end
   end
 
   def title
-    @showcase = ShowcaseQuery.new.find(params[:id])
+    @showcase = ShowcaseQuery.new.public_find(params[:id])
     check_user_edits!(@showcase.collection)
     cache_key = CacheKeys::Generator.new(key_generator: CacheKeys::Custom::Showcases,
                                          action: "title",
@@ -79,7 +79,7 @@ class ShowcasesController < ApplicationController
   end
 
   def publish
-    @showcase = ShowcaseQuery.new.find(params[:id])
+    @showcase = ShowcaseQuery.new.public_find(params[:id])
     check_user_edits!(@showcase.collection)
 
     unless Publish.call(@showcase)
@@ -90,7 +90,7 @@ class ShowcasesController < ApplicationController
   end
 
   def unpublish
-    @showcase = ShowcaseQuery.new.find(params[:id])
+    @showcase = ShowcaseQuery.new.public_find(params[:id])
     check_user_edits!(@showcase.collection)
 
     unless Unpublish.call(@showcase)
@@ -113,7 +113,7 @@ class ShowcasesController < ApplicationController
   end
 
   def showcase
-    @showcase ||= ShowcaseQuery.new.find(params[:id])
+    @showcase ||= ShowcaseQuery.new.public_find(params[:id])
   end
 
   def collection

--- a/app/decorators/showcase_decorator.rb
+++ b/app/decorators/showcase_decorator.rb
@@ -1,5 +1,5 @@
 class ShowcaseDecorator < Draper::Decorator
-  delegate :id, :name_line_1, :name_line_2, :description, to: :object
+  delegate :id, :unique_id, :name_line_1, :name_line_2, :description, to: :object
 
   def sections
     SectionQuery.new(object.sections).ordered

--- a/app/views/pages/_list.html.erb
+++ b/app/views/pages/_list.html.erb
@@ -11,10 +11,10 @@
     <% pages.each do |page| %>
       <tr>
         <td class="image" >
-          <%= link_to Thumbnail.display(page.image, "page"), edit_page_path(page) %>
+          <%= link_to Thumbnail.display(page.image, "page"), edit_page_path(page.unique_id) %>
         </td>
         <td>
-          <h4 class="media-heading"><%= h link_to page.name, edit_page_path(page) %></h4>
+          <h4 class="media-heading"><%= h link_to page.name, edit_page_path(page.unique_id) %></h4>
         </td>
         <td>
           <%= truncate(strip_tags(page.content), length: 200, omission: '...') %>

--- a/app/views/showcases/_list.html.erb
+++ b/app/views/showcases/_list.html.erb
@@ -10,10 +10,10 @@
     <% showcases.each do |showcase| %>
       <tr>
         <td class="image" >
-          <%= link_to Thumbnail.display(showcase.image, "showcase"), showcase_path(showcase) %>
+          <%= link_to Thumbnail.display(showcase.image, "showcase"), showcase_path(showcase.unique_id) %>
         </td>
         <td>
-          <h4 class="media-heading"><%= h link_to showcase.name_line_1, showcase_path(showcase) %></h4>
+          <h4 class="media-heading"><%= h link_to showcase.name_line_1, showcase_path(showcase.unique_id) %></h4>
           <%= h showcase.description %>
         </td>
         <td>

--- a/app/views/showcases/edit.html.erb
+++ b/app/views/showcases/edit.html.erb
@@ -6,7 +6,7 @@
 <%= react_component 'ShowcaseEditor', {
       itemsJSONPath: v1_collection_items_path(@showcase.collection.unique_id),
       sectionsCreatePath: showcase_sections_path(@showcase, :json),
-      showcaseJSONPath: showcase_path(@showcase.id, :json),
+      showcaseJSONPath: showcase_path(@showcase.unique_id, :json),
     },
     {prerender: false }
 %>

--- a/app/views/showcases/show.json.jbuilder
+++ b/app/views/showcases/show.json.jbuilder
@@ -1,7 +1,7 @@
 json.name_line_1 @showcase.name_line_1
 json.name_line_2 @showcase.name_line_2
 json.description @showcase.description
-json.editUrl title_showcase_path(@showcase.id)
+json.editUrl title_showcase_path(@showcase.unique_id)
 json.image @showcase.image
 json.set! :sections do
   json.array! @showcase.sections do |section|

--- a/app/views/showcases/title.html.erb
+++ b/app/views/showcases/title.html.erb
@@ -1,7 +1,7 @@
 <% page_title(@showcase.name_line_1, @showcase.collection) %>
 <%= collection_nav(@showcase.collection, :showcases) %>
 
-<%= back_action_bar(edit_showcase_path(@showcase.id)) %>
+<%= back_action_bar(edit_showcase_path(@showcase.unique_id)) %>
 
 <%= simple_form_for @showcase do |f| %>
   <div class="panel panel-default">

--- a/config/style_guides/.ruby-style.yml
+++ b/config/style_guides/.ruby-style.yml
@@ -277,7 +277,7 @@ Style/FrozenStringLiteralComment:
   Description: >-
                  Add the frozen_string_literal comment to the top of files
                  to help transition from Ruby 2.3.0 to Ruby 3.0.
-  Enabled: true
+  Enabled: false
 
 Style/InitialIndentation:
   Description: >-
@@ -497,7 +497,7 @@ Style/NegatedIf:
                  Favor unless over if for negative conditions
                  (or control flow or).
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#unless-for-negatives'
-  Enabled: true
+  Enabled: false
 
 Style/NegatedWhile:
   Description: 'Favor until over while for negative conditions.'
@@ -1498,9 +1498,3 @@ Rails/Validation:
 Security/JSONLoad:
   Description : 'Prefer usage of JSON.parse'
   Enabled: true
-
-Style/FrozenStringLiteralComment:
-  Enabled: false
-
-Style/NegatedIf:
-  Enabled: false

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 require "cache_spec_helper"
 
 RSpec.describe PagesController, type: :controller do
-  let(:page) { instance_double(Page, id: 1, name: "name", collection: collection, items: [], destroy!: true) }
+  let(:page) { instance_double(Page, id: 1, unique_id: 1, name: "name", collection: collection, items: [], destroy!: true) }
   let(:collection) { instance_double(Collection, id: 1, name_line_1: "name_line_1", pages: relation) }
 
   let(:relation) { Page.all }
@@ -14,6 +14,7 @@ RSpec.describe PagesController, type: :controller do
 
     allow_any_instance_of(CollectionQuery).to receive(:find).and_return(collection)
     allow_any_instance_of(PageQuery).to receive(:find).and_return(page)
+    allow_any_instance_of(PageQuery).to receive(:public_find).and_return(page)
     allow_any_instance_of(PageQuery).to receive(:build).and_return(page)
     allow(SavePage).to receive(:call).and_return(true)
   end
@@ -161,7 +162,7 @@ RSpec.describe PagesController, type: :controller do
   end
 
   describe "GET #edit" do
-    subject { get :edit, id: page.id }
+    subject { get :edit, id: page.unique_id }
 
     it "checks the editor permissions" do
       expect_any_instance_of(described_class).to receive(:check_user_edits!).with(collection)
@@ -169,7 +170,7 @@ RSpec.describe PagesController, type: :controller do
     end
 
     it "uses page query " do
-      expect_any_instance_of(PageQuery).to receive(:find).with("1").and_return(page)
+      expect_any_instance_of(PageQuery).to receive(:public_find).with("1").and_return(page)
       subject
     end
 

--- a/spec/controllers/sections_controller_spec.rb
+++ b/spec/controllers/sections_controller_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 require "cache_spec_helper"
 
 RSpec.describe SectionsController, type: :controller do
-  let(:showcase) { double(Showcase, id: 1, name: "name", sections: relation, collection: collection) }
+  let(:showcase) { double(Showcase, id: 1, unique_id: 1, name: "name", sections: relation, collection: collection) }
   let(:collection) { instance_double(Collection, id: 1, name_line_1: "name_line_1") }
   let(:section) { double(Section, id: 1, destroy!: true, showcase: showcase, :order= => true, order: 1, collection: collection, "item=" => true) }
   let(:item) { instance_double(Item) }
@@ -24,7 +24,7 @@ RSpec.describe SectionsController, type: :controller do
 
   describe "POST #create" do
     subject { post :create, create_params_with_item }
-    
+
     it "checks the editor permissions" do
       expect_any_instance_of(described_class).to receive(:check_user_edits!).with(collection)
       subject

--- a/spec/controllers/showcases_controller_spec.rb
+++ b/spec/controllers/showcases_controller_spec.rb
@@ -2,17 +2,18 @@ require "rails_helper"
 require "cache_spec_helper"
 
 RSpec.describe ShowcasesController, type: :controller do
-  let(:showcase) { instance_double(Showcase, id: 1, name_line_1: "name_line_1", collection: collection, sections: [], destroy!: true) }
+  let(:showcase) { instance_double(Showcase, id: 1, unique_id: 1, name_line_1: "name_line_1", collection: collection, sections: [], destroy!: true) }
   let(:collection) { instance_double(Collection, id: 1, name_line_1: "name_line_1", showcases: relation) }
 
   let(:relation) { Showcase.all }
   let(:create_params) { { collection_id: collection.id, showcase: { name_line_1: "name_line_1", description: "description" } } }
-  let(:update_params) { { id: showcase.id, showcase: { name_line_1: "name_line_1", description: "description" } } }
+  let(:update_params) { { id: showcase.unique_id, showcase: { name_line_1: "name_line_1", description: "description" } } }
 
   before(:each) do
     sign_in_admin
 
     allow_any_instance_of(CollectionQuery).to receive(:find).and_return(collection)
+    allow_any_instance_of(ShowcaseQuery).to receive(:public_find).and_return(showcase)
     allow_any_instance_of(ShowcaseQuery).to receive(:find).and_return(showcase)
     allow_any_instance_of(ShowcaseQuery).to receive(:build).and_return(showcase)
     allow(SaveShowcase).to receive(:call).and_return(true)
@@ -172,7 +173,7 @@ RSpec.describe ShowcasesController, type: :controller do
   end
 
   describe "GET #show" do
-    subject { get :show, id: showcase.id }
+    subject { get :show, id: showcase.unique_id }
 
     it "checks the editor permissions" do
       expect_any_instance_of(described_class).to receive(:check_user_edits!).with(collection)
@@ -180,7 +181,7 @@ RSpec.describe ShowcasesController, type: :controller do
     end
 
     it "uses showcase query " do
-      expect_any_instance_of(ShowcaseQuery).to receive(:find).with("1").and_return(showcase)
+      expect_any_instance_of(ShowcaseQuery).to receive(:public_find).with("1").and_return(showcase)
       subject
     end
 
@@ -197,7 +198,7 @@ RSpec.describe ShowcasesController, type: :controller do
     end
 
     it "renders json" do
-      get :show, id: showcase.id, format: :json
+      get :show, id: showcase.unique_id, format: :json
 
       expect(response).to be_success
     end
@@ -206,7 +207,7 @@ RSpec.describe ShowcasesController, type: :controller do
   end
 
   describe "GET #edit" do
-    subject { get :edit, id: showcase.id }
+    subject { get :edit, id: showcase.unique_id }
 
     it "checks the editor permissions" do
       expect_any_instance_of(described_class).to receive(:check_user_edits!).with(collection)
@@ -214,7 +215,7 @@ RSpec.describe ShowcasesController, type: :controller do
     end
 
     it "uses showcase query " do
-      expect_any_instance_of(ShowcaseQuery).to receive(:find).with("1").and_return(showcase)
+      expect_any_instance_of(ShowcaseQuery).to receive(:public_find).with("1").and_return(showcase)
       subject
     end
 
@@ -234,7 +235,7 @@ RSpec.describe ShowcasesController, type: :controller do
   end
 
   describe "GET #title" do
-    subject { get :title, id: showcase.id }
+    subject { get :title, id: showcase.unique_id }
 
     it "checks the editor permissions" do
       expect_any_instance_of(described_class).to receive(:check_user_edits!).with(collection)
@@ -242,7 +243,7 @@ RSpec.describe ShowcasesController, type: :controller do
     end
 
     it "uses showcase query " do
-      expect_any_instance_of(ShowcaseQuery).to receive(:find).with("1").and_return(showcase)
+      expect_any_instance_of(ShowcaseQuery).to receive(:public_find).with("1").and_return(showcase)
       subject
     end
 
@@ -296,7 +297,7 @@ RSpec.describe ShowcasesController, type: :controller do
   end
 
   describe "PUT #publish" do
-    subject { put :publish, id: showcase.id }
+    subject { put :publish, id: showcase.unique_id }
 
     it_behaves_like "a private content-based etag cacher" do
       before do
@@ -306,7 +307,7 @@ RSpec.describe ShowcasesController, type: :controller do
   end
 
   describe "PUT #unpublish" do
-    subject { put :unpublish, id: showcase.id }
+    subject { put :unpublish, id: showcase.unique_id }
 
     it_behaves_like "a private content-based etag cacher" do
       before do

--- a/spec/services/destroy/showcase_spec.rb
+++ b/spec/services/destroy/showcase_spec.rb
@@ -30,7 +30,7 @@ describe Destroy::Showcase do
     let(:subject) { Destroy::Showcase.new(destroy_section: destroy_section) }
     let(:showcase) { FactoryGirl.create(:showcase) }
     let(:collection) { FactoryGirl.create(:collection) }
-    let(:sections) { [FactoryGirl.create(:section, id: 1, showcase_id: showcase.id), FactoryGirl.create(:section, id: 2, showcase_id: showcase.id)] }
+    let(:sections) { [FactoryGirl.create(:section, id: 1, showcase_id: showcase.unique_id, showcase: showcase), FactoryGirl.create(:section, id: 2, showcase_id: showcase.unique_id, showcase: showcase)] }
 
     before(:each) do
       collection


### PR DESCRIPTION
The @id field in now links to the api pages instead of to the honeycomb UI. 

I've changed all pages and showcases to use the unique_id field for their uri instead so that we can easily parse the v1 url to link to these resources.

This is already getting very messy and I'm worried about the complexity and readability as we move forward. There's already discussion about how things should have been done - separating the API from the UI - but I think it's worth talking about seriously so this codebase can be more maintainable. 