### PR TITLE
Import CSV

### DIFF
--- a/app/assets/javascripts/components.js
+++ b/app/assets/javascripts/components.js
@@ -44,6 +44,7 @@ ShowcasesPanel = require("./components/ShowcasesPanel");
 PagesPanel = require("./components/PagesPanel");
 Thumbnail = require("./components/Thumbnail");
 ProgressOverlay = require("./components/ProgressOverlay");
+ImportResultsDialog = require("./components/ImportResultsDialog");
 CsvImportButton = require("./components/CsvImportButton");
 GoogleImportButton = require("./components/GoogleImportButton");
 GoogleExportButton = require("./components/GoogleExportButton");

--- a/app/assets/javascripts/components.js
+++ b/app/assets/javascripts/components.js
@@ -44,6 +44,7 @@ ShowcasesPanel = require("./components/ShowcasesPanel");
 PagesPanel = require("./components/PagesPanel");
 Thumbnail = require("./components/Thumbnail");
 ProgressOverlay = require("./components/ProgressOverlay");
+CsvImportButton = require("./components/CsvImportButton");
 GoogleImportButton = require("./components/GoogleImportButton");
 GoogleExportButton = require("./components/GoogleExportButton");
 

--- a/app/assets/javascripts/components/CsvImportButton.jsx
+++ b/app/assets/javascripts/components/CsvImportButton.jsx
@@ -3,6 +3,7 @@ var React = require('react');
 var mui = require("material-ui");
 var FlatButton = mui.FlatButton;
 var FontIcon = mui.FontIcon;
