### PR TITLE
DEC-1340 Indexing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,7 @@ gem "paper_trail", "~> 4.0.0.beta2"
 gem "faraday"
 gem "faraday_middleware"
 
-gem "rsolr"
+gem "rsolr", github: "ndlib/rsolr"
 
 gem "sanitize"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,14 @@ GIT
       rails
 
 GIT
+  remote: git://github.com/ndlib/rsolr.git
+  revision: 9276b7d359f4807e5acc187968d0754af32f40ff
+  specs:
+    rsolr (2.0.0.pre1)
+      builder (>= 2.1.2)
+      faraday
+
+GIT
   remote: https://github.com/jonhartzler/react-rails-img.git
   revision: cc5c4ea42829d8baf6b7815532279843eef651d0
   specs:
@@ -386,8 +394,6 @@ GEM
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
     retriable (1.4.1)
-    rsolr (1.0.12)
-      builder (>= 2.1.2)
     rspec (3.1.0)
       rspec-core (~> 3.1.0)
       rspec-expectations (~> 3.1.0)
@@ -568,7 +574,7 @@ DEPENDENCIES
   react-rails
   react-rails-img!
   responders (~> 2.0)
-  rsolr
+  rsolr!
   rspec-collection_matchers
   rspec-rails
   rubocop (~> 0.36.0)

--- a/app/models/waggle/adapters/solr/index/item.rb
+++ b/app/models/waggle/adapters/solr/index/item.rb
@@ -25,11 +25,23 @@ module Waggle
               hash.merge!(string_fields)
               hash.merge!(datetime_fields)
             end
+            if waggle_item.children && !waggle_item.children.empty?
+              @as_solr[:_childDocuments_] = children_field
+            end
             @as_solr[:last_updated_sort] = datetime_as_solr(waggle_item.send(:last_updated))
             @as_solr
           end
 
           private
+
+          def children_field
+            children = []
+            waggle_item.children.each do |child|
+              waggle_child = Waggle::Adapters::Solr::Index::Item.new(waggle_item: Waggle::Item.from_item(child))
+              children << waggle_child.as_solr
+            end
+            children
+          end
 
           def string_fields
             {}.tap do |hash|
@@ -38,7 +50,8 @@ module Waggle
                 :unique_id,
                 :collection_id,
                 :type,
-                :thumbnail_url
+                :thumbnail_url,
+                :is_parent,
               ].each do |field|
                 hash[string_field_name(field)] = string_as_solr(waggle_item.send(field))
               end

--- a/app/models/waggle/adapters/solr/index/item.rb
+++ b/app/models/waggle/adapters/solr/index/item.rb
@@ -51,7 +51,7 @@ module Waggle
                 :collection_id,
                 :type,
                 :thumbnail_url,
-                :is_parent,
+                :part_parent,
               ].each do |field|
                 hash[string_field_name(field)] = string_as_solr(waggle_item.send(field))
               end

--- a/app/models/waggle/adapters/solr/search/hit.rb
+++ b/app/models/waggle/adapters/solr/search/hit.rb
@@ -26,6 +26,10 @@ module Waggle
             fetch_string(:unique_id)
           end
 
+          def part_parent
+            fetch_string(:part_parent)
+          end
+
           def collection_id
             fetch_string(:collection_id)
           end

--- a/app/models/waggle/adapters/solr/session.rb
+++ b/app/models/waggle/adapters/solr/session.rb
@@ -37,9 +37,11 @@ module Waggle
         private
 
         def parent_objects_as_solr(*objects)
-          objects_as_solr(*objects
-            .map { |waggle_item| waggle_item.parent ? Waggle::Item.from_item(waggle_item.parent) : waggle_item }
-            .uniq { |item| item.unique_id })
+          # we only want to index parent objects, so if we're changing children make sure we get their parents
+          # and only index them one time
+          objects_as_solr(*objects.
+            map { |waggle_item| waggle_item.parent ? Waggle::Item.from_item(waggle_item.parent) : waggle_item }.
+            uniq(&:unique_id))
         end
 
         def objects_as_solr(*objects)

