### PR TITLE
DEC-977 Icons not showing up on metadata form in IE 11

### DIFF
--- a/app/assets/stylesheets/ui-customizations.css.scss
+++ b/app/assets/stylesheets/ui-customizations.css.scss
@@ -630,5 +630,8 @@ div.dataTables_filter {
   }
 }
 
+.material-icons {
+	font-feature-settings: 'liga' 1;
+}
 
 @import "_material-design-overwrites.scss";

--- a/app/assets/stylesheets/ui-customizations.css.scss
+++ b/app/assets/stylesheets/ui-customizations.css.scss
@@ -631,7 +631,7 @@ div.dataTables_filter {
 }
 
 .material-icons {
-	font-feature-settings: 'liga' 1;
+  font-feature-settings: 'liga' 1;
 }
 
 @import "_material-design-overwrites.scss";

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,7 +27,7 @@
     <link href="//fonts.googleapis.com/css?family=Roboto" rel="stylesheet" type="text/css">
     <%= favicon_link_tag "/favicon.ico", rel: "shortcut icon" %>
 
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <link href="//fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <%= javascript_include_tag "application" %>
     <%= javascript_include_tag 'flash', 'jquery.cookie' %>
   </head>


### PR DESCRIPTION
The icons on the right and left of the metadata fields on the form seem to be missing in IE 11.