+var ImportResultsDialog = require("./ImportResultsDialog");
 
 var CsvImportButton = React.createClass({
   mixins: [MuiThemeMixin],
@@ -11,6 +12,12 @@ var CsvImportButton = React.createClass({
     postUri: React.PropTypes.string.isRequired,
   },
 
+  getInitialState: function() {
+    return {
+      uploaded: false,
+      response: {}
+    };
+  },
 
   uploadFile: function(media) {
     var xhr = new XMLHttpRequest();
@@ -18,7 +25,8 @@ var CsvImportButton = React.createClass({
     xhr.onreadystatechange = () => {
       if(xhr.readyState === 4) {
         if(xhr.status === 200) {
-          console.log(JSON.parse(xhr.responseText));
+console.log(JSON.parse(xhr.responseText));
+          this.setState({ uploaded: true, response: JSON.parse(xhr.responseText) });
         } else {
           console.log(xhr.responseText);
         }
@@ -41,7 +49,8 @@ var CsvImportButton = React.createClass({
     );
     return (
       <div>
-        <form ref={ "csvForm" } id="csvForm" action={ this.props.postUri } method="post" encType="multipart/form-data">
+        <ImportResultsDialog open={ this.state.uploaded } results={ this.state.response } />
+        <form action={ this.props.postUri } method="post" encType="multipart/form-data">
           <input ref={ "csvInput" } id="csvInput" type="file" name="csv_file" style={{ display: "none" }} onChange={ this.uploadFile } />
         </form>
         <FlatButton

--- a/app/assets/javascripts/components/CsvImportButton.jsx
+++ b/app/assets/javascripts/components/CsvImportButton.jsx
@@ -4,6 +4,7 @@ var mui = require("material-ui");
 var FlatButton = mui.FlatButton;
 var FontIcon = mui.FontIcon;
 var ImportResultsDialog = require("./ImportResultsDialog");
+var EventEmitter = require("../EventEmitter");
 
 var CsvImportButton = React.createClass({
   mixins: [MuiThemeMixin],
@@ -14,7 +15,6 @@ var CsvImportButton = React.createClass({
 
   getInitialState: function() {
     return {
-      uploading: false,
       uploaded: false,
       response: {}
     };
@@ -27,7 +27,8 @@ var CsvImportButton = React.createClass({
       xhr.onreadystatechange = () => {
         if(xhr.readyState === 4) {
           if(xhr.status === 200) {
-            this.setState({ uploading: false, uploaded: true, response: JSON.parse(xhr.responseText) });
+            this.setState({ uploaded: true, response: JSON.parse(xhr.responseText) });
+            EventEmitter.emit("ImportFinished");
             this.refs.csvInput.value = '';
           } else {
             console.log(xhr.responseText);
@@ -35,12 +36,11 @@ var CsvImportButton = React.createClass({
         }
       };
 
-      this.setState({ uploading: true, uploaded: false }, function(){
-        var f = this.refs.csvInput;
-        var formData = new FormData();
-        formData.append("csv_file", f.files[0], f.files[0].name);
-        xhr.send(formData);
-      }.bind(this));
+      EventEmitter.emit("ImportStarted");
+      var f = this.refs.csvInput;
+      var formData = new FormData();
+      formData.append("csv_file", f.files[0], f.files[0].name);
+      xhr.send(formData);
     }
   },
 
@@ -49,7 +49,7 @@ var CsvImportButton = React.createClass({
     var buttonLabel = (
       <span>
         <FontIcon className="glyphicon glyphicon-import" label="Upload" color="#000" style={iconStyle}/>
-        <span>Import CSV</span>
+        <span>Import from CSV</span>
       </span>
     );
     return (
@@ -59,7 +59,6 @@ var CsvImportButton = React.createClass({
           <input ref={ "csvInput" } id="csvInput" type="file" name="csv_file" style={{ display: "none" }} onChange={ this.uploadFile } />
         </form>
         <FlatButton
-          disabled={ this.state.uploading }
           primary={false}
           onTouchTap={ function() { this.refs.csvInput.click(); }.bind(this) }
           label={buttonLabel}

--- a/app/assets/javascripts/components/CsvImportButton.jsx
+++ b/app/assets/javascripts/components/CsvImportButton.jsx
@@ -1,0 +1,57 @@
+/** @jsx React.DOM */
+var React = require('react');
+var mui = require("material-ui");
+var FlatButton = mui.FlatButton;
+var FontIcon = mui.FontIcon;
+
+var CsvImportButton = React.createClass({
+  mixins: [MuiThemeMixin],
+
+  propTypes: {
+    postUri: React.PropTypes.string.isRequired,
+  },
+
+
+  uploadFile: function(media) {
+    var xhr = new XMLHttpRequest();
+    xhr.open('POST', this.props.postUri);
+    xhr.onreadystatechange = () => {
+      if(xhr.readyState === 4) {
+        if(xhr.status === 200) {
+          console.log(JSON.parse(xhr.responseText));
+        } else {
+          console.log(xhr.responseText);
+        }
+      }
+    };
+
+    var f = this.refs.csvInput;
+    var formData = new FormData();
+    formData.append("csv_file", f.files[0], f.files[0].name);
+    xhr.send(formData);
+  },
+
+  render: function() {
+    var iconStyle = {fontSize: 14, marginRight: ".5em"};
+    var buttonLabel = (
+      <span>
+        <FontIcon className="glyphicon glyphicon-import" label="Upload" color="#000" style={iconStyle}/>
+        <span>Import CSV</span>
+      </span>
+    );
+    return (
+      <div>
+        <form ref={ "csvForm" } id="csvForm" action={ this.props.postUri } method="post" encType="multipart/form-data">
+          <input ref={ "csvInput" } id="csvInput" type="file" name="csv_file" style={{ display: "none" }} onChange={ this.uploadFile } />
+        </form>
+        <FlatButton
+          primary={false}
+          onTouchTap={ function() { this.refs.csvInput.click(); }.bind(this) }
+          label={buttonLabel}
+        />
+      </div>
+    );
+  }
+});
+
+module.exports = CsvImportButton;

--- a/app/assets/javascripts/components/CsvImportButton.jsx
+++ b/app/assets/javascripts/components/CsvImportButton.jsx
@@ -14,29 +14,34 @@ var CsvImportButton = React.createClass({
 
   getInitialState: function() {
     return {
+      uploading: false,
       uploaded: false,
       response: {}
     };
   },
 
   uploadFile: function(media) {
-    var xhr = new XMLHttpRequest();
-    xhr.open('POST', this.props.postUri);
-    xhr.onreadystatechange = () => {
-      if(xhr.readyState === 4) {
-        if(xhr.status === 200) {
-console.log(JSON.parse(xhr.responseText));
-          this.setState({ uploaded: true, response: JSON.parse(xhr.responseText) });
-        } else {
-          console.log(xhr.responseText);
+    if(this.refs.csvInput.files){
+      var xhr = new XMLHttpRequest();
+      xhr.open('POST', this.props.postUri);
+      xhr.onreadystatechange = () => {
+        if(xhr.readyState === 4) {
+          if(xhr.status === 200) {
+            this.setState({ uploading: false, uploaded: true, response: JSON.parse(xhr.responseText) });
+            this.refs.csvInput.value = '';
+          } else {
+            console.log(xhr.responseText);
+          }
         }
-      }
-    };
+      };
 
-    var f = this.refs.csvInput;
-    var formData = new FormData();
-    formData.append("csv_file", f.files[0], f.files[0].name);
-    xhr.send(formData);
+      this.setState({ uploading: true, uploaded: false }, function(){
+        var f = this.refs.csvInput;
+        var formData = new FormData();
+        formData.append("csv_file", f.files[0], f.files[0].name);
+        xhr.send(formData);
+      }.bind(this));
+    }
   },
 
   render: function() {
@@ -54,6 +59,7 @@ console.log(JSON.parse(xhr.responseText));
           <input ref={ "csvInput" } id="csvInput" type="file" name="csv_file" style={{ display: "none" }} onChange={ this.uploadFile } />
         </form>
         <FlatButton
+          disabled={ this.state.uploading }
           primary={false}
           onTouchTap={ function() { this.refs.csvInput.click(); }.bind(this) }
           label={buttonLabel}

--- a/app/assets/javascripts/components/GoogleExportButton.jsx
+++ b/app/assets/javascripts/components/GoogleExportButton.jsx
@@ -47,7 +47,7 @@ var GoogleExportButton = React.createClass({
     var buttonLabel = (
       <span>
         <FontIcon className="glyphicon glyphicon-export" label="Download" color="#000" style={iconStyle}/>
-        <span>Export Metadata</span>
+        <span>Export to Google</span>
       </span>
     );
     return (

--- a/app/assets/javascripts/components/GoogleImportButton.jsx
+++ b/app/assets/javascripts/components/GoogleImportButton.jsx
@@ -7,6 +7,11 @@ var FontIcon = mui.FontIcon;
 var GoogleImportButton = React.createClass({
   mixins: [MuiThemeMixin, GooglePickerMixin],
 
+  filePicked: function(url) {
+    EventEmitter.emit("ImportStarted");
+    window.location.href = url;
+  },
+
   render: function() {
     var iconStyle = {fontSize: 14, marginRight: ".5em"};
     var buttonLabel = (
@@ -19,7 +24,7 @@ var GoogleImportButton = React.createClass({
       <div>
         <FlatButton
           primary={false}
-          onTouchTap={this.loadPicker}
+          onTouchTap={ function() { this.loadPicker(this.filePicked); }.bind(this) }
           label={buttonLabel}
         />
       </div>

--- a/app/assets/javascripts/components/GoogleImportButton.jsx
+++ b/app/assets/javascripts/components/GoogleImportButton.jsx
@@ -12,7 +12,7 @@ var GoogleImportButton = React.createClass({
     var buttonLabel = (
       <span>
         <FontIcon className="glyphicon glyphicon-import" label="Upload" color="#000" style={iconStyle}/>
-        <span>Import Metadata</span>
+        <span>Import from Google</span>
       </span>
     );
     return (

--- a/app/assets/javascripts/components/ImportResultsDialog.jsx
+++ b/app/assets/javascripts/components/ImportResultsDialog.jsx
@@ -1,0 +1,136 @@
+var React = require('react');
+var mui = require("material-ui");
+var Dialog = mui.Dialog;
+var RaisedButton = mui.RaisedButton;
+var FlatButton = mui.FlatButton;
+
+var ImportResultsDialog = React.createClass({
+  mixins: [MuiThemeMixin],
+
+  propTypes: {
+    open: React.PropTypes.bool.isRequired,
+    results: React.PropTypes.object.isRequired,
+  },
+
+  getInitialState: function() {
+    return {
+      open: this.props.open,
+    };
+  },
+
+  componentWillReceiveProps: function(nextProps) {
+    if(nextProps.open) {
+      this.setState({
+        open: nextProps.open,
+      });
+    }
+  },
+
+  componentDidMount: function() {
+    if(this.state.open){
+      this.refs.ResultsDialog.show();
+    } else {
+      this.refs.ResultsDialog.dismiss();
+    }
+  },
+
+  componentDidUpdate: function(prevProps, prevState) {
+    if(this.state.open){
+      this.refs.ResultsDialog.show();
+    } else {
+      this.refs.ResultsDialog.dismiss();
+    }
+  },
+
+  handleClose: function() {
+    this.setState({ open: false });
+  },
+
+  summary: function() {
+    var summary = this.props.results.summary;
+    var totals = (<div>Of { summary.total_count } total rows:</div>);
+
+    var newCount = null;
+    if (summary.new_count > 0) {
+      newCount = (<div>{ summary.new_count } items were created.</div>);
+    }
+    var changedCount = null;
+    if (summary.changed_count > 0) {
+      changedCount = (<div>{ summary.changed_count } items were updated.</div>);
+    }
+    var unchangedCount = null;
+    if (summary.unchanged_count > 0) {
+      unchangedCount = (<div>{ summary.unchanged_count } items had no changes.</div>);
+    }
+
+    return [totals, newCount, changedCount, unchangedCount];
+  },
+
+  errors: function() {
+    return (null);
+/*
+    <% if @results[:summary][:error_count] > 0 %>
+      <div><%= @results[:summary][:error_count] %> rows were not imported due to the following errors:</div>
+      <table class="table table-striped">
+        <thead>
+          <tr>
+            <th>Row</th>
+            <th>Item Id</th>
+            <th>Item Name</th>
+            <th>Errors</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @results[:errors].each do |index, row| %>
+            <tr>
+              <td><%= index + 2 %></td>
+              <td><%= row[:item].user_defined_id %></td>
+              <td><%= row[:item].name %></td>
+              <td>
+                <% row[:errors].each do |error| %>
+                  <div><%= error %></div>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    <% end %>
+*/
+  },
+
+  render: function() {
+    const actions = [
+      <FlatButton
+        label="OK"
+        primary={true}
+        onTouchTap={this.handleClose}
+      />,
+    ];
+    var dialogBody = null;
+    if(this.state.open){
+      dialogBody = (
+        <div>
+          { this.summary() }
+          { this.errors() }
+        </div>
+      );
+    }
+
+    return (
+      <div>
+        <Dialog
+          ref={ "ResultsDialog" }
+          title="Import Results"
+          actions={actions}
+          modal={false}
+          open={this.state.open}
+          onRequestClose={this.handleClose}
+        >
+          { dialogBody }
+        </Dialog>
+      </div>
+    );
+  }
+});
+module.exports = ImportResultsDialog;

--- a/app/assets/javascripts/components/ImportResultsDialog.jsx
+++ b/app/assets/javascripts/components/ImportResultsDialog.jsx
@@ -19,11 +19,9 @@ var ImportResultsDialog = React.createClass({
   },
 
   componentWillReceiveProps: function(nextProps) {
-    if(nextProps.open) {
-      this.setState({
-        open: nextProps.open,
-      });
-    }
+    this.setState({
+      open: nextProps.open,
+    });
   },
 
   componentDidMount: function() {
@@ -67,36 +65,49 @@ var ImportResultsDialog = React.createClass({
   },
 
   errors: function() {
-    return (null);
-/*
-    <% if @results[:summary][:error_count] > 0 %>
-      <div><%= @results[:summary][:error_count] %> rows were not imported due to the following errors:</div>
-      <table class="table table-striped">
-        <thead>
+
+    var summary = this.props.results.summary;
+    if (summary.error_count > 0) {
+      var errors = this.props.results.errors;
+      var tableRows = [];
+
+      for(rowIndex in errors){
+        var row = errors[rowIndex];
+        var errorDetails = [];
+        row.errors.forEach(function(error) {
+          errorDetails.push(<div>{ error }</div>);
+        });
+
+        tableRows.push((
           <tr>
-            <th>Row</th>
-            <th>Item Id</th>
-            <th>Item Name</th>
-            <th>Errors</th>
+            <td>{ parseInt(rowIndex) + 2 }</td>
+            <td>{ row.item.user_defined_id }</td>
+            <td>{ row.item.metadata.name[0] }</td>
+            <td>
+              { errorDetails }
+            </td>
           </tr>
-        </thead>
-        <tbody>
-          <% @results[:errors].each do |index, row| %>
+        ));
+      };
+
+      return [
+        <div>{ summary.error_count } rows were not imported due to the following errors:</div>,
+        <table className="table table-striped">
+          <thead>
             <tr>
-              <td><%= index + 2 %></td>
-              <td><%= row[:item].user_defined_id %></td>
-              <td><%= row[:item].name %></td>
-              <td>
-                <% row[:errors].each do |error| %>
-                  <div><%= error %></div>
-                <% end %>
-              </td>
+              <th>Row</th>
+              <th>Item Id</th>
+              <th>Item Name</th>
+              <th>Errors</th>
             </tr>
-          <% end %>
-        </tbody>
-      </table>
-    <% end %>
-*/
+          </thead>
+          <tbody>
+            { tableRows }
+          </tbody>
+        </table>
+      ];
+    }
+    return null;
   },
 
   render: function() {
@@ -126,6 +137,7 @@ var ImportResultsDialog = React.createClass({
           modal={false}
           open={this.state.open}
           onRequestClose={this.handleClose}
+          bodyStyle={ { overflowY: "auto", maxHeight: "70vh" } }
         >
           { dialogBody }
         </Dialog>

--- a/app/assets/javascripts/components/search/SearchPage.jsx
+++ b/app/assets/javascripts/components/search/SearchPage.jsx
@@ -75,6 +75,17 @@ var SearchPage = React.createClass({
   componentWillMount: function() {
     EventEmitter.on("SearchExecutingQuery", function() { this.setState({ searching: true }); }.bind(this));
     EventEmitter.on("SearchQueryComplete", this.resultsAreIn);
+    EventEmitter.on("ImportStarted", function() { this.setState({ searching: true }); }.bind(this));
+    EventEmitter.on("ImportFinished", this.requery);
+    SearchActions.executeQuery(this.props.searchUrl, {
+      searchTerm: this.props.searchTerm,
+      sortField: this.props.defaultSortField,
+      sortDirection: this.props.defaultSortDirection,
+      rowLimit: this.props.rows
+    });
+  },
+
+  requery: function() {
     SearchActions.executeQuery(this.props.searchUrl, {
       searchTerm: this.props.searchTerm,
       sortField: this.props.defaultSortField,
@@ -96,7 +107,7 @@ var SearchPage = React.createClass({
   getThumbnail: function(thumbnailUrl) {
     // This regex will always match as an array of 4
     var reg = new RegExp( '^(.*)(\/.*)([\/].*$)', 'i' );
-    
+
     var string = reg.exec(thumbnailUrl);
     if(string && string.length == 4) {
       thumbnailUrl = string[1] + "/small" + string[3];

--- a/app/assets/javascripts/mixins/GooglePickerMixin.jsx
+++ b/app/assets/javascripts/mixins/GooglePickerMixin.jsx
@@ -14,7 +14,10 @@ var GooglePickerMixin = {
 
   pickerApiLoaded: false,
 
-  loadPicker: function() {
+  filePickedCallback: null,
+
+  loadPicker: function(callback) {
+    filePickedCallback = callback;
     gapi.load("auth", {"callback": this.onAuthApiLoad});
     gapi.load("picker", {"callback": this.onPickerApiLoad});
   },
@@ -74,7 +77,7 @@ var GooglePickerMixin = {
         },
         method: "POST",
         success: (function(data, textStatus) {
-          window.location.href = data.auth_uri;
+          filePickedCallback(data.auth_uri);
         }),
         error: (function(xhr) {
           alert(xhr);

--- a/app/assets/stylesheets/ui-customizations.css.scss
+++ b/app/assets/stylesheets/ui-customizations.css.scss
@@ -67,7 +67,7 @@ filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#d9a500', end
 	background:image_url('logo.w.svg') no-repeat;
 	background-size: contain;
 	margin:10px 10px 10px 10px;
-	z-index: 10;
+  z-index: 10;
 	position: relative;
 }
 

--- a/app/assets/stylesheets/ui-customizations.css.scss
+++ b/app/assets/stylesheets/ui-customizations.css.scss
@@ -67,7 +67,7 @@ filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#d9a500', end
 	background:image_url('logo.w.svg') no-repeat;
 	background-size: contain;
 	margin:10px 10px 10px 10px;
-	z-index: 20;
+	z-index: 10;
 	position: relative;
 }
 

--- a/app/controllers/import_controller.rb
+++ b/app/controllers/import_controller.rb
@@ -24,7 +24,7 @@ class ImportController < ApplicationController
 
     @results = GoogleCreateItems.call(auth_code: params[:code],
                                       callback_uri: import_google_sheet_callback_collections_url,
-                                      collection_id: state_hash[:collection_id],
+                                      collection: @collection,
                                       file: state_hash[:file],
                                       sheet: state_hash[:sheet])
   end

--- a/app/controllers/v1/import_controller.rb
+++ b/app/controllers/v1/import_controller.rb
@@ -1,0 +1,10 @@
+module V1
+  # Version 1 API
+  class ImportController < APIController
+    def csv
+      collection = CollectionQuery.new.any_find(params[:collection_id])
+      result = CsvCreateItems.call(collection: collection, file: params[:file])
+      render json: result
+    end
+  end
+end

--- a/app/controllers/v1/import_controller.rb
+++ b/app/controllers/v1/import_controller.rb
@@ -3,6 +3,8 @@ module V1
   class ImportController < APIController
     def csv
       collection = CollectionQuery.new.any_find(params[:collection_id])
+      return if rendered_forbidden?(collection)
+
       result = CsvCreateItems.call(collection: collection, file: params[:csv_file])
       render json: result
     end

--- a/app/controllers/v1/import_controller.rb
+++ b/app/controllers/v1/import_controller.rb
@@ -3,7 +3,7 @@ module V1
   class ImportController < APIController
     def csv
       collection = CollectionQuery.new.any_find(params[:collection_id])
-      result = CsvCreateItems.call(collection: collection, file: params[:file])
+      result = CsvCreateItems.call(collection: collection, file: params[:csv_file])
       render json: result
     end
   end

--- a/app/models/waggle/adapters/solr/session.rb
+++ b/app/models/waggle/adapters/solr/session.rb
@@ -13,7 +13,7 @@ module Waggle
         end
 
         def index(*objects)
-          connection.add(*objects_as_solr(objects))
+          connection.add(objects_as_solr(*objects))
         end
 
         def index!(*objects)
@@ -26,7 +26,7 @@ module Waggle
         end
 
         def remove(*objects)
-          connection.delete_by_id(*object_solr_ids(objects))
+          connection.delete_by_id(object_solr_ids(*objects))
         end
 
         def remove!(*objects)
@@ -36,15 +36,15 @@ module Waggle
 
         private
 
-        def objects_as_solr(objects)
-          solr_objects(objects).map(&:as_solr)
+        def objects_as_solr(*objects)
+          solr_objects(*objects).map(&:as_solr)
         end
 
-        def object_solr_ids(objects)
-          solr_objects(objects).map(&:id)
+        def object_solr_ids(*objects)
+          solr_objects(*objects).map(&:id)
         end
 
-        def solr_objects(objects)
+        def solr_objects(*objects)
           objects.map { |waggle_item| Waggle::Adapters::Solr::Index::Item.new(waggle_item: waggle_item) }
         end
 

--- a/app/services/create_items.rb
+++ b/app/services/create_items.rb
@@ -2,8 +2,8 @@
 # Allows injecting a block to change the item attributes before
 # attempting to create the item.
 class CreateItems
-  def self.call(collection_id:, find_by:, items_hash:, counts:, errors:)
-    new.create_or_update!(collection_id: collection_id,
+  def self.call(collection:, find_by:, items_hash:, counts:, errors:)
+    new.create_or_update!(collection: collection,
                           find_by: find_by,
                           items_hash: items_hash,
                           counts: counts,
@@ -24,13 +24,13 @@ class CreateItems
   #   valid_count    - Count of how many items passed validation
   #   error_count    - Count of how many items failed validation
   #   total_count    - Total number of items processed
-  def create_or_update!(collection_id:, find_by:, items_hash:, counts:, errors:)
+  def create_or_update!(collection:, find_by:, items_hash:, counts:, errors:)
     ActiveRecord::Base.transaction do
       items_hash.each.with_index do |item_props, index|
         rewrite_errors = []
         item_props = yield(item_props, rewrite_errors).symbolize_keys if block_given?
-        item_creator = FindOrCreateItem.call(props: { collection_id: collection_id, **item_props }, find_by: find_by)
-        saved = rewrite_errors.present? ? false : item_creator.save
+        item_creator = FindOrCreateItem.call(props: { collection_id: collection.id, **item_props }, find_by: find_by)
+        saved = rewrite_errors.present? ? false : item_creator.save(index: false)
         add_to_errors(
           errors: errors,
           index: index,
@@ -40,6 +40,7 @@ class CreateItems
         update_counts(save_successful: saved, item: item_creator, counts: counts)
       end
     end
+    Index::Collection.index!(collection)
   end
 
   private

--- a/app/services/csv_create_items.rb
+++ b/app/services/csv_create_items.rb
@@ -36,7 +36,7 @@ class CsvCreateItems
         RewriteItemMetadata.call(item_hash: item_props, errors: rewrite_errors, configuration: collection_configuration)
       end
     else
-      errors = "File must be UTF-8. If saving from Excel, choose 'Windows Comma Separated (.csv)' format."
+      errors = "File must be UTF-8."
     end
 
     {

--- a/app/services/csv_create_items.rb
+++ b/app/services/csv_create_items.rb
@@ -1,0 +1,62 @@
+require 'csv'
+# Performs batch creation of items from a csv file
+# Assumes you have a valid auth token to access the doc
+class CsvCreateItems
+  attr_reader :configuration, :collection
+
+  # Simplified call to create_from_worksheet!
+  def self.call(collection:, file:)
+    new(collection: collection, file: file).create!
+  end
+
+  def initialize(collection:, file:)
+    @collection = collection
+    @file = file
+  end
+
+  # Adds new items to a collection for each row in a google spread sheet
+  def create!
+    counts = {
+      total_count: 0,
+      valid_count: 0,
+      new_count: 0,
+      error_count: 0,
+      changed_count: 0,
+      unchanged_count: 0
+    }
+    errors = {}
+    file = File.read(@file.path)
+    if file.valid_encoding?
+      items = csv_to_hash(file: file)
+      CreateItems.call(collection: @collection,
+                       find_by: [:collection_id, :user_defined_id],
+                       items_hash: items,
+                       counts: counts,
+                       errors: errors) do |item_props, rewrite_errors|
+        RewriteItemMetadata.call(item_hash: item_props, errors: rewrite_errors, configuration: collection_configuration)
+      end
+    else
+      errors = "File must be UTF-8. If saving from Excel, choose 'Windows Comma Separated (.csv)' format."
+    end
+
+    {
+      summary: counts,
+      errors: errors
+    }
+  end
+
+  def csv_to_hash(file:)
+    results = []
+    csv = CSV.parse(file, headers: true)
+    csv.each do |row|
+      results << row.to_hash
+    end
+    results
+  end
+
+  private
+
+  def collection_configuration
+    @configuration ||= CollectionConfigurationQuery.new(@collection).find
+  end
+end

--- a/app/services/find_or_create_item.rb
+++ b/app/services/find_or_create_item.rb
@@ -31,8 +31,8 @@ class FindOrCreateItem
     is_valid
   end
 
-  def save
-    if is_valid && SaveItem.call(item, {})
+  def save(index: true)
+    if is_valid && SaveItem.call(item, {}, index: index)
       true
     else
       false

--- a/app/services/google_create_items.rb
+++ b/app/services/google_create_items.rb
@@ -4,9 +4,9 @@ class GoogleCreateItems
   attr_reader :session
 
   # Simplified call to create_from_worksheet!
-  def self.call(auth_code:, callback_uri:, collection_id:, file:, sheet:)
+  def self.call(auth_code:, callback_uri:, collection:, file:, sheet:)
     instance = new(auth_code: auth_code, callback_uri: callback_uri)
-    instance.create_from_worksheet!(collection_id: collection_id, file: file, sheet: sheet)
+    instance.create_from_worksheet!(collection: collection, file: file, sheet: sheet)
   end
 
   def initialize(auth_code:, callback_uri:)
@@ -15,7 +15,7 @@ class GoogleCreateItems
   end
 
   # Adds new items to a collection for each row in a google spread sheet
-  def create_from_worksheet!(collection_id:, file:, sheet:)
+  def create_from_worksheet!(collection:, file:, sheet:)
     counts = {
       total_count: 0,
       valid_count: 0,
@@ -30,12 +30,12 @@ class GoogleCreateItems
     if worksheet.present?
       items = session.worksheet_to_hash(worksheet: worksheet)
 
-      CreateItems.call(collection_id: collection_id,
+      CreateItems.call(collection: collection,
                        find_by: [:collection_id, :user_defined_id],
                        items_hash: items,
                        counts: counts,
                        errors: errors) do |item_props, rewrite_errors|
-        RewriteItemMetadata.call(item_hash: item_props, errors: rewrite_errors, configuration: configuration(collection_id))
+        RewriteItemMetadata.call(item_hash: item_props, errors: rewrite_errors, configuration: configuration(collection))
       end
     end
     {
@@ -46,7 +46,7 @@ class GoogleCreateItems
 
   private
 
-  def configuration(collection_id)
-    @configuration ||= CollectionConfigurationQuery.new(CollectionQuery.new.find(collection_id)).find
+  def configuration(collection)
+    @configuration ||= CollectionConfigurationQuery.new(collection).find
   end
 end

--- a/app/services/index/collection.rb
+++ b/app/services/index/collection.rb
@@ -1,0 +1,30 @@
+module Index
+  module Collection
+    def self.index!(collection)
+      Waggle.set_configuration(get_configuration(collection))
+      waggle_items = collection.items.map { |i| item_to_waggle_item(i) }
+
+      Waggle.index!(*waggle_items)
+    rescue StandardError => exception
+      notify_error(exception: exception, collection: collection, action: "index!")
+    end
+
+    def self.item_to_waggle_item(item)
+      Waggle::Item.from_item(item)
+    end
+
+    private_class_method :item_to_waggle_item
+
+    def self.notify_error(exception:, collection:, action:)
+      NotifyError.call(exception: exception, parameters: { collection: collection }, component: to_s, action: action)
+      if Rails.env.development?
+        raise exception
+      end
+    end
+    private_class_method :notify_error
+
+    def self.get_configuration(collection)
+      CollectionConfigurationQuery.new(collection).find
+    end
+  end
+end

--- a/app/services/index/collection.rb
+++ b/app/services/index/collection.rb
@@ -1,8 +1,9 @@
 module Index
   module Collection
-    def self.index!(collection)
+    def self.index!(collection:, items: collection.items)
+      return if items.count == 0 # purely for optimization to prevent unnecessary sql/http calls to solr
       Waggle.set_configuration(get_configuration(collection))
-      waggle_items = collection.items.map { |i| item_to_waggle_item(i) }
+      waggle_items = items.map { |i| item_to_waggle_item(i) }
 
       Waggle.index!(*waggle_items)
     rescue StandardError => exception

--- a/app/services/index/collection.rb
+++ b/app/services/index/collection.rb
@@ -1,7 +1,7 @@
 module Index
   module Collection
     def self.index!(collection:, items: collection.items)
-      return if items.count == 0 # purely for optimization to prevent unnecessary sql/http calls to solr
+      return if items.count.zero? # purely for optimization to prevent unnecessary sql/http calls to solr
       set_configuration(collection: collection)
       waggle_items = items.map { |i| Waggle::Item.from_item(i) }
       Waggle.index!(*waggle_items)
@@ -9,16 +9,17 @@ module Index
       notify_error(exception: exception, collection: collection, action: "index!")
     end
 
-    private
-
     def self.notify_error(exception:, collection:, action:)
       NotifyError.call(exception: exception, parameters: { collection: collection }, component: to_s, action: action)
       fail exception if Rails.env.development?
     end
+    private_class_method :notify_error
 
     def self.set_configuration(collection: collection)
       config = CollectionConfigurationQuery.new(collection).find
       Waggle.set_configuration(config)
     end
+    private_class_method :set_configuration
+
   end
 end

--- a/app/services/index/collection.rb
+++ b/app/services/index/collection.rb
@@ -15,7 +15,7 @@ module Index
     end
     private_class_method :notify_error
 
-    def self.set_configuration(collection: collection)
+    def self.set_configuration(collection:)
       config = CollectionConfigurationQuery.new(collection).find
       Waggle.set_configuration(config)
     end

--- a/app/services/index/collection.rb
+++ b/app/services/index/collection.rb
@@ -13,9 +13,7 @@ module Index
 
     def self.notify_error(exception:, collection:, action:)
       NotifyError.call(exception: exception, parameters: { collection: collection }, component: to_s, action: action)
-      if Rails.env.development?
-        raise exception
-      end
+      fail exception if Rails.env.development?
     end
 
     def self.set_configuration(collection: collection)

--- a/app/services/save_item.rb
+++ b/app/services/save_item.rb
@@ -1,8 +1,8 @@
 class SaveItem
   attr_reader :params, :item, :uploaded_image
 
-  def self.call(item, params)
-    new(item, params).save
+  def self.call(item, params, index: true)
+    new(item, params).save(index: index)
   end
 
   def initialize(item, params)
@@ -10,7 +10,7 @@ class SaveItem
     @item = item
   end
 
-  def save
+  def save(index: true)
     fix_params
     item.attributes = params
     check_user_defined_id
@@ -18,7 +18,7 @@ class SaveItem
     pre_process_name
 
     if item.save && process_uploaded_image
-      index_item
+      index_item if index
       fix_image_references
       item
     else

--- a/app/services/save_item.rb
+++ b/app/services/save_item.rb
@@ -11,11 +11,7 @@ class SaveItem
   end
 
   def save(index: true)
-    fix_params
-    item.attributes = params
-    check_user_defined_id
-    check_unique_id
-    pre_process_name
+    pre_process
 
     if item.save && process_uploaded_image
       index_item if index
@@ -27,6 +23,14 @@ class SaveItem
   end
 
   private
+
+  def pre_process
+    fix_params
+    item.attributes = params
+    check_user_defined_id
+    check_unique_id
+    pre_process_name
+  end
 
   def fix_params
     @params = params.with_indifferent_access

--- a/app/views/items/_action_bar.html.erb
+++ b/app/views/items/_action_bar.html.erb
@@ -22,6 +22,11 @@
       }) %>
     </div>
     <div style="float: left">
+      <%= react_component("CsvImportButton", {
+        postUri: v1_collection_import_csv_path(@collection.unique_id) })
+      %>
+    </div>
+    <div style="float: left">
       <%= react_component("GoogleExportButton", {
         developerKey: Rails.application.secrets.google["developer_key"],
         clientId: Rails.application.secrets.google["client_id"],

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,6 +79,7 @@ Rails.application.routes.draw do
       get :metadata_configuration, defaults: { format: :json }
       get :site_path, defaults: { format: :json }
       put :site_path, to: "collections#site_path_update", defaults: { format: :json }
+      post :import_csv, to: "import#csv"
       resources :search, only: [:index], defaults: { format: :json }
       resources :items, only: [:index, :create], defaults: { format: :json }
       resources :showcases, only: [:index], defaults: { format: :json }

--- a/lib/tasks/search.rake
+++ b/lib/tasks/search.rake
@@ -1,7 +1,9 @@
 namespace :search do
   desc "reindex all content"
   task index_all: :environment do
-    Index::Item.index_all!(Item.all)
+    Collection.all.each do |collection|
+      Index::Collection.index!(collection: collection)
+    end
   end
 
   desc "remove all content"

--- a/spec/controllers/v1/import_controller_spec.rb
+++ b/spec/controllers/v1/import_controller_spec.rb
@@ -4,7 +4,7 @@ require "cache_spec_helper"
 RSpec.describe V1::ImportController, type: :controller do
   let(:collection) { instance_double(Collection, id: "1", updated_at: nil, items: nil) }
   let(:file) { "file" }
-  subject { post :csv, collection_id: collection.id, file: file }
+  subject { post :csv, collection_id: collection.id, csv_file: file }
 
   before(:each) do
     allow_any_instance_of(CollectionQuery).to receive(:any_find).and_return(collection)

--- a/spec/controllers/v1/import_controller_spec.rb
+++ b/spec/controllers/v1/import_controller_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+require "cache_spec_helper"
+
+RSpec.describe V1::ImportController, type: :controller do
+  let(:collection) { instance_double(Collection, id: "1", updated_at: nil, items: nil) }
+  let(:file) { "file" }
+  subject { post :csv, collection_id: collection.id, file: file }
+
+  before(:each) do
+    allow_any_instance_of(CollectionQuery).to receive(:any_find).and_return(collection)
+  end
+
+  it "calls CsvCreateItems with the posted file" do
+    expect(CsvCreateItems).to receive(:call).with(collection: collection, file: file)
+    subject
+  end
+
+  it "renders the result from CsvCreateItems as json" do
+    allow(CsvCreateItems).to receive(:call).and_return("json response")
+    subject
+    expect(response.body).to eq("json response")
+  end
+end

--- a/spec/controllers/v1/import_controller_spec.rb
+++ b/spec/controllers/v1/import_controller_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe V1::ImportController, type: :controller do
   subject { post :csv, collection_id: collection.id, csv_file: file }
 
   before(:each) do
+    sign_in_admin
     allow_any_instance_of(CollectionQuery).to receive(:any_find).and_return(collection)
   end
 
@@ -19,5 +20,11 @@ RSpec.describe V1::ImportController, type: :controller do
     allow(CsvCreateItems).to receive(:call).and_return("json response")
     subject
     expect(response.body).to eq("json response")
+  end
+
+  it "checks the editor permissions" do
+    allow(CsvCreateItems).to receive(:call).and_return("json response")
+    expect_any_instance_of(described_class).to receive(:rendered_forbidden?).with(collection)
+    subject
   end
 end

--- a/spec/models/waggle/adapters/solr/session_spec.rb
+++ b/spec/models/waggle/adapters/solr/session_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Waggle::Adapters::Solr::Session do
           expect(Waggle::Adapters::Solr::Index::Item).to receive(:new).with(waggle_item: waggle_item).and_call_original
         end
         allow_any_instance_of(Waggle::Adapters::Solr::Index::Item).to receive(:as_solr).and_return(test: "test")
-        expect(connection).to receive(:add).with(*[{ test: "test" }, { test: "test" }])
+        expect(connection).to receive(:add).with([{ test: "test" }, { test: "test" }])
         subject
       end
     end
@@ -67,7 +67,7 @@ RSpec.describe Waggle::Adapters::Solr::Session do
         items.each do |waggle_item|
           expect(Waggle::Adapters::Solr::Index::Item).to receive(:new).with(waggle_item: waggle_item).and_call_original
         end
-        expect(connection).to receive(:delete_by_id).with("item-1 Item", "item-2 Item")
+        expect(connection).to receive(:delete_by_id).with(["item-1 Item", "item-2 Item"])
         subject
       end
     end

--- a/spec/services/create_items_spec.rb
+++ b/spec/services/create_items_spec.rb
@@ -90,10 +90,22 @@ RSpec.describe CreateItems, helpers: :item_meta_helpers do
       subject
     end
 
-    it "uses FindOrCreateItem service to save all items" do
+    it "uses FindOrCreateItem service to save all items without indexing them" do
       allow(item).to receive(:assign_attributes).and_return(true)
       allow(CreateUniqueId).to receive(:call).and_return(true)
-      expect(creator).to receive(:save).exactly(3).and_return true
+      expect(creator).to receive(:save).with(index: false).exactly(3).and_return true
+      subject
+    end
+
+    it "indexes changed items" do
+      expect(Index::Collection).to receive(:index!).with(collection: collection, items: [item, item, item])
+      subject
+    end
+
+    it "does not index unchanged items" do
+      allow(creator).to receive(:changed?).and_return(false)
+      allow(creator).to receive(:new_record?).and_return(false)
+      expect(Index::Collection).not_to receive(:index!).with(collection: collection, items: [item, item, item])
       subject
     end
 

--- a/spec/services/csv_create_items_spec.rb
+++ b/spec/services/csv_create_items_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe CsvCreateItems, helpers: :item_meta_helpers do
       item_meta_hash_remapped(item_id: 3),
     ]
   end
-  let(:file) { instance_double(ActionDispatch::Http::UploadedFile, path: "file path")}
+  let(:file) { instance_double(ActionDispatch::Http::UploadedFile, path: "file path") }
   let(:file_contents) { instance_double(String, valid_encoding?: true) }
   let(:errors) { instance_double(ActiveModel::Errors, full_messages: []) }
   let(:metadata_fields) { instance_double(Metadata::Fields, errors: errors) }
@@ -39,7 +39,7 @@ RSpec.describe CsvCreateItems, helpers: :item_meta_helpers do
   let(:collection) { instance_double(Collection, id: 1) }
   let(:subject) { described_class.call(param_hash) }
 
-  before (:each) do
+  before(:each) do
     allow(File).to receive(:read).and_return(file_contents)
     allow(FindOrCreateItem).to receive(:new).and_return(item_creator)
     allow(SaveItem).to receive(:call).and_return true

--- a/spec/services/csv_create_items_spec.rb
+++ b/spec/services/csv_create_items_spec.rb
@@ -1,0 +1,100 @@
+require "rails_helper"
+require "support/item_meta_helpers"
+
+RSpec.configure do |c|
+  c.include ItemMetaHelpers, helpers: :item_meta_helpers
+end
+
+RSpec.describe CsvCreateItems, helpers: :item_meta_helpers do
+  let(:items) do
+    [
+      item_meta_hash(item_id: 1),
+      item_meta_hash(item_id: 2),
+      item_meta_hash(item_id: 3),
+    ]
+  end
+  let(:remapped_items) do
+    [
+      item_meta_hash_remapped(item_id: 1),
+      item_meta_hash_remapped(item_id: 2),
+      item_meta_hash_remapped(item_id: 3),
+    ]
+  end
+  let(:file) { instance_double(ActionDispatch::Http::UploadedFile, path: "file path")}
+  let(:file_contents) { instance_double(String, valid_encoding?: true) }
+  let(:errors) { instance_double(ActiveModel::Errors, full_messages: []) }
+  let(:metadata_fields) { instance_double(Metadata::Fields, errors: errors) }
+  let(:item) { instance_double(Item, valid?: true, changed?: false, new_record?: false, errors: errors, item_metadata: metadata_fields, validate: true) }
+  let(:item_creator) { instance_double(FindOrCreateItem, using: item, save: true, new_record?: true, changed?: false, item: item) }
+  let(:param_hash) { { collection: collection, file: file } }
+  let(:configuration) do
+    double(
+      Metadata::Configuration,
+      field?: true,
+      field_names: [],
+      label?: "label",
+      label: double(name: :name, multiple: true, type: :string)
+    )
+  end
+  let(:collection) { instance_double(Collection, id: 1) }
+  let(:subject) { described_class.call(param_hash) }
+
+  before (:each) do
+    allow(File).to receive(:read).and_return(file_contents)
+    allow(FindOrCreateItem).to receive(:new).and_return(item_creator)
+    allow(SaveItem).to receive(:call).and_return true
+    allow(Index::Collection).to receive(:index!).and_return true
+    allow_any_instance_of(described_class).to receive(:collection_configuration).and_return(configuration)
+  end
+
+  it "throws an exception if a label is not found" do
+    allow(CSV).to receive(:parse).and_return([{ item: "item" }])
+    items[0][:InvalidFieldName] = "invalid value"
+    expect(subject).to include(:errors)
+  end
+
+  it "calls CreateItems with the hash read from the csv" do
+    allow(CSV).to receive(:parse).and_return([{ item: "item" }])
+    expect(CreateItems).to receive(:call).with(hash_including(items_hash: [{ item: "item" }]))
+    subject
+  end
+
+  it "renders an error when the file is not UTF-8 encoded" do
+    allow(file_contents).to receive(:valid_encoding?).and_return(false)
+    expect(subject).to include(:errors)
+  end
+
+  context "when csv has items" do
+    it "injects a RewriteItemMetadata call to properly map user data to valid item data" do
+      allow(CSV).to receive(:parse).and_return(items)
+      expect(RewriteItemMetadata).to receive(:call).with(item_hash: items[0], errors: [], configuration: configuration).and_return({})
+      expect(RewriteItemMetadata).to receive(:call).with(item_hash: items[1], errors: [], configuration: configuration).and_return({})
+      expect(RewriteItemMetadata).to receive(:call).with(item_hash: items[2], errors: [], configuration: configuration).and_return({})
+      subject
+    end
+
+    it "returns a hash with summary" do
+      allow(CSV).to receive(:parse).and_return(items)
+      expected = { summary: { total_count: 3, valid_count: 3, new_count: 3, error_count: 0, changed_count: 0, unchanged_count: 0 } }
+      expect(subject).to include(expected)
+    end
+
+    it "returns a hash with errors" do
+      allow(CSV).to receive(:parse).and_return(items)
+      expect(subject).to include(:errors)
+    end
+  end
+
+  context "worksheet has no items" do
+    it "returns a hash with summary" do
+      allow(CSV).to receive(:parse).and_return([])
+      expected = { summary: { total_count: 0, valid_count: 0, new_count: 0, error_count: 0, changed_count: 0, unchanged_count: 0 } }
+      expect(subject).to include(expected)
+    end
+
+    it "returns a hash with errors" do
+      allow(CSV).to receive(:parse).and_return([])
+      expect(subject).to include(errors: [])
+    end
+  end
+end

--- a/spec/services/find_or_create_item_spec.rb
+++ b/spec/services/find_or_create_item_spec.rb
@@ -96,7 +96,7 @@ describe FindOrCreateItem do
 
   context "when saving the created item" do
     it "uses SaveItem to save the item" do
-      expect(SaveItem).to receive(:call).with(item, {})
+      expect(SaveItem).to receive(:call).with(item, {}, index: true)
       subject.find_or_create_by(criteria: {})
       subject.save
     end

--- a/spec/services/google_create_items_spec.rb
+++ b/spec/services/google_create_items_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe GoogleCreateItems, helpers: :item_meta_helpers do
   let(:errors) { instance_double(ActiveModel::Errors, full_messages: []) }
   let(:metadata_fields) { instance_double(Metadata::Fields, errors: errors) }
   let(:item) { instance_double(Item, valid?: true, changed?: false, new_record?: false, errors: errors, item_metadata: metadata_fields, validate: true) }
-  let(:item_creator) { instance_double(FindOrCreateItem, using: item, save: true, new_record?: true, item: item) }
+  let(:item_creator) { instance_double(FindOrCreateItem, using: item, save: true, new_record?: true, changed?: false, item: item) }
   let(:worksheet) { instance_double(GoogleDrive::Worksheet) }
   let(:param_hash) { { auth_code: "auth", callback_uri: "callback", collection: collection, file: "file", sheet: "sheet" } }
   let(:configuration) do

--- a/spec/services/google_create_items_spec.rb
+++ b/spec/services/google_create_items_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe GoogleCreateItems, helpers: :item_meta_helpers do
   let(:item) { instance_double(Item, valid?: true, changed?: false, new_record?: false, errors: errors, item_metadata: metadata_fields, validate: true) }
   let(:item_creator) { instance_double(FindOrCreateItem, using: item, save: true, new_record?: true, item: item) }
   let(:worksheet) { instance_double(GoogleDrive::Worksheet) }
-  let(:param_hash) { { auth_code: "auth", callback_uri: "callback", collection_id: 1, file: "file", sheet: "sheet" } }
+  let(:param_hash) { { auth_code: "auth", callback_uri: "callback", collection: collection, file: "file", sheet: "sheet" } }
   let(:configuration) do
     double(
       Metadata::Configuration,
@@ -35,7 +35,7 @@ RSpec.describe GoogleCreateItems, helpers: :item_meta_helpers do
       label: double(name: :name, multiple: true, type: :string)
     )
   end
-
+  let(:collection) { instance_double(Collection, id: 1) }
   let(:subject) { described_class.call(param_hash) }
 
   before (:each) do
@@ -44,6 +44,7 @@ RSpec.describe GoogleCreateItems, helpers: :item_meta_helpers do
     allow_any_instance_of(GoogleSession).to receive(:worksheet_to_hash).and_return(items)
     allow(FindOrCreateItem).to receive(:new).and_return(item_creator)
     allow(SaveItem).to receive(:call).and_return true
+    allow(Index::Collection).to receive(:index!).and_return true
     allow_any_instance_of(described_class).to receive(:configuration).and_return(configuration)
   end
 
@@ -66,7 +67,7 @@ RSpec.describe GoogleCreateItems, helpers: :item_meta_helpers do
     allow_any_instance_of(GoogleSession).to receive(:worksheet_to_hash).and_return([{ item: "item" }])
     creator = GoogleCreateItems.new(auth_code: param_hash[:auth_code], callback_uri: param_hash[:callback_uri])
     expect(CreateItems).to receive(:call).with(hash_including(items_hash: [{ item: "item" }]))
-    creator.create_from_worksheet!(collection_id: param_hash[:collection_id], file: param_hash[:file], sheet: param_hash[:sheet])
+    creator.create_from_worksheet!(collection: collection, file: param_hash[:file], sheet: param_hash[:sheet])
   end
 
   context "worksheet has items" do
@@ -76,13 +77,13 @@ RSpec.describe GoogleCreateItems, helpers: :item_meta_helpers do
       expect(RewriteItemMetadata).to receive(:call).with(item_hash: items[0], errors: [], configuration: configuration).and_return({})
       expect(RewriteItemMetadata).to receive(:call).with(item_hash: items[1], errors: [], configuration: configuration).and_return({})
       expect(RewriteItemMetadata).to receive(:call).with(item_hash: items[2], errors: [], configuration: configuration).and_return({})
-      creator.create_from_worksheet!(collection_id: param_hash[:collection_id], file: param_hash[:file], sheet: param_hash[:sheet])
+      creator.create_from_worksheet!(collection: collection, file: param_hash[:file], sheet: param_hash[:sheet])
     end
 
     it "returns a hash with summary" do
       allow_any_instance_of(GoogleSession).to receive(:worksheet_to_hash).and_return(items)
       creator = GoogleCreateItems.new(auth_code: param_hash[:auth_code], callback_uri: param_hash[:callback_uri])
-      results = creator.create_from_worksheet!(collection_id: param_hash[:collection_id], file: param_hash[:file], sheet: param_hash[:sheet])
+      results = creator.create_from_worksheet!(collection: collection, file: param_hash[:file], sheet: param_hash[:sheet])
       expected = { summary: { total_count: 3, valid_count: 3, new_count: 3, error_count: 0, changed_count: 0, unchanged_count: 0 } }
       expect(results).to include(expected)
     end
@@ -90,7 +91,7 @@ RSpec.describe GoogleCreateItems, helpers: :item_meta_helpers do
     it "returns a hash with errors" do
       allow_any_instance_of(GoogleSession).to receive(:worksheet_to_hash).and_return(items)
       creator = GoogleCreateItems.new(auth_code: param_hash[:auth_code], callback_uri: param_hash[:callback_uri])
-      results = creator.create_from_worksheet!(collection_id: param_hash[:collection_id], file: param_hash[:file], sheet: param_hash[:sheet])
+      results = creator.create_from_worksheet!(collection: collection, file: param_hash[:file], sheet: param_hash[:sheet])
       expect(results).to include(:errors)
     end
   end
@@ -99,7 +100,7 @@ RSpec.describe GoogleCreateItems, helpers: :item_meta_helpers do
     it "returns a hash with summary" do
       allow_any_instance_of(GoogleSession).to receive(:worksheet_to_hash).and_return([])
       creator = GoogleCreateItems.new(auth_code: param_hash[:auth_code], callback_uri: param_hash[:callback_uri])
-      results = creator.create_from_worksheet!(collection_id: param_hash[:collection_id], file: param_hash[:file], sheet: param_hash[:sheet])
+      results = creator.create_from_worksheet!(collection: collection, file: param_hash[:file], sheet: param_hash[:sheet])
       expected = { summary: { total_count: 0, valid_count: 0, new_count: 0, error_count: 0, changed_count: 0, unchanged_count: 0 } }
       expect(results).to include(expected)
     end
@@ -107,7 +108,7 @@ RSpec.describe GoogleCreateItems, helpers: :item_meta_helpers do
     it "returns a hash with errors" do
       allow_any_instance_of(GoogleSession).to receive(:worksheet_to_hash).and_return([])
       creator = GoogleCreateItems.new(auth_code: param_hash[:auth_code], callback_uri: param_hash[:callback_uri])
-      results = creator.create_from_worksheet!(collection_id: param_hash[:collection_id], file: param_hash[:file], sheet: param_hash[:sheet])
+      results = creator.create_from_worksheet!(collection: collection, file: param_hash[:file], sheet: param_hash[:sheet])
       expect(results).to include(errors: [])
     end
   end

--- a/spec/services/index/collection_spec.rb
+++ b/spec/services/index/collection_spec.rb
@@ -1,0 +1,42 @@
+RSpec.describe Index::Collection do
+  let(:item) { instance_double(Item) }
+  let(:waggle_item) { instance_double(Waggle::Item) }
+  let(:config) { instance_double(CollectionConfiguration) }
+  let(:collection) { instance_double(Collection, items: [item, item], collection_configuration: config) }
+
+  describe "index!" do
+    subject { described_class.index!(collection: collection) }
+    before do
+      allow(Waggle::Item).to receive(:from_item).and_return(waggle_item)
+      allow_any_instance_of(CollectionConfigurationQuery).to receive(:find).and_return(config)
+    end
+
+    it "calls Waggle.index! with wagglified items for all items in the collection" do
+      expect(Waggle).to receive(:index!).with(waggle_item, waggle_item).and_return("index!")
+      subject
+    end
+
+    it "doesn't call waggle if there are no items" do
+      allow(collection).to receive(:items).and_return([])
+      expect(Waggle).not_to receive(:index!)
+      subject
+    end
+
+    it "uses the configuration of the collection for all items" do
+      allow(Waggle).to receive(:index!).and_return("index!")
+      expect(Waggle).to receive(:set_configuration).with(config).once
+      subject
+    end
+
+    it "rescues from and notifies about errors" do
+      expect(Waggle).to receive(:index!).and_raise(Errno::ECONNREFUSED)
+      expect(NotifyError).to receive(:call).with(
+        exception: kind_of(Errno::ECONNREFUSED),
+        parameters: { collection: collection },
+        component: described_class.to_s,
+        action: "index!"
+      )
+      expect(subject).to be_nil
+    end
+  end
+end

--- a/spec/services/save_item_spec.rb
+++ b/spec/services/save_item_spec.rb
@@ -31,6 +31,12 @@ RSpec.describe SaveItem, type: :model do
     expect(subject).to be false
   end
 
+  it "skips indexing if passed index: false" do
+      allow(item).to receive(:save).and_return(true)
+      expect(Index::Item).not_to receive(:index!)
+      described_class.call(item, params, index: false)
+  end
+
   it "uses the param cleaner before setting item attributes" do
     expect(ParamCleaner).to receive(:call).with(hash: params).ordered
     expect(item).to receive(:attributes=).with("unique_id" => "ad").ordered

--- a/spec/services/save_item_spec.rb
+++ b/spec/services/save_item_spec.rb
@@ -32,9 +32,9 @@ RSpec.describe SaveItem, type: :model do
   end
 
   it "skips indexing if passed index: false" do
-      allow(item).to receive(:save).and_return(true)
-      expect(Index::Item).not_to receive(:index!)
-      described_class.call(item, params, index: false)
+    allow(item).to receive(:save).and_return(true)
+    expect(Index::Item).not_to receive(:index!)
+    described_class.call(item, params, index: false)
   end
 
   it "uses the param cleaner before setting item attributes" do


### PR DESCRIPTION
- Adds support for importing metadata directly from a CSV file. The file must be UTF-8.
- Changes indexing to batch items per collection. This amounts to a 9x speedup on importing large collections. This impacts this new csv import, the existing google import, and the rake task for reindexing all collections. 