### PR TITLE
Fix showcase and page quick delete buttons

### DIFF
--- a/app/decorators/item_decorator.rb
+++ b/app/decorators/item_decorator.rb
@@ -54,7 +54,7 @@ class ItemDecorator < Draper::Decorator
       data: meta_data,
       embedBaseUrl: CreateBeehiveURL.call(object.collection),
       previewUrl: CreateBeehiveURL.call(object),
-      canDelete: ItemQuery.can_delete_item?(object)
+      canDelete: CanDelete.item?(object)
     )
   end
 

--- a/app/policy/can_delete.rb
+++ b/app/policy/can_delete.rb
@@ -1,0 +1,14 @@
+# Some debate on if this should be 1 or 3 classes. If we start adding things here, break it apart (or talk about it)
+class CanDelete
+  def self.page?(page)
+    !SiteObjectsQuery.new.exists?(collection_object: page)
+  end
+
+  def self.item?(item)
+    !item.showcases.any? && !item.pages.any? && !item.children.any?
+  end
+
+  def self.showcase?(showcase)
+    !SiteObjectsQuery.new.exists?(collection_object: showcase)
+  end
+end

--- a/app/queries/item_query.rb
+++ b/app/queries/item_query.rb
@@ -27,11 +27,7 @@ class ItemQuery
     relation.find_by!(unique_id: id)
   end
 
-  def self.can_delete_item?(item)
-    !item.showcases.any? && !item.pages.any? && !item.children.any?
-  end
-
   def can_delete?
-    ItemQuery.can_delete_item?(relation)
+    CanDelete.item?(relation)
   end
 end

--- a/app/queries/page_query.rb
+++ b/app/queries/page_query.rb
@@ -23,11 +23,7 @@ class PageQuery
     relation.find_by!(unique_id: id)
   end
 
-  def self.can_delete_page?(page)
-    !SiteObjectsQuery.new.exists?(collection_object: page)
-  end
-
   def can_delete?
-    PageQuery.can_delete_page?(relation)
+    CanDelete.page?(relation)
   end
 end

--- a/app/queries/page_query.rb
+++ b/app/queries/page_query.rb
@@ -23,7 +23,11 @@ class PageQuery
     relation.find_by!(unique_id: id)
   end
 
+  def self.can_delete_page?(page)
+    !SiteObjectsQuery.new.exists?(collection_object: page)
+  end
+
   def can_delete?
-    !SiteObjectsQuery.new.exists?(collection_object: relation)
+    PageQuery.can_delete_page?(relation)
   end
 end

--- a/app/queries/showcase_query.rb
+++ b/app/queries/showcase_query.rb
@@ -27,11 +27,7 @@ class ShowcaseQuery
     relation.find_by!(unique_id: id)
   end
 
-  def self.can_delete_showcase?(showcase)
-    !SiteObjectsQuery.new.exists?(collection_object: showcase)
-  end
-
   def can_delete?
-    ShowcaseQuery.can_delete_showcase?(relation)
+    CanDelete.showcase?(relation)
   end
 end

--- a/app/queries/showcase_query.rb
+++ b/app/queries/showcase_query.rb
@@ -27,7 +27,11 @@ class ShowcaseQuery
     relation.find_by!(unique_id: id)
   end
 
+  def self.can_delete_showcase?(showcase)
+    !SiteObjectsQuery.new.exists?(collection_object: showcase)
+  end
+
   def can_delete?
-    !SiteObjectsQuery.new.exists?(collection_object: relation)
+    ShowcaseQuery.can_delete_showcase?(relation)
   end
 end

--- a/app/services/destroy/collection.rb
+++ b/app/services/destroy/collection.rb
@@ -22,13 +22,13 @@ module Destroy
           destroy_collection_user.cascade!(collection_user: child)
         end
         collection.showcases.each do |child|
