### PR TITLE
update gem to point to one that works in our environment.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,7 @@ gem "whenever", require: false
 # Use Uglifier as compressor for JavaScript assets
 gem "uglifier", ">= 1.3.0"
 gem "react-rails"
-gem "react-rails-img"
+gem "react-rails-img", git: "git@github.com:/jonhartzler/react-rails-img.git"
 gem "browserify-rails", "~>0.7.2"
 gem "underscore-rails"
 gem "showdown-rails"

--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,7 @@ gem "whenever", require: false
 # Use Uglifier as compressor for JavaScript assets
 gem "uglifier", ">= 1.3.0"
 gem "react-rails"
-gem "react-rails-img", git: "git@github.com:/jonhartzler/react-rails-img.git"
+gem "react-rails-img", git: "https://github.com/jonhartzler/react-rails-img.git"
 gem "browserify-rails", "~>0.7.2"
 gem "underscore-rails"
 gem "showdown-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,6 +32,13 @@ GIT
       jettywrapper (~> 2.0.3)
 
 GIT
+  remote: git@github.com:/jonhartzler/react-rails-img.git
+  revision: cc5c4ea42829d8baf6b7815532279843eef651d0
+  specs:
+    react-rails-img (0.1.5)
+      react-rails
+
+GIT
   remote: https://github.com/ndlib/google-drive-ruby.git
   revision: 263a978cb4a2fafcc33822aeda011ca37aac9019
   branch: DEC-1008-Speedup-update-cells
@@ -394,8 +401,6 @@ GEM
       execjs
       rails (>= 3.2)
       tilt
-    react-rails-img (0.1.5)
-      react-rails
     ref (1.0.5)
     request_store (1.1.0)
     responders (2.1.0)
@@ -587,7 +592,7 @@ DEPENDENCIES
   rake (< 11)
   rb-readline
   react-rails
-  react-rails-img
+  react-rails-img!
   responders (~> 2.0)
   rsolr
   rspec-collection_matchers
@@ -609,4 +614,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   1.13.0
+   1.13.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,7 +32,7 @@ GIT
       jettywrapper (~> 2.0.3)
 
 GIT
-  remote: git@github.com:/jonhartzler/react-rails-img.git
+  remote: https://github.com/jonhartzler/react-rails-img.git
   revision: cc5c4ea42829d8baf6b7815532279843eef651d0
   specs:
     react-rails-img (0.1.5)


### PR DESCRIPTION
Basically the gem react_rails_img does not recognize the fact we have a pre_production env.  So far I have forked the gem.  

https://github.com/jonhartzler/react-rails-img

I will probably make a pull request with the project.  
