### PR TITLE
DEC-1237

### DIFF
--- a/app/assets/javascripts/components/ItemShowImageBox.jsx
+++ b/app/assets/javascripts/components/ItemShowImageBox.jsx
@@ -38,14 +38,6 @@ var ItemShowImageBox = React.createClass({
     }
   },
 
-  thumbnailSrc: function() {
-    if (this.props.item.media.thumbnailUrl) {
-      return this.props.item.media.thumbnailUrl;
-    } else {
-      return '/images/blank.png';
-    }
-  },
-
   itemReadyHtml: function () {
     return (<Thumbnail thumbnailUrl={ this.props.item.media.thumbnailUrl } thumbType={ "item" } />);
   },

--- a/app/services/serialize_av_media.rb
+++ b/app/services/serialize_av_media.rb
@@ -15,6 +15,8 @@ class SerializeAVMedia
     # (contained in json_response) can simply be added to the media object's attributes
     result = media.json_response.merge(result) if media.json_response
     result.merge!(media.errors.to_hash) if media.errors
+
+    result = result.with_indifferent_access
     unless result[:thumbnailUrl].present?
       result[:thumbnailUrl] = default_thumbnail(media: media)
     end

--- a/app/values/cache_keys/custom/v1_items.rb
+++ b/app/values/cache_keys/custom/v1_items.rb
@@ -7,15 +7,15 @@ module CacheKeys
       end
 
       def show(item:)
-        CacheKeys::ActiveRecord.new.generate(record: [item, item.collection, item.children, item.collection.collection_configuration])
+        CacheKeys::ActiveRecord.new.generate(record: [item, item.collection, item.children, item.media, item.collection.collection_configuration])
       end
 
       def showcases(item:)
-        CacheKeys::ActiveRecord.new.generate(record: [item, item.collection, item.showcases, item.collection.collection_configuration])
+        CacheKeys::ActiveRecord.new.generate(record: [item, item.collection, item.showcases, item.media, item.collection.collection_configuration])
       end
 
       def pages(item:)
-        CacheKeys::ActiveRecord.new.generate(record: [item, item.collection, item.pages, item.collection.collection_configuration])
+        CacheKeys::ActiveRecord.new.generate(record: [item, item.collection, item.pages, item.media, item.collection.collection_configuration])
       end
     end
   end

--- a/spec/controllers/v1/items_controller_spec.rb
+++ b/spec/controllers/v1/items_controller_spec.rb
@@ -4,7 +4,7 @@ require "cache_spec_helper"
 RSpec.describe V1::ItemsController, type: :controller do
   let(:collection_configuration) { CollectionConfiguration.new }
   let(:collection) { instance_double(Collection, id: "1", updated_at: nil, items: nil, collection_configuration: collection_configuration) }
-  let(:item) { instance_double(Item, id: "1", collection: collection, children: nil) }
+  let(:item) { instance_double(Item, id: "1", collection: collection, children: nil, media: nil) }
 
   before(:each) do
     allow_any_instance_of(ItemQuery).to receive(:public_find).and_return(item)
@@ -224,7 +224,7 @@ RSpec.describe V1::ItemsController, type: :controller do
     let(:collection_configuration) { CollectionConfiguration.new }
     let(:collection) { Collection.new(unique_id: "test", items: [], collection_configuration: collection_configuration) }
     subject { get :showcases, item_id: "id", format: :json }
-    let(:item) { instance_double(Item, id: "1", collection: collection, children: nil, showcases: nil) }
+    let(:item) { instance_double(Item, id: "1", collection: collection, children: nil, showcases: nil, media: nil) }
 
     it "calls ItemQuery" do
       expect_any_instance_of(ItemQuery).to receive(:public_find).with("id").and_return(item)
@@ -259,7 +259,7 @@ RSpec.describe V1::ItemsController, type: :controller do
     let(:collection_configuration) { CollectionConfiguration.new }
     let(:collection) { Collection.new(unique_id: "test", items: [], collection_configuration: collection_configuration) }
     subject { get :pages, item_id: "id", format: :json }
-    let(:item) { instance_double(Item, id: "1", collection: collection, children: nil, pages: nil) }
+    let(:item) { instance_double(Item, id: "1", collection: collection, children: nil, pages: nil, media: nil) }
 
     it "calls ItemQuery" do
       expect_any_instance_of(ItemQuery).to receive(:public_find).with("id").and_return(item)

--- a/spec/values/cache_keys/custom/v1_items_spec.rb
+++ b/spec/values/cache_keys/custom/v1_items_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe CacheKeys::Custom::V1Items do
 
   context "show" do
     let(:collection) { instance_double(Collection, items: "items", collection_configuration: "config") }
-    let(:item) { instance_double(Item, collection: collection, children: "children") }
+    let(:item) { instance_double(Item, collection: collection, children: "children", media: "media") }
 
     it "uses CacheKeys::ActiveRecord" do
       expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate)
@@ -25,14 +25,14 @@ RSpec.describe CacheKeys::Custom::V1Items do
     end
 
     it "uses the correct data" do
-      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with(record: [item, collection, "children", "config"])
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with(record: [item, collection, "children", "media", "config"])
       subject.show(item: item)
     end
   end
 
   context "showcases" do
     let(:collection) { instance_double(Collection, items: "items", collection_configuration: "config") }
-    let(:item) { instance_double(Item, collection: collection, children: "children", showcases: "showcases") }
+    let(:item) { instance_double(Item, collection: collection, children: "children", showcases: "showcases", media: "media") }
 
     it "uses CacheKeys::ActiveRecord" do
       expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate)
@@ -40,14 +40,14 @@ RSpec.describe CacheKeys::Custom::V1Items do
     end
 
     it "uses the correct data" do
-      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with(record: [item, collection, "showcases", "config"])
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with(record: [item, collection, "showcases", "media", "config"])
       subject.showcases(item: item)
     end
   end
 
   context "pages" do
     let(:collection) { instance_double(Collection, items: "items", collection_configuration: "config") }
-    let(:item) { instance_double(Item, collection: collection, children: "children", pages: "pages") }
+    let(:item) { instance_double(Item, collection: collection, children: "children", pages: "pages", media: "media") }
 
     it "uses CacheKeys::ActiveRecord" do
       expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate)
@@ -55,7 +55,7 @@ RSpec.describe CacheKeys::Custom::V1Items do
     end
 
     it "uses the correct data" do
-      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with(record: [item, collection, "pages", "config"])
+      expect_any_instance_of(CacheKeys::ActiveRecord).to receive(:generate).with(record: [item, collection, "pages", "media", "config"])
       subject.pages(item: item)
     end
   end


### PR DESCRIPTION
Media thumbnails were not working as intended. There were two issues: 
1) An incorrect expectation of ruby hash containing the symbol key thumbnailUrl: instead of the string version.
2) The cache headers were not taking into account media changes.