### PR TITLE
DEC-450 Quick delete button(s)

### DIFF
--- a/app/assets/javascripts/components.js
+++ b/app/assets/javascripts/components.js
@@ -49,6 +49,7 @@ GoogleImportButton = require("./components/GoogleImportButton");
 GoogleExportButton = require("./components/GoogleExportButton");
 
 EntriesList = require("./components/EntriesList");
+DeleteButton = require("./components/DeleteButton");
 
 // Item search
 SearchPage = require("./components/search/SearchPage");

--- a/app/assets/javascripts/components/DeleteButton.jsx
+++ b/app/assets/javascripts/components/DeleteButton.jsx
@@ -6,8 +6,6 @@ var ItemStore = require("../stores/ItemStore");
 var ItemActions = require('../actions/ItemActions');
 
 var DeleteButton = React.createClass({
-  mixins: [DialogMixin],
-
   propTypes: {
     type: React.PropTypes.oneOf(['item', 'showcase', 'page']).isRequired,
     id: React.PropTypes.string.isRequired,
@@ -97,6 +95,36 @@ var DeleteButton = React.createClass({
     } else {
       return([this.cancelDismiss(), this.dialogConfirm()]);
     }
+  },
+
+  cancelDismiss: function() {
+    return (
+        <mui.FlatButton
+        label="Cacnel"
+        primary={true}
+        onTouchTap={this.dismissMessage}
+      />
+    );
+  },
+
+  okDismiss: function() {
+    return (
+      <mui.FlatButton
+        label="OK"
+        primary={true}
+        onTouchTap={this.dismissMessage}
+      />
+    );
+  },
+
+  dialogConfirm: function() {
+    return (
+      <mui.FlatButton
+        label="Yes"
+        primary={true}
+        onTouchTap={this.confirmMessage}
+      />
+    );
   },
 
   render: function() {

--- a/app/assets/javascripts/components/DeleteButton.jsx
+++ b/app/assets/javascripts/components/DeleteButton.jsx
@@ -21,21 +21,38 @@ var DeleteButton = React.createClass({
   },
 
   dismissConfirm: function() {
-    ItemStore.removeListener("ItemDeleteFinished", this.itemDeleteFinished);
-    ItemActions.removeListener("ItemDeleteFailed", this.itemDeleteFailed);
+    ItemStore.removeListener("ItemDeleteFinished", this.deleteSuccess);
+    ItemActions.removeListener("ItemDeleteFailed", this.deleteFailed);
     this.refs.deleteConfirm.dismiss();
+    this.setState({
+      deleting: false,
+    });
   },
 
-  itemDeleteFailed: function() {
+  deleteFailed: function() {
     this.dismissConfirm();
     this.refs.failedConfirm.show();
   },
 
-  itemDeleteFinished: function() {
+  deleteSuccess: function() {
     this.dismissConfirm();
     if(this.props.callback) {
       this.props.callback(this.props.id);
     }
+  },
+
+  genericDelete: function(url) {
+    $.ajax({
+      url: url,
+      dataType: "json",
+      method: "DELETE",
+      success: (function(data) {
+        this.deleteSuccess();
+      }).bind(this),
+      error: (function(xhr) {
+        this.deleteFailed();
+      }).bind(this),
+    });
   },
 
   delete: function() {
@@ -46,17 +63,17 @@ var DeleteButton = React.createClass({
     let id = this.props.id;
     switch(this.props.type) {
       case 'item':
-        ItemStore.on("ItemDeleteFinished", this.itemDeleteFinished);
-        ItemActions.on("ItemDeleteFailed", this.itemDeleteFailed);
+        ItemStore.on("ItemDeleteFinished", this.deleteSuccess);
+        ItemActions.on("ItemDeleteFailed", this.deleteFailed);
         ItemActions.delete(id);
       break;
       case 'showcase':
-        console.log("cant delete showcases yet");
-        // return '/showcases/' + id;
+        var url = '/v1/showcases/' + id;
+        this.genericDelete(url);
       break;
       case 'page':
-        console.log("cant delete pages yet");
-        // return '/pages/' + id;
+        var url = '/v1/pages/' + id;
+        this.genericDelete(url);
       break;
     }
   },
@@ -95,7 +112,7 @@ var DeleteButton = React.createClass({
           defaultOpen={false}
           actions={this.confirmActions()}
         >
-          <p>Are you sure you want to delete?</p>
+          <p>Are you sure you want to delete this entry?</p>
         </mui.Dialog>
         <mui.Dialog
           ref="failedConfirm"
@@ -104,7 +121,7 @@ var DeleteButton = React.createClass({
           defaultOpen={false}
           actions={[this.okDismiss()]}
         >
-          <p>Delete failed, check object details for reasons.</p>
+          <p>Delete failed, check entry detail view for more information.</p>
         </mui.Dialog>
       </div>
     );

--- a/app/assets/javascripts/components/DeleteButton.jsx
+++ b/app/assets/javascripts/components/DeleteButton.jsx
@@ -1,0 +1,115 @@
+'use strict'
+var React = require('react');
+var mui = require("material-ui");
+
+var ItemStore = require("../stores/ItemStore");
+var ItemActions = require('../actions/ItemActions');
+
+var DeleteButton = React.createClass({
+  mixins: [DialogMixin],
+
+  propTypes: {
+    type: React.PropTypes.oneOf(['item', 'showcase', 'page']).isRequired,
+    id: React.PropTypes.string.isRequired,
+    callback: React.PropTypes.func,
+  },
+
+  getInitialState: function() {
+    return {
+      deleting: false,
+    }
+  },
+
+  dismissConfirm: function() {
+    ItemStore.removeListener("ItemDeleteFinished", this.itemDeleteFinished);
+    ItemActions.removeListener("ItemDeleteFailed", this.itemDeleteFailed);
+    this.refs.deleteConfirm.dismiss();
+  },
+
+  itemDeleteFailed: function() {
+    this.dismissConfirm();
+    this.refs.failedConfirm.show();
+  },
+
+  itemDeleteFinished: function() {
+    this.dismissConfirm();
+    if(this.props.callback) {
+      this.props.callback(this.props.id);
+    }
+  },
+
+  delete: function() {
+    this.setState({
+      deleting: true,
+    });
+
+    let id = this.props.id;
+    switch(this.props.type) {
+      case 'item':
+        ItemStore.on("ItemDeleteFinished", this.itemDeleteFinished);
+        ItemActions.on("ItemDeleteFailed", this.itemDeleteFailed);
+        ItemActions.delete(id);
+      break;
+      case 'showcase':
+        console.log("cant delete showcases yet");
+        // return '/showcases/' + id;
+      break;
+      case 'page':
+        console.log("cant delete pages yet");
+        // return '/pages/' + id;
+      break;
+    }
+  },
+
+  confirmDelete: function() {
+    this.refs.deleteConfirm.show();
+  },
+
+  dismissMessage: function() {
+    this.refs.deleteConfirm.dismiss();
+    this.refs.failedConfirm.dismiss();
+  },
+
+  confirmMessage: function() {
+    this.delete();
+  },
+
+  confirmActions: function() {
+    if(this.state.deleting) {
+      return ([<mui.CircularProgress mode="indeterminate" size={0.5} />]);
+    } else {
+      return([this.cancelDismiss(), this.dialogConfirm()]);
+    }
+  },
+
+  render: function() {
+    return (
+      <div>
+        <mui.IconButton onClick={this.confirmDelete} >
+          <mui.FontIcon className="material-icons" color="#f44336">delete</mui.FontIcon>
+        </mui.IconButton>
+        <mui.Dialog
+          ref="deleteConfirm"
+          modal={true}
+          title="Delete"
+          defaultOpen={false}
+          actions={this.confirmActions()}
+        >
+          <p>Are you sure you want to delete?</p>
+        </mui.Dialog>
+        <mui.Dialog
+          ref="failedConfirm"
+          modal={true}
+          title="Delete Failed"
+          defaultOpen={false}
+          actions={[this.okDismiss()]}
+        >
+          <p>Delete failed, check object details for reasons.</p>
+        </mui.Dialog>
+      </div>
+    );
+  }
+
+});
+
+module.exports = DeleteButton;

--- a/app/assets/javascripts/components/EntriesList.jsx
+++ b/app/assets/javascripts/components/EntriesList.jsx
@@ -15,6 +15,10 @@ var Styles = {
     cursor: "pointer"
   },
   cells:{
+    deleteButton: {
+      fontSize: "18px",
+      width: "75px",
+    },
     thumbnail: {
       height: "80px",
       paddingTop: "8px",
@@ -32,6 +36,9 @@ var Styles = {
     },
   },
   headers: {
+    deleteButton: {
+      width: "75px",
+    },
     thumbnail: {
       height: "80px",
       paddingTop: "8px",
@@ -52,15 +59,18 @@ var EntriesList = React.createClass({
     entries: React.PropTypes.array.isRequired,
     openUrl: React.PropTypes.string.isRequired,
     hasEntryCount: React.PropTypes.bool,
+    deleteButtonType: React.PropTypes.string,
   },
 
   getDefaultProps: function() {
     return { hasEntryCount: false };
   },
 
-  openItem: function(rowNumber) {
-    var selectedId = this.props.entries[rowNumber].id;
-    window.location = this.props.openUrl.replace("<id>", selectedId);
+  openItem: function(rowNumber, columnId) {
+    if(columnId != 1) {
+      var selectedId = this.props.entries[rowNumber].id;
+      window.location = this.props.openUrl.replace("<id>", selectedId);
+    }
   },
 
   entryCountHeader: function() {
@@ -84,6 +94,24 @@ var EntriesList = React.createClass({
     }
   },
 
+  deleteCallback: function() {
+    window.location.reload();
+  },
+
+  deleteColumn: function(header, id) {
+    if(this.props.deleteButtonType) {
+      if(header) {
+        return(<mui.TableHeaderColumn style={Styles.headers.deleteButton}></mui.TableHeaderColumn>);
+      } else {
+        return(
+          <mui.TableRowColumn style={ Styles.cells.deleteButton }>
+            <DeleteButton type={this.props.deleteButtonType} id={id} callback={this.deleteCallback}/>
+          </mui.TableRowColumn>
+        );
+      }
+    }
+  },
+
   items: function() {
     return this.props.entries.map(function(entry) {
       var dateOptions = { year: "numeric", month: "short", day: "numeric" };
@@ -94,6 +122,7 @@ var EntriesList = React.createClass({
       }
       return (
         <mui.TableRow key={ entry.id } style={ Styles.row }>
+            { this.deleteColumn(false, entry.id) }
             <mui.TableRowColumn style={ Styles.cells.thumbnail }>
               <Thumbnail thumbnailUrl={ entry.thumb } thumbType={ this.props.entryType } />
             </mui.TableRowColumn>
@@ -112,6 +141,7 @@ var EntriesList = React.createClass({
           <mui.Table selectable={false} fixedFooter={true} onCellClick={ this.openItem }>
             <mui.TableHeader displaySelectAll={false} adjustForCheckbox={false}>
               <mui.TableRow>
+                { this.deleteColumn(true) }
                 <mui.TableHeaderColumn style={Styles.headers.thumbnail}></mui.TableHeaderColumn>
                 <mui.TableHeaderColumn style={Styles.headers.itemName}>
                   <span>{this.props.header}</span>

--- a/app/assets/javascripts/components/EntriesList.jsx
+++ b/app/assets/javascripts/components/EntriesList.jsx
@@ -67,7 +67,7 @@ var EntriesList = React.createClass({
   },
 
   openItem: function(rowNumber, columnId) {
-    if(columnId != 1) {
+    if(columnId != 4) {
       var selectedId = this.props.entries[rowNumber].id;
       window.location = this.props.openUrl.replace("<id>", selectedId);
     }
@@ -122,13 +122,13 @@ var EntriesList = React.createClass({
       }
       return (
         <mui.TableRow key={ entry.id } style={ Styles.row }>
-            { this.deleteColumn(false, entry.id) }
             <mui.TableRowColumn style={ Styles.cells.thumbnail }>
               <Thumbnail thumbnailUrl={ entry.thumb } thumbType={ this.props.entryType } />
             </mui.TableRowColumn>
             <mui.TableRowColumn style={ Styles.cells.itemName }>{ entry.name }</mui.TableRowColumn>
             { this.entryCount(entry) }
             <mui.TableRowColumn style={ Styles.cells.lastModifiedAt }>{ dateString }</mui.TableRowColumn>
+            { this.deleteColumn(false, entry.id) }
         </mui.TableRow>
       );
     }.bind(this));
@@ -141,7 +141,6 @@ var EntriesList = React.createClass({
           <mui.Table selectable={false} fixedFooter={true} onCellClick={ this.openItem }>
             <mui.TableHeader displaySelectAll={false} adjustForCheckbox={false}>
               <mui.TableRow>
-                { this.deleteColumn(true) }
                 <mui.TableHeaderColumn style={Styles.headers.thumbnail}></mui.TableHeaderColumn>
                 <mui.TableHeaderColumn style={Styles.headers.itemName}>
                   <span>{this.props.header}</span>
@@ -150,6 +149,7 @@ var EntriesList = React.createClass({
                 <mui.TableHeaderColumn style={Styles.headers.lastModifiedAt}>
                   <span>Last Modified At</span>
                 </mui.TableHeaderColumn>
+                { this.deleteColumn(true) }
               </mui.TableRow>
             </mui.TableHeader>
             <mui.TableBody displayRowCheckbox={false} showRowHover={true} className="item-list">

--- a/app/assets/javascripts/components/EntriesList.jsx
+++ b/app/assets/javascripts/components/EntriesList.jsx
@@ -66,8 +66,14 @@ var EntriesList = React.createClass({
     return { hasEntryCount: false };
   },
 
+  getInitialState: function() {
+    return {
+      deleteColumn: 4,
+    }
+  },
+
   openItem: function(rowNumber, columnId) {
-    if(columnId != 4) {
+    if(columnId != this.state.deleteColumn) {
       var selectedId = this.props.entries[rowNumber].id;
       window.location = this.props.openUrl.replace("<id>", selectedId);
     }

--- a/app/assets/javascripts/components/search/SearchPage.jsx
+++ b/app/assets/javascripts/components/search/SearchPage.jsx
@@ -107,7 +107,7 @@ var SearchPage = React.createClass({
   },
 
   openItem: function(rowNumber, columnId) {
-    if(columnId != 1) {
+    if(columnId != 4) {
       var selectedId = SearchStore.hits[rowNumber]["@id"];
       var reg = new RegExp( '^.*\/(.*)$', 'i' );
       var string = reg.exec(selectedId);
@@ -138,14 +138,14 @@ var SearchPage = React.createClass({
       var itemId = atIdSplit[atIdSplit.length - 1];
       return (
         <mui.TableRow key={ atId } style={ Styles.row }>
-            <mui.TableRowColumn style={ Styles.cells.deleteButton }>
-              <DeleteButton type="item" id={itemId} callback={this.executeQuery}/>
-            </mui.TableRowColumn>
             <mui.TableRowColumn style={ Styles.cells.thumbnail }>
               { this.getThumbnail(hit.thumbnailURL, hit.type) }
             </mui.TableRowColumn>
             <mui.TableRowColumn style={ Styles.cells.itemName }>{ hit.name }</mui.TableRowColumn>
             <mui.TableRowColumn style={ Styles.cells.lastModifiedAt }>{ dateString }</mui.TableRowColumn>
+            <mui.TableRowColumn style={ Styles.cells.deleteButton }>
+              <DeleteButton type="item" id={itemId} callback={this.executeQuery}/>
+            </mui.TableRowColumn>
         </mui.TableRow>
       );
     }.bind(this));
@@ -171,7 +171,6 @@ var SearchPage = React.createClass({
           <mui.Table selectable={false} fixedFooter={true} onCellClick={ this.openItem }>
             <mui.TableHeader displaySelectAll={false} adjustForCheckbox={false}>
               <mui.TableRow>
-                <mui.TableHeaderColumn style={Styles.headers.deleteButton}></mui.TableHeaderColumn>
                 <mui.TableHeaderColumn style={Styles.headers.thumbnail}></mui.TableHeaderColumn>
                 <mui.TableHeaderColumn style={Styles.headers.itemName}>
                   <SearchSortButton field="name" rows={this.props.rows} searchUrl={this.props.searchUrl} />
@@ -181,6 +180,7 @@ var SearchPage = React.createClass({
                   <SearchSortButton field="last_updated" rows={this.props.rows} searchUrl={this.props.searchUrl} />
                   <span>Last Modified At</span>
                 </mui.TableHeaderColumn>
+                <mui.TableHeaderColumn style={Styles.headers.deleteButton}></mui.TableHeaderColumn>
               </mui.TableRow>
             </mui.TableHeader>
             <mui.TableBody displayRowCheckbox={false} showRowHover={true} className="item-list">

--- a/app/assets/javascripts/components/search/SearchPage.jsx
+++ b/app/assets/javascripts/components/search/SearchPage.jsx
@@ -76,6 +76,7 @@ var SearchPage = React.createClass({
   getInitialState: function() {
     return {
       searching: false,
+      deleteColumn: 4,
     };
   },
 
@@ -107,7 +108,7 @@ var SearchPage = React.createClass({
   },
 
   openItem: function(rowNumber, columnId) {
-    if(columnId != 4) {
+    if(columnId != this.state.deleteColumn) {
       var selectedId = SearchStore.hits[rowNumber]["@id"];
       var reg = new RegExp( '^.*\/(.*)$', 'i' );
       var string = reg.exec(selectedId);

--- a/app/assets/javascripts/mixins/DialogMixin.jsx
+++ b/app/assets/javascripts/mixins/DialogMixin.jsx
@@ -25,5 +25,15 @@ var DialogMixin = {
     );
   },
 
+  dialogConfirm: function() {
+    return (
+      <FlatButton
+        label="Yes"
+        primary={true}
+        onTouchTap={this.confirmMessage}
+      />
+    );
+  }
+
 }
 module.exports = DialogMixin;

--- a/app/assets/javascripts/mixins/DialogMixin.jsx
+++ b/app/assets/javascripts/mixins/DialogMixin.jsx
@@ -25,15 +25,5 @@ var DialogMixin = {
     );
   },
 
-  dialogConfirm: function() {
-    return (
-      <FlatButton
-        label="Yes"
-        primary={true}
-        onTouchTap={this.confirmMessage}
-      />
-    );
-  }
-
 }
 module.exports = DialogMixin;

--- a/app/controllers/v1/pages_controller.rb
+++ b/app/controllers/v1/pages_controller.rb
@@ -19,5 +19,16 @@ module V1
                                            page: @page)
       fresh_when(etag: cache_key.generate)
     end
+
+    def destroy
+      @page = PageQuery.new.public_find(params[:id])
+      return if rendered_forbidden?(@page.collection)
+
+      if Destroy::Page.new.cascade!(page: @page)
+        render json: { status: "Success" }
+      else
+        render json: { status: "Unable to delete item" }, status: :unprocessable_entity
+      end
+    end
   end
 end

--- a/app/controllers/v1/showcases_controller.rb
+++ b/app/controllers/v1/showcases_controller.rb
@@ -19,5 +19,16 @@ module V1
                                            showcase: @showcase)
       fresh_when(etag: cache_key.generate)
     end
+
+    def destroy
+      @showcase = ShowcaseQuery.new.public_find(params[:id])
+      return if rendered_forbidden?(@showcase.collection)
+
+      if Destroy::Showcase.new.cascade!(showcase: @showcase)
+        render json: { status: "Success" }
+      else
+        render json: { status: "Unable to delete item" }, status: :unprocessable_entity
+      end
+    end
   end
 end

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -8,5 +8,6 @@
     entryType: "page",
     entries: @list_items,
     openUrl: "/pages/<id>/edit",
+    deleteButtonType: "page",
   }
 %>

--- a/app/views/showcases/index.html.erb
+++ b/app/views/showcases/index.html.erb
@@ -8,5 +8,6 @@
     entryType: "showcase",
     entries: @list_items,
     openUrl: "/showcases/<id>/edit",
+    deleteButtonType: "showcase",
   }
 %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -105,8 +105,8 @@ Rails.application.routes.draw do
       put "finish_upload", to: "media#finish_upload"
     end
 
-    resources :showcases, only: [:show], defaults: { format: :json }
-    resources :pages, only: [:show], defaults: { format: :json }
+    resources :showcases, only: [:show, :destroy], defaults: { format: :json }
+    resources :pages, only: [:show, :destroy], defaults: { format: :json }
     resources :sections, only: [:show], defaults: { format: :json }
   end
 

--- a/spec/controllers/v1/showcases_controller_spec.rb
+++ b/spec/controllers/v1/showcases_controller_spec.rb
@@ -3,7 +3,7 @@ require "cache_spec_helper"
 
 RSpec.describe V1::ShowcasesController, type: :controller do
   let(:collection) { instance_double(Collection, id: "1", updated_at: nil, showcases: nil, collection_configuration: "collection_configuration") }
-  let(:showcase) { instance_double(Showcase, id: "1", updated_at: nil, sections: nil, items: nil, collection: collection) }
+  let(:showcase) { instance_double(Showcase, id: "1", updated_at: nil, sections: [], items: [], collection: collection, destroy!: true) }
 
   before(:each) do
     allow_any_instance_of(ShowcaseQuery).to receive(:public_find).and_return(showcase)
@@ -60,6 +60,30 @@ RSpec.describe V1::ShowcasesController, type: :controller do
 
     it "uses the V1Showcases#show to generate the cache key" do
       expect_any_instance_of(CacheKeys::Custom::V1Showcases).to receive(:show)
+      subject
+    end
+  end
+
+  describe "#destroy" do
+    subject { delete :destroy, id: showcase.id, format: :json }
+
+    before(:each) do
+      sign_in_admin
+    end
+
+    it "is successful" do
+      subject
+
+      expect(response).to be_success
+    end
+
+    it "uses showcase query " do
+      expect_any_instance_of(ShowcaseQuery).to receive(:public_find).with("1").and_return(showcase)
+      subject
+    end
+
+    it "uses the Destroy::Showcase.cascade method" do
+      expect_any_instance_of(Destroy::Showcase).to receive(:cascade!)
       subject
     end
   end


### PR DESCRIPTION
The request was for a quick way to delete items.

Initial implementation was with checkboxes in the item listing view which would then mass-delete all selected items. Unfortunately, getting information for each item on weather or not it can be deleted was expensive and slow.

Instead, I went with a delete button on the list view for each item which will save a few page transitions at least. I added these buttons to the items/pages/and showcases listings. 