-          destroy_showcase.cascade!(showcase: child)
+          destroy_showcase.force_cascade!(showcase: child)
         end
         collection.items.each do |child|
           destroy_item.cascade!(item: child)
         end
         collection.pages.each do |child|
-          @destroy_page.cascade!(page: child)
+          @destroy_page.force_cascade!(page: child)
         end
         if collection.collection_configuration
           @destroy_collection_configuration.cascade!(collection_configuration: collection.collection_configuration)

--- a/app/services/destroy/item.rb
+++ b/app/services/destroy/item.rb
@@ -9,7 +9,7 @@ module Destroy
 
     # Destroy the object only
     def destroy!(item:)
-      unless item.pages.any? || item.sections.any?
+      if CanDelete.item?(item)
         item.destroy!
         remove_from_index(item: item)
       end

--- a/app/services/destroy/page.rb
+++ b/app/services/destroy/page.rb
@@ -2,7 +2,7 @@ module Destroy
   class Page
     # Destroy the object only
     def destroy!(page:)
-      if PageQuery.can_delete_page?(page)
+      if CanDelete.page?(page)
         page.destroy!
       end
     end
@@ -10,7 +10,7 @@ module Destroy
     # There are no additional cascades for Pages,
     # so destroys the object only
     def cascade!(page:)
-      if PageQuery.can_delete_page?(page)
+      if CanDelete.page?(page)
         ActiveRecord::Base.transaction do
           DestroyPageItemAssociations.call(page_id: page.id)
           page.destroy!

--- a/app/services/destroy/page.rb
+++ b/app/services/destroy/page.rb
@@ -9,12 +9,16 @@ module Destroy
 
     # There are no additional cascades for Pages,
     # so destroys the object only
-    def cascade!(page:)
+    def force_cascade!(page: page)
+      ActiveRecord::Base.transaction do
+        DestroyPageItemAssociations.call(page_id: page.id)
+        page.destroy!
+      end
+    end
+
+    def cascade!(page: page)
       if CanDelete.page?(page)
-        ActiveRecord::Base.transaction do
-          DestroyPageItemAssociations.call(page_id: page.id)
-          page.destroy!
-        end
+        force_cascade!(page: page)
       end
     end
   end

--- a/app/services/destroy/page.rb
+++ b/app/services/destroy/page.rb
@@ -2,15 +2,19 @@ module Destroy
   class Page
     # Destroy the object only
     def destroy!(page:)
-      page.destroy!
+      if PageQuery.can_delete_page?(page)
+        page.destroy!
+      end
     end
 
     # There are no additional cascades for Pages,
     # so destroys the object only
     def cascade!(page:)
-      ActiveRecord::Base.transaction do
-        DestroyPageItemAssociations.call(page_id: page.id)
-        page.destroy!
+      if PageQuery.can_delete_page?(page)
+        ActiveRecord::Base.transaction do
+          DestroyPageItemAssociations.call(page_id: page.id)
+          page.destroy!
+        end
       end
     end
   end

--- a/app/services/destroy/page.rb
+++ b/app/services/destroy/page.rb
@@ -9,14 +9,14 @@ module Destroy
 
     # There are no additional cascades for Pages,
     # so destroys the object only
-    def force_cascade!(page: page)
+    def force_cascade!(page:)
       ActiveRecord::Base.transaction do
         DestroyPageItemAssociations.call(page_id: page.id)
         page.destroy!
       end
     end
 
-    def cascade!(page: page)
+    def cascade!(page:)
       if CanDelete.page?(page)
         force_cascade!(page: page)
       end

--- a/app/services/destroy/showcase.rb
+++ b/app/services/destroy/showcase.rb
@@ -9,16 +9,20 @@ module Destroy
 
     # Destroy the object only
     def destroy!(showcase:)
-      showcase.destroy!
+      if ShowcaseQuery.can_delete_showcase?(showcase)
+        showcase.destroy!
+      end
     end
 
     # Destroys this object and all associated objects.
     def cascade!(showcase: showcase)
