### PR TITLE
Bugfix: Video thumbnail not showing correctly on Beehive pprd

### DIFF
--- a/app/models/waggle/adapters/solr/index/item.rb
+++ b/app/models/waggle/adapters/solr/index/item.rb
@@ -11,7 +11,7 @@ module Waggle
           end
 
           def id
-            "#{waggle_item.id} #{waggle_item.type}"
+            "#{waggle_item.collection_id} #{waggle_item.id}"
           end
 
           def metadata

--- a/spec/models/waggle/adapters/solr/index/item_spec.rb
+++ b/spec/models/waggle/adapters/solr/index/item_spec.rb
@@ -27,8 +27,8 @@ RSpec.describe Waggle::Adapters::Solr::Index::Item do
   end
 
   describe "id" do
-    it "is the id plus type" do
-      expect(subject.id).to eq("#{data.fetch('id')} ImageObject")
+    it "is the id plus collection id" do
+      expect(subject.id).to eq("animals #{data.fetch('id')}")
     end
   end
 
@@ -42,7 +42,7 @@ RSpec.describe Waggle::Adapters::Solr::Index::Item do
         creator_facet: ["Bob"],
         name_sort: "pig-in-mud",
         creator_sort: "Bob",
-        id: "pig-in-mud ImageObject",
+        id: "animals pig-in-mud",
         at_id_s: "http://localhost:3017/v1/items/pig-in-mud",
         unique_id_s: "pig-in-mud",
         collection_id_s: "animals",

--- a/spec/models/waggle/adapters/solr/session_spec.rb
+++ b/spec/models/waggle/adapters/solr/session_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Waggle::Adapters::Solr::Session do
   end
 
   context "indexing" do
-    let(:items) { [instance_double(Waggle::Item, id: "item-1", type: "Item"), instance_double(Waggle::Item, id: "item-2", type: "Item")] }
+    let(:items) { [instance_double(Waggle::Item, id: "item-1", type: "Item", collection_id: "collection-1"), instance_double(Waggle::Item, id: "item-2", type: "Item", collection_id: "collection-2")] }
     let(:connection) { instance_double(RSolr::Client) }
 
     before do
@@ -67,7 +67,7 @@ RSpec.describe Waggle::Adapters::Solr::Session do
         items.each do |waggle_item|
           expect(Waggle::Adapters::Solr::Index::Item).to receive(:new).with(waggle_item: waggle_item).and_call_original
         end
-        expect(connection).to receive(:delete_by_id).with(["item-1 Item", "item-2 Item"])
+        expect(connection).to receive(:delete_by_id).with(["collection-1 item-1", "collection-2 item-2"])
         subject
       end
     end


### PR DESCRIPTION
The problem was duplication of items in the index, which caused react to flatten items in the array due to duplicate keys. We were using a combination of item.unique_id and item.type to uniquely identify the object to solr. We now have items with different types (ex: MetadataOnlyObject, VideoObject, etc), so this no longer works. Additionally, item.unique_id is only guaranteed to be unique within a collection. Changed this to use the collection.unique_id + item.unique_id when identifying the object in solr. This will mean we need to reindex after a deploy.