### PR TITLE
Fix environment banner

### DIFF
--- a/app/assets/stylesheets/ui-customizations.css.scss
+++ b/app/assets/stylesheets/ui-customizations.css.scss
@@ -6,8 +6,8 @@ $multi-field-color: #696969;
 $dnd-ondrag-color: rgba(0, 0, 0, 0.05);
 $dnd-onhover-color: rgba(0, 0, 0, 0.15);
 $blockquote-gray: #777;
-$pprd-background: #ff0000;
-$pprd-color: #ffffff;
+$environment-background: #cc0000;
+$environment-color: #ffffff;
 
 body {
 	background: #fff;
@@ -24,9 +24,9 @@ h1, h2, h3, h4, h5, h6 {
 	margin:0;
 }
 
-.pprd {
-  background-color: $pprd-background;
-  color: $pprd-color;
+.environment {
+  background-color: $environment-background;
+  color: $environment-color;
   text-align: center;
 }
 

--- a/app/assets/stylesheets/ui-customizations.css.scss
+++ b/app/assets/stylesheets/ui-customizations.css.scss
@@ -28,6 +28,7 @@ h1, h2, h3, h4, h5, h6 {
   background-color: $environment-background;
   color: $environment-color;
   text-align: center;
+	line-height: 3em;
 }
 
 .title-bar {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -34,9 +34,10 @@
   <body>
 
 <header id="banner" role="banner" class="home">
-  <% if Rails.env == "pprd" %>
-    <div class="pprd">
-      TEST ENV
+
+  <% if Rails.env != "production" %>
+    <div class="environment">
+      <%= Rails.env.upcase %>
     </div>
   <% end %>
 


### PR DESCRIPTION
 * Preproduction banner was checking specifically for “pprd”, I’m
guessing it’s actually preproduction on the server or something.
 * Changed to show banner whenever environment is not “production”, so
it will show up on development too now.