-      ActiveRecord::Base.transaction do
-        showcase.sections.each do |child|
-          @destroy_section.cascade!(section: child)
+      if ShowcaseQuery.can_delete_showcase?(showcase)
+        ActiveRecord::Base.transaction do
+          showcase.sections.each do |child|
+            @destroy_section.cascade!(section: child)
+          end
+          showcase.destroy!
         end
-        showcase.destroy!
       end
     end
   end

--- a/app/services/destroy/showcase.rb
+++ b/app/services/destroy/showcase.rb
@@ -15,14 +15,18 @@ module Destroy
     end
 
     # Destroys this object and all associated objects.
+    def force_cascade!(showcase: showcase)
+      ActiveRecord::Base.transaction do
+        showcase.sections.each do |child|
+          @destroy_section.cascade!(section: child)
+        end
+        showcase.destroy!
+      end
+    end
+
     def cascade!(showcase: showcase)
       if CanDelete.showcase?(showcase)
-        ActiveRecord::Base.transaction do
-          showcase.sections.each do |child|
-            @destroy_section.cascade!(section: child)
-          end
-          showcase.destroy!
-        end
+        force_cascade!(showcase: showcase)
       end
     end
   end

--- a/app/services/destroy/showcase.rb
+++ b/app/services/destroy/showcase.rb
@@ -15,7 +15,7 @@ module Destroy
     end
 
     # Destroys this object and all associated objects.
-    def force_cascade!(showcase: showcase)
+    def force_cascade!(showcase:)
       ActiveRecord::Base.transaction do
         showcase.sections.each do |child|
           @destroy_section.cascade!(section: child)
@@ -24,7 +24,7 @@ module Destroy
       end
     end
 
-    def cascade!(showcase: showcase)
+    def cascade!(showcase:)
       if CanDelete.showcase?(showcase)
         force_cascade!(showcase: showcase)
       end

--- a/app/services/destroy/showcase.rb
+++ b/app/services/destroy/showcase.rb
@@ -9,14 +9,14 @@ module Destroy
 
     # Destroy the object only
     def destroy!(showcase:)
-      if ShowcaseQuery.can_delete_showcase?(showcase)
+      if CanDelete.showcase?(showcase)
         showcase.destroy!
       end
     end
 
     # Destroys this object and all associated objects.
     def cascade!(showcase: showcase)
-      if ShowcaseQuery.can_delete_showcase?(showcase)
+      if CanDelete.showcase?(showcase)
         ActiveRecord::Base.transaction do
           showcase.sections.each do |child|
             @destroy_section.cascade!(section: child)

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -192,6 +192,7 @@ RSpec.describe PagesController, type: :controller do
 
     before(:each) do
       allow(DestroyPageItemAssociations).to receive(:call).and_return(1)
+      allow_any_instance_of(SiteObjectsQuery).to receive(:exists?).and_return(false)
     end
 
     it "on success, redirects" do

--- a/spec/controllers/showcases_controller_spec.rb
+++ b/spec/controllers/showcases_controller_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 require "cache_spec_helper"
 
 RSpec.describe ShowcasesController, type: :controller do
-  let(:showcase) { instance_double(Showcase, id: 1, unique_id: 1, name_line_1: "name_line_1", collection: collection, sections: [], destroy!: true) }
+  let(:showcase) { instance_double(Showcase, id: 1, unique_id: 1, name_line_1: "name_line_1", collection: collection, collection_id: collection.id, sections: [], destroy!: true) }
   let(:collection) { instance_double(Collection, id: 1, name_line_1: "name_line_1", showcases: relation) }
 
   let(:relation) { Showcase.all }
@@ -264,6 +264,10 @@ RSpec.describe ShowcasesController, type: :controller do
 
   describe "DELETE #destroy" do
     subject { delete :destroy, id: showcase.id }
