### PR TITLE
Bugfix: Video thumbnail cache

### DIFF
--- a/app/decorators/v1/showcase_json_decorator.rb
+++ b/app/decorators/v1/showcase_json_decorator.rb
@@ -1,7 +1,7 @@
 
 module V1
   class ShowcaseJSONDecorator < Draper::Decorator
-    delegate :id, :description, :collection, :unique_id, :updated_at, :name, :name_line_1, :name_line_2, :items
+    delegate :id, :description, :collection, :unique_id, :updated_at, :name, :name_line_1, :name_line_2, :items, :items_media
 
     def self.display(showcase, json)
       new(showcase).display(json)

--- a/app/models/showcase.rb
+++ b/app/models/showcase.rb
@@ -3,7 +3,7 @@ class Showcase < ActiveRecord::Base
   has_many :sections
   has_many :items, through: :sections
   belongs_to :image, class_name: "Image", foreign_key: :media_id
-
+  has_many :items_media, through: :items, class_name: "Media", source: :media
   validates :name_line_1, :collection, :unique_id, presence: true
 
   has_paper_trail

--- a/app/values/cache_keys/custom/v1_showcases.rb
+++ b/app/values/cache_keys/custom/v1_showcases.rb
@@ -12,6 +12,7 @@ module CacheKeys
                                                       showcase.collection.collection_configuration,
                                                       showcase.sections,
                                                       showcase.items,
+                                                      showcase.items_media,
                                                       showcase.next])
       end
     end

--- a/spec/controllers/v1/showcases_controller_spec.rb
+++ b/spec/controllers/v1/showcases_controller_spec.rb
@@ -3,7 +3,7 @@ require "cache_spec_helper"
 
 RSpec.describe V1::ShowcasesController, type: :controller do
   let(:collection) { instance_double(Collection, id: "1", updated_at: nil, showcases: nil, collection_configuration: "collection_configuration") }
-  let(:showcase) { instance_double(Showcase, id: "1", updated_at: nil, sections: [], items: [], collection: collection, destroy!: true) }
+  let(:showcase) { instance_double(Showcase, id: "1", updated_at: nil, sections: [], items: [], items_media: [], collection: collection, destroy!: true) }
 
   before(:each) do
     allow_any_instance_of(ShowcaseQuery).to receive(:public_find).and_return(showcase)

--- a/spec/values/cache_keys/custom/v1_showcases_spec.rb
+++ b/spec/values/cache_keys/custom/v1_showcases_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe CacheKeys::Custom::V1Showcases do
                       collection: collection,
                       sections: "sections",
                       items: "items",
+                      items_media: "items.media",
                       next: "next",
                       object: showcase)
     end
@@ -33,9 +34,16 @@ RSpec.describe CacheKeys::Custom::V1Showcases do
     end
 
     it "uses the correct data" do
+      record = [showcase,
+                showcase_json.collection,
+                collection.collection_configuration,
+                showcase_json.sections,
+                showcase_json.items,
+                showcase_json.items_media,
+                showcase_json.next]
       expect_any_instance_of(CacheKeys::ActiveRecord).
         to receive(:generate).
-        with(record: [showcase, showcase_json.collection, collection.collection_configuration, showcase_json.sections, showcase_json.items, showcase_json.next])
+        with(record: record)
       subject.show(showcase: showcase_json)
     end
   end


### PR DESCRIPTION
-Changed cache key for v1 showcase to also include all associated media
-Added an association to showcases to make it easier to get the collection of media associated with a collection (through sections then items)