### PR TITLE
DEC-1284 Adding text section would hit error

### DIFF
--- a/app/form/section_form.rb
+++ b/app/form/section_form.rb
@@ -5,7 +5,7 @@ class SectionForm
     if controller.params[:id]
       section = SectionQuery.new.find(controller.params[:id])
     else
-      showcase = ShowcaseQuery.new.find(controller.params[:showcase_id])
+      showcase = ShowcaseQuery.new.public_find(controller.params[:showcase_id])
       section = SectionQuery.new(showcase.sections).build
       section.order = controller.params[:section][:order]
     end

--- a/spec/form/section_form_spec.rb
+++ b/spec/form/section_form_spec.rb
@@ -76,14 +76,14 @@ describe SectionForm do
 
     context "new_params" do
       before(:each) do
-        allow_any_instance_of(ShowcaseQuery).to receive(:find).with("20").and_return(showcase)
+        allow_any_instance_of(ShowcaseQuery).to receive(:public_find).with("20").and_return(showcase)
         allow_any_instance_of(SectionQuery).to receive(:build).and_return(section)
 
         allow(controller).to receive(:params).and_return(new_params)
       end
 
       it "finds the object from showcase" do
-        expect_any_instance_of(ShowcaseQuery).to receive(:find).with("20").and_return(showcase)
+        expect_any_instance_of(ShowcaseQuery).to receive(:public_find).with("20").and_return(showcase)
         subject
       end
 


### PR DESCRIPTION
The section#new action was still assuming internal id instead of public id for showcases. I've changed the query to use public_find instead.