+
+    before (:each) do
+      allow_any_instance_of(SiteObjectsQuery).to receive(:exists?).and_return(false)
+    end
 
     it "on success, redirects, and flashes " do
       subject

--- a/spec/controllers/v1/pages_controller_spec.rb
+++ b/spec/controllers/v1/pages_controller_spec.rb
@@ -83,6 +83,7 @@ RSpec.describe V1::PagesController, type: :controller do
     before(:each) do
       sign_in_admin
       allow(DestroyPageItemAssociations).to receive(:call).and_return(1)
+      allow_any_instance_of(SiteObjectsQuery).to receive(:exists?).and_return(false)
     end
 
     it "is successful" do

--- a/spec/controllers/v1/showcases_controller_spec.rb
+++ b/spec/controllers/v1/showcases_controller_spec.rb
@@ -69,6 +69,7 @@ RSpec.describe V1::ShowcasesController, type: :controller do
 
     before(:each) do
       sign_in_admin
+      allow_any_instance_of(SiteObjectsQuery).to receive(:exists?).and_return(false)
     end
 
     it "is successful" do

--- a/spec/services/destroy/collection_spec.rb
+++ b/spec/services/destroy/collection_spec.rb
@@ -3,8 +3,8 @@ require "rails_helper"
 describe Destroy::Collection do
   describe "#cascade" do
     let(:destroy_item) { instance_double(Destroy::Item, cascade!: nil) }
-    let(:destroy_showcase) { instance_double(Destroy::Showcase, cascade!: nil) }
-    let(:destroy_page) { instance_double(Destroy::Page, cascade!: nil) }
+    let(:destroy_showcase) { instance_double(Destroy::Showcase, force_cascade!: nil) }
+    let(:destroy_page) { instance_double(Destroy::Page, force_cascade!: nil) }
     let(:destroy_collection_user) { instance_double(Destroy::CollectionUser, cascade!: nil) }
     let(:destroy_collection_configuration) { instance_double(Destroy::CollectionConfiguration, cascade!: nil) }
     let(:subject) do
@@ -35,17 +35,17 @@ describe Destroy::Collection do
     end
 
     it "calls DestroyShowcase.cascade on all associated showcases" do
-      expect(destroy_showcase).to receive(:cascade!).with(showcase: showcase).twice
+      expect(destroy_showcase).to receive(:force_cascade!).with(showcase: showcase).twice
       subject.cascade!(collection: collection)
     end
 
     it "calls DestroyPage.cascade on all associated pages" do
-      expect(destroy_page).to receive(:cascade!).with(page: page).twice
+      expect(destroy_page).to receive(:force_cascade!).with(page: page).twice
       subject.cascade!(collection: collection)
     end
 
     it "calls DestroyShowcase then DestroyItem to prevent FK constraints on Item->Section" do
-      expect(destroy_showcase).to receive(:cascade!).with(showcase: showcase).at_least(:once).ordered
+      expect(destroy_showcase).to receive(:force_cascade!).with(showcase: showcase).at_least(:once).ordered
       expect(destroy_item).to receive(:cascade!).with(item: item).at_least(:once).ordered
       subject.cascade!(collection: collection)
     end
@@ -152,7 +152,7 @@ describe Destroy::Collection do
     end
 
     it "rolls back if an error occurs with Destroy::Showcase" do
-      allow(destroy_showcase).to receive(:cascade!).with(showcase: showcase).and_raise("error")
+      allow(destroy_showcase).to receive(:force_cascade!).with(showcase: showcase).and_raise("error")
       expect { subject.cascade!(collection: collection) }.to raise_error("error")
       data_still_exists!
     end

--- a/spec/services/destroy/page_spec.rb
+++ b/spec/services/destroy/page_spec.rb
@@ -12,6 +12,12 @@ describe Destroy::Page do
       expect(page).to receive(:destroy!)
       subject.destroy!(page: page)
     end