--- a/app/models/waggle/adapters/solr/session.rb
+++ b/app/models/waggle/adapters/solr/session.rb
@@ -37,7 +37,7 @@ module Waggle
         private
 
         def parent_objects_as_solr(*objects)
-          objects_as_solr(*objects.select { |item| item.is_parent })
+          objects_as_solr(*objects.select(&:is_parent))
         end
 
         def objects_as_solr(*objects)

--- a/app/models/waggle/adapters/solr/session.rb
+++ b/app/models/waggle/adapters/solr/session.rb
@@ -37,7 +37,9 @@ module Waggle
         private
 
         def parent_objects_as_solr(*objects)
-          objects_as_solr(*objects.select(&:is_parent))
+          objects_as_solr(*objects
+            .map { |waggle_item| waggle_item.parent ? Waggle::Item.from_item(waggle_item.parent) : waggle_item }
+            .uniq { |item| item.unique_id })
         end
 
         def objects_as_solr(*objects)

--- a/app/models/waggle/adapters/solr/session.rb
+++ b/app/models/waggle/adapters/solr/session.rb
@@ -13,7 +13,7 @@ module Waggle
         end
 
         def index(*objects)
-          connection.add(objects_as_solr(*objects))
+          connection.add(parent_objects_as_solr(*objects))
         end
 
         def index!(*objects)
@@ -35,6 +35,10 @@ module Waggle
         end
 
         private
+
+        def parent_objects_as_solr(*objects)
+          objects_as_solr(*objects.select { |item| item.is_parent })
+        end
 
         def objects_as_solr(*objects)
           solr_objects(*objects).map(&:as_solr)

--- a/app/models/waggle/item.rb
+++ b/app/models/waggle/item.rb
@@ -1,14 +1,19 @@
 module Waggle
   class Item
-    attr_reader :data
+    attr_reader :data, :decoratedItem
 
     def self.from_item(item)
-      api_data = V1::ItemJSONDecorator.new(item).to_hash
-      new(api_data)
+      jsonItem = V1::ItemJSONDecorator.new(item)
+      new(jsonItem, jsonItem.to_hash)
     end
 
-    def initialize(data)
-      @data = data
+    def self.from_hash(hash)
+      new(nil, hash)
+    end
+
+    def initialize(jsonItem, hash)
+      @decoratedItem = jsonItem
+      @data = hash
     end
 
     def id
@@ -33,6 +38,20 @@ module Waggle
       else
         "Metadata Only"
       end
+    end
+
+    def children
+      return [] if !decoratedItem
+      decoratedItem.children
+    end
+
+    def is_parent
+      parent == nil
+    end
+
+    def parent
+      return nil if !decoratedItem
+      decoratedItem.parent
     end
 
     def last_updated

--- a/app/models/waggle/item.rb
+++ b/app/models/waggle/item.rb
@@ -3,16 +3,16 @@ module Waggle
     attr_reader :data, :decoratedItem
 
     def self.from_item(item)
-      jsonItem = V1::ItemJSONDecorator.new(item)
-      new(jsonItem, jsonItem.to_hash)
+      json_item = V1::ItemJSONDecorator.new(item)
+      new(json_item, json_item.to_hash)
     end
 
     def self.from_hash(hash)
       new(nil, hash)
     end
 
-    def initialize(jsonItem, hash)
-      @decoratedItem = jsonItem
+    def initialize(json_item, hash)
+      @decoratedItem = json_item
       @data = hash
     end
 
@@ -46,7 +46,7 @@ module Waggle
     end
 
     def is_parent
-      parent == nil
+      parent.nil?
     end
 
     def parent

--- a/app/models/waggle/item.rb
+++ b/app/models/waggle/item.rb
@@ -49,6 +49,10 @@ module Waggle
       parent.nil?
     end
 
+    def part_parent
+      parent.nil? ? "_is_parent_" : data.fetch("isPartOf/parent")
+    end
+
     def parent
       return nil if !decoratedItem
       decoratedItem.parent

