### PR TITLE
DEC-929 showcase thumbnails

### DIFF
--- a/app/assets/javascripts/components/showcase_editor/ShowcaseEditorTitle.jsx
+++ b/app/assets/javascripts/components/showcase_editor/ShowcaseEditorTitle.jsx
@@ -61,7 +61,7 @@ var ShowcaseEditorTitle = React.createClass({
   },
 
   image: function() {
-    if(this.props.showcase.image && this.props.showcase.image.status == "ready") {
+    if(this.props.showcase.image && this.props.showcase.image.status == "ready" && this.props.showcase.image["thumbnail/small"]) {
       return (
         <div>
           <h4>Background Image</h4>


### PR DESCRIPTION
If honeypot didn't have a thumbnail/small image for a showcase, the showcase edit button wouldn't show up. 

This is part of a larger issue where we just blindly index into dictionaries without checking if they keys exist. I'm not sure the best way to correct this in javascript (other than add if statements). In python there's dict.get(key, default) which allows for safe indexing all the time since default can be an empty dictionary. eg. we would do image.get("thumbnail/small", {}).get("contenturl", ""). I haven't found an equivalent in javascript as of yet. 