+
+    it "does not destroy the Page if CanDelete fails" do
+      expect(CanDelete).to receive(:page?).and_return(false)
+      expect(page).not_to receive(:destroy!)
+      subject.destroy!(page: page)
+    end
   end
 
   describe "#cascade" do
@@ -19,6 +25,24 @@ describe Destroy::Page do
       expect(page).to receive(:destroy!)
       expect(DestroyPageItemAssociations).to receive(:call).and_return(1)
       subject.cascade!(page: page)
+    end
+
+    it "doesn't destroy the Page if CanDelete fails" do
+      expect(CanDelete).to receive(:page?).and_return(false)
+      expect(page).not_to receive(:destroy!)
+      expect(DestroyPageItemAssociations).not_to receive(:call)
+      subject.cascade!(page: page)
+    end
+
+    it "returns nil if CanDelete fails" do
+      expect(CanDelete).to receive(:page?).and_return(false)
+      expect(subject.cascade!(page: page)).to be(nil)
+    end
+
+    it "can force destroy the Page" do
+      expect(page).to receive(:destroy!)
+      expect(DestroyPageItemAssociations).to receive(:call).and_return(1)
+      subject.force_cascade!(page: page)
     end
   end
 

--- a/spec/services/destroy/page_spec.rb
+++ b/spec/services/destroy/page_spec.rb
@@ -3,6 +3,10 @@ require "rails_helper"
 describe Destroy::Page do
   let(:page) { instance_double(Page, id: 1) }
 
+  before (:each) do
+    allow_any_instance_of(SiteObjectsQuery).to receive(:exists?).and_return(false)
+  end
+
   describe "#destroy" do
     it "destroys the Page" do
       expect(page).to receive(:destroy!)

--- a/spec/services/destroy/showcase_spec.rb
+++ b/spec/services/destroy/showcase_spec.rb
@@ -6,6 +6,10 @@ describe Destroy::Showcase do
   let(:destroy_section) { instance_double(Destroy::Section, cascade!: nil) }
   let(:subject) { Destroy::Showcase.new(destroy_section: destroy_section) }
 
+  before (:each) do
+    allow_any_instance_of(SiteObjectsQuery).to receive(:exists?).and_return(false)
+  end
+
   describe "#destroy" do
     it "destroys the Showcase" do
       expect(showcase).to receive(:destroy!)

--- a/spec/services/destroy/showcase_spec.rb
+++ b/spec/services/destroy/showcase_spec.rb
@@ -15,6 +15,12 @@ describe Destroy::Showcase do
       expect(showcase).to receive(:destroy!)
       subject.destroy!(showcase: showcase)
     end
+
+    it "does not destroy the Showcase if CanDelete fails" do
+      expect(CanDelete).to receive(:showcase?).and_return(false)
+      expect(showcase).not_to receive(:destroy!)
+      subject.destroy!(showcase: showcase)
+    end
   end
 
   describe "#cascade" do
@@ -26,6 +32,22 @@ describe Destroy::Showcase do
     it "destroys the Section" do
       expect(showcase).to receive(:destroy!)
       subject.cascade!(showcase: showcase)
+    end
+
+    it "does not destroy the Section if CanDelete fails" do
+      expect(CanDelete).to receive(:showcase?).and_return(false)
+      expect(showcase).not_to receive(:destroy!)
+      subject.cascade!(showcase: showcase)
+    end
+
+    it "returns nil if CanDelete fails" do
+      expect(CanDelete).to receive(:showcase?).and_return(false)
+      expect(subject.cascade!(showcase: showcase)).to be(nil)
+    end
+
+    it "can force destroy the showcase" do
+      expect(showcase).to receive(:destroy!)
+      subject.force_cascade!(showcase: showcase)
     end
   end
 


### PR DESCRIPTION
The showcase and page quick delete buttons didn't check if the item could be deleted, which would break the site path. This no longer happens.