--- a/app/models/waggle/search/hit.rb
+++ b/app/models/waggle/search/hit.rb
@@ -4,7 +4,7 @@ module Waggle
       attr_reader :adapter_hit
       private :adapter_hit
 
-      delegate :name, :at_id, :type, :description, :date_created, :creator, :thumbnail_url, :last_updated, to: :adapter_hit
+      delegate :name, :at_id, :part_parent, :type, :description, :date_created, :creator, :thumbnail_url, :last_updated, to: :adapter_hit
 
       def initialize(adapter_hit)
         @adapter_hit = adapter_hit

--- a/app/views/v1/search/_hit.json.jbuilder
+++ b/app/views/v1/search/_hit.json.jbuilder
@@ -1,5 +1,6 @@
 json.set! "@type", "SearchHit"
 json.set! "@id", hit.at_id
+json.set! "isPartOf/Item", hit.part_parent
 json.type hit.type
 json.name hit.name
 json.shortDescription hit.short_description

--- a/spec/fixtures/v1/items/pig-in-mud.json
+++ b/spec/fixtures/v1/items/pig-in-mud.json
@@ -19,6 +19,7 @@
     "@context":"http://schema.org",
     "@type":"ImageObject",
     "@id":"http://localhost:3017/v1/items/pig-in-mud",
+    "isPartOf/parent":"http://localhost:3017/v1/item/parent_id",
     "isPartOf/collection":"http://localhost:3017/v1/collections/animals",
     "id":"pig-in-mud",
     "collection_id":"animals",

--- a/spec/models/waggle/adapters/solr/index/item_spec.rb
+++ b/spec/models/waggle/adapters/solr/index/item_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Waggle::Adapters::Solr::Index::Item do
   let(:item_id) { "pig-in-mud" }
   let(:raw_data) { File.read(Rails.root.join("spec/fixtures/v1/items/#{item_id}.json")) }
   let(:data) { JSON.parse(raw_data).fetch("items") }
-  let(:waggle_item) { Waggle::Item.new(data) }
+  let(:waggle_item) { Waggle::Item.from_hash(data) }
   let(:configuration) { double(Metadata::Configuration, fields: [], facets: [], sorts: []) }
   let(:metadata) do
     double(
@@ -35,6 +35,7 @@ RSpec.describe Waggle::Adapters::Solr::Index::Item do
   describe "as_solr" do
     it "is the hash to send to solr" do
       expect(subject.as_solr).to eq(
+        is_parent_s: "true",
         name_t: ["pig-in-mud"],
         creator_t: ["Bob"],
         description_t: ["Source"],

--- a/spec/models/waggle/adapters/solr/index/item_spec.rb
+++ b/spec/models/waggle/adapters/solr/index/item_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Waggle::Adapters::Solr::Index::Item do
   describe "as_solr" do
     it "is the hash to send to solr" do
       expect(subject.as_solr).to eq(
-        is_parent_s: "true",
+        part_parent_s: "_is_parent_",
         name_t: ["pig-in-mud"],
         creator_t: ["Bob"],
         description_t: ["Source"],

--- a/spec/models/waggle/adapters/solr/session_spec.rb
+++ b/spec/models/waggle/adapters/solr/session_spec.rb
@@ -43,7 +43,8 @@ RSpec.describe Waggle::Adapters::Solr::Session do
       it "maps objects to solr objects and indexes their as_solr values" do
         items.each do |waggle_item|
           expect(Waggle::Adapters::Solr::Index::Item).to receive(:new).with(waggle_item: waggle_item).and_call_original
-          expect(waggle_item).to receive(:is_parent).and_return(true)
+          expect(waggle_item).to receive(:parent).and_return(nil)
+          expect(waggle_item).to receive(:unique_id).and_return(waggle_item.id)
         end
         allow_any_instance_of(Waggle::Adapters::Solr::Index::Item).to receive(:as_solr).and_return(test: "test")
         expect(connection).to receive(:add).with([{ test: "test" }, { test: "test" }])

--- a/spec/models/waggle/adapters/solr/session_spec.rb
+++ b/spec/models/waggle/adapters/solr/session_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Waggle::Adapters::Solr::Session do
   end
 
   context "indexing" do
-    let(:items) { [instance_double(Waggle::Item, id: "item-1", type: "Item", collection_id: "collection-1"), instance_double(Waggle::Item, id: "item-2", type: "Item", collection_id: "collection-2")] }
+    let(:items) { [instance_double(Waggle::Item, id: "item-1", type: "Item", collection_id: "collection-1", parent: nil), instance_double(Waggle::Item, id: "item-2", type: "Item", collection_id: "collection-2", parent: nil)] }
     let(:connection) { instance_double(RSolr::Client) }
 
     before do
@@ -43,6 +43,7 @@ RSpec.describe Waggle::Adapters::Solr::Session do
       it "maps objects to solr objects and indexes their as_solr values" do
         items.each do |waggle_item|
           expect(Waggle::Adapters::Solr::Index::Item).to receive(:new).with(waggle_item: waggle_item).and_call_original
+          expect(waggle_item).to receive(:is_parent).and_return(true)
         end
         allow_any_instance_of(Waggle::Adapters::Solr::Index::Item).to receive(:as_solr).and_return(test: "test")
         expect(connection).to receive(:add).with([{ test: "test" }, { test: "test" }])

--- a/spec/models/waggle/item_spec.rb
+++ b/spec/models/waggle/item_spec.rb
@@ -42,18 +42,18 @@ RSpec.describe Waggle::Item do
     let(:decorator_barren) { instance_double(V1::ItemJSONDecorator, parent: data.fetch("id"), children: []) }
 
     it "returns empy array with no chlidren" do
-      testItem = described_class.new(decorator_barren, data)
-      expect(testItem.children).to eq([])
+      test_item = described_class.new(decorator_barren, data)
+      expect(test_item.children).to eq([])
     end
 
     it "returns children when present" do
-      testItem = described_class.new(decorator_with_child, data)
-      expect(testItem.children).to eq(["child1"])
+      test_item = described_class.new(decorator_with_child, data)
+      expect(test_item.children).to eq(["child1"])
     end
 
     it "returns children when present" do
-      testItem = described_class.new(decorator_many_child, data)
-      expect(testItem.children).to eq(["child1", "child2", "child3"])
+      test_item = described_class.new(decorator_many_child, data)
+      expect(test_item.children).to eq(["child1", "child2", "child3"])
     end
   end
 
@@ -63,23 +63,23 @@ RSpec.describe Waggle::Item do
     let(:decorator_child) { instance_double(V1::ItemJSONDecorator, parent: parent, children: []) }
 
     it "is a parent when it has no parent" do
-      testItem = described_class.new(decorator_parent, data)
-      expect(testItem.part_parent).to eq("_is_parent_")
+      test_item = described_class.new(decorator_parent, data)
+      expect(test_item.part_parent).to eq("_is_parent_")
     end
 
     it "returns nil parent when no parent" do
-      testItem = described_class.new(decorator_parent, data)
-      expect(testItem.part_parent).to eq("_is_parent_")
+      test_item = described_class.new(decorator_parent, data)
+      expect(test_item.part_parent).to eq("_is_parent_")
     end
 
     it "returns parent when present" do
-      testItem = described_class.new(decorator_child, data)
-      expect(testItem.part_parent).to eq("http://localhost:3017/v1/item/parent_id")
+      test_item = described_class.new(decorator_child, data)
+      expect(test_item.part_parent).to eq("http://localhost:3017/v1/item/parent_id")
     end
 
     it "is not a parent if it has one" do
-      testItem = described_class.new(decorator_child, data)
-      expect(testItem.parent).to eq(parent)
+      test_item = described_class.new(decorator_child, data)
+      expect(test_item.parent).to eq(parent)
     end
   end
 

--- a/spec/models/waggle/item_spec.rb
+++ b/spec/models/waggle/item_spec.rb
@@ -37,47 +37,47 @@ RSpec.describe Waggle::Item do
   end
 
   describe "children" do
-    let(:decoratorWithChild) { instance_double(V1::ItemJSONDecorator, parent: nil, children: ["child1"]) }
-    let(:decoratorManyChild) { instance_double(V1::ItemJSONDecorator, parent: nil, children: ["child1", "child2", "child3"]) }
-    let(:decoratorBarren) { instance_double(V1::ItemJSONDecorator, parent: data.fetch("id"), children: []) }
+    let(:decorator_with_child) { instance_double(V1::ItemJSONDecorator, parent: nil, children: ["child1"]) }
+    let(:decorator_many_child) { instance_double(V1::ItemJSONDecorator, parent: nil, children: ["child1", "child2", "child3"]) }
+    let(:decorator_barren) { instance_double(V1::ItemJSONDecorator, parent: data.fetch("id"), children: []) }
 
     it "returns empy array with no chlidren" do
-      testItem = described_class.new(decoratorBarren, data)
+      testItem = described_class.new(decorator_barren, data)
       expect(testItem.children).to eq([])
     end
 
     it "returns children when present" do
-      testItem = described_class.new(decoratorWithChild, data)
+      testItem = described_class.new(decorator_with_child, data)
       expect(testItem.children).to eq(["child1"])
     end
 
     it "returns children when present" do
-      testItem = described_class.new(decoratorManyChild, data)
+      testItem = described_class.new(decorator_many_child, data)
       expect(testItem.children).to eq(["child1", "child2", "child3"])
     end
   end
 
   describe "parent" do
-    let(:decoratorParent) { instance_double(V1::ItemJSONDecorator, parent: nil, children: []) }
-    let(:decoratorChild) { instance_double(V1::ItemJSONDecorator, parent: data.fetch("id"), children: []) }
+    let(:decorator_parent) { instance_double(V1::ItemJSONDecorator, parent: nil, children: []) }
+    let(:decorator_child) { instance_double(V1::ItemJSONDecorator, parent: data.fetch("id"), children: []) }
 
     it "is a parent when it has no parent" do
-      testItem = described_class.new(decoratorParent, data)
+      testItem = described_class.new(decorator_parent, data)
       expect(testItem.is_parent).to be_truthy
     end
 
     it "returns nil parent when no parent" do
-      testItem = described_class.new(decoratorParent, data)
+      testItem = described_class.new(decorator_parent, data)
       expect(testItem.is_parent).to be_truthy
     end
 
     it "returns parent when present" do
-      testItem = described_class.new(decoratorChild, data)
+      testItem = described_class.new(decorator_child, data)
       expect(testItem.is_parent).to be_falsy
     end
 
     it "is not a parent if it has one" do
-      testItem = described_class.new(decoratorChild, data)
+      testItem = described_class.new(decorator_child, data)
       expect(testItem.parent).to eq(data.fetch("id"))
     end
   end

--- a/spec/models/waggle/item_spec.rb
+++ b/spec/models/waggle/item_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Waggle::Item do
   let(:item_id) { "pig-in-mud" }
   let(:raw_data) { File.read(Rails.root.join("spec/fixtures/v1/items/#{item_id}.json")) }
   let(:data) { JSON.parse(raw_data).fetch("items") }
-  let(:subject) { described_class.new(data) }
+  let(:subject) { described_class.from_hash(data) }
 
   describe "id" do
     it "is the id" do
@@ -80,7 +80,7 @@ RSpec.describe Waggle::Item do
 
     it "converts an item to its api hash and instantiates a new waggle item" do
       expect(V1::ItemJSONDecorator).to receive(:new).with(item).and_return(decorator)
-      expect(described_class).to receive(:new).with(decorator.to_hash).and_return("waggle item")
+      expect(described_class).to receive(:new).with(decorator, decorator.to_hash).and_return("waggle item")
       expect(subject).to eq("waggle item")
     end
   end

--- a/spec/models/waggle/item_spec.rb
+++ b/spec/models/waggle/item_spec.rb
@@ -36,6 +36,52 @@ RSpec.describe Waggle::Item do
     end
   end
 
+  describe "children" do
+    let(:decoratorWithChild) { instance_double(V1::ItemJSONDecorator, parent: nil, children: ["child1"]) }
+    let(:decoratorManyChild) { instance_double(V1::ItemJSONDecorator, parent: nil, children: ["child1", "child2", "child3"]) }
+    let(:decoratorBarren) { instance_double(V1::ItemJSONDecorator, parent: data.fetch("id"), children: []) }
+
+    it "returns empy array with no chlidren" do
+      testItem = described_class.new(decoratorBarren, data)
+      expect(testItem.children).to eq([])
+    end
+
+    it "returns children when present" do
+      testItem = described_class.new(decoratorWithChild, data)
+      expect(testItem.children).to eq(["child1"])
+    end
+
+    it "returns children when present" do
+      testItem = described_class.new(decoratorManyChild, data)
+      expect(testItem.children).to eq(["child1", "child2", "child3"])
+    end
+  end
+
+  describe "parent" do
+    let(:decoratorParent) { instance_double(V1::ItemJSONDecorator, parent: nil, children: []) }
+    let(:decoratorChild) { instance_double(V1::ItemJSONDecorator, parent: data.fetch("id"), children: []) }
+
+    it "is a parent when it has no parent" do
+      testItem = described_class.new(decoratorParent, data)
+      expect(testItem.is_parent).to be_truthy
+    end
+
+    it "returns nil parent when no parent" do
+      testItem = described_class.new(decoratorParent, data)
+      expect(testItem.is_parent).to be_truthy
+    end
+
+    it "returns parent when present" do
+      testItem = described_class.new(decoratorChild, data)
+      expect(testItem.is_parent).to be_falsy
+    end
+
+    it "is not a parent if it has one" do
+      testItem = described_class.new(decoratorChild, data)
+      expect(testItem.parent).to eq(data.fetch("id"))
+    end
+  end
+
   describe "thumbnail_url" do
     it "is the media's medium thumbnail contentUrl when the media is an ImageObject" do
       data["media"]["@type"] = "ImageObject"

--- a/spec/models/waggle/item_spec.rb
+++ b/spec/models/waggle/item_spec.rb
@@ -58,27 +58,28 @@ RSpec.describe Waggle::Item do
   end
 
   describe "parent" do
+    let(:parent) { instance_double(Item, unique_id: "parent_id") }
     let(:decorator_parent) { instance_double(V1::ItemJSONDecorator, parent: nil, children: []) }
-    let(:decorator_child) { instance_double(V1::ItemJSONDecorator, parent: data.fetch("id"), children: []) }
+    let(:decorator_child) { instance_double(V1::ItemJSONDecorator, parent: parent, children: []) }
 
     it "is a parent when it has no parent" do
       testItem = described_class.new(decorator_parent, data)
-      expect(testItem.is_parent).to be_truthy
+      expect(testItem.part_parent).to eq("_is_parent_")
     end
 
     it "returns nil parent when no parent" do
       testItem = described_class.new(decorator_parent, data)
-      expect(testItem.is_parent).to be_truthy
+      expect(testItem.part_parent).to eq("_is_parent_")
     end
 
     it "returns parent when present" do
       testItem = described_class.new(decorator_child, data)
-      expect(testItem.is_parent).to be_falsy
+      expect(testItem.part_parent).to eq("http://localhost:3017/v1/item/parent_id")
     end
 
     it "is not a parent if it has one" do
       testItem = described_class.new(decorator_child, data)
-      expect(testItem.parent).to eq(data.fetch("id"))
+      expect(testItem.parent).to eq(parent)
     end
   end
 


### PR DESCRIPTION
Altered indexing to correctly account for children. 

This required updating the rsolr gem from 1.0 to 2.0, which had a bug with only having one child, which I fixed in a fork of the repo.

I'm open to suggestions on what we want the identifier to be for parents. Right now it's just a string relation is_parent: "true" or "false"