### PR TITLE
Import parent/child associations

### DIFF
--- a/app/services/create_items.rb
+++ b/app/services/create_items.rb
@@ -27,9 +27,10 @@ class CreateItems
   def create_or_update!(collection:, find_by:, items_hash:, counts:, errors:)
     items_to_index = []
     ActiveRecord::Base.transaction do
-      items_hash.each.with_index do |item_props, index|
+      items_hash.each do |item_props|
         rewrite_errors = []
-        item_props = yield(item_props, rewrite_errors).symbolize_keys if block_given?
+        index = item_props[:original_index]
+        item_props = yield(item_props[:item_hash], rewrite_errors).symbolize_keys if block_given?
         item_creator = FindOrCreateItem.call(props: { collection_id: collection.id, **item_props }, find_by: find_by)
         saved = rewrite_errors.present? ? false : item_creator.save(index: false)
         add_to_errors(

--- a/app/services/create_items.rb
+++ b/app/services/create_items.rb
@@ -18,6 +18,11 @@ class CreateItems
 
   # Attempts to create/update items given in the items_hash. Increments keys in
   # counts and appends any errors to the given errors array.
+  #
+  # Entries within the items_hash array are expected to be of format:
+  #   { index: index, item_hash: item }
+  # where item_hash is the items' new properties, and index will be used when populating errors
+  #
   # Count hash keys are defined as:
   #   new_count      - Count of how many new records were created
   #   changed_count  - Count of how many items already existed but were changed
@@ -29,7 +34,7 @@ class CreateItems
     ActiveRecord::Base.transaction do
       items_hash.each do |item_props|
         rewrite_errors = []
-        index = item_props[:original_index]
+        index = item_props[:index]
         item_props = yield(item_props[:item_hash], rewrite_errors).symbolize_keys if block_given?
         item_creator = FindOrCreateItem.call(props: { collection_id: collection.id, **item_props }, find_by: find_by)
         saved = rewrite_errors.present? ? false : item_creator.save(index: false)

--- a/app/services/google_create_items.rb
+++ b/app/services/google_create_items.rb
@@ -52,9 +52,9 @@ class GoogleCreateItems
     children = []
     items.each.with_index do |item, index|
       if item["Parent Identifier"].present?
-        parents << { original_index: index, item_hash: item }
+        parents << { index: index, item_hash: item }
       else
-        children << { original_index: index, item_hash: item }
+        children << { index: index, item_hash: item }
       end
     end
     [parents, children]

--- a/app/services/google_create_items.rb
+++ b/app/services/google_create_items.rb
@@ -29,13 +29,14 @@ class GoogleCreateItems
     worksheet = session.get_worksheet(file: file, sheet: sheet)
     if worksheet.present?
       items = session.worksheet_to_hash(worksheet: worksheet)
-
-      CreateItems.call(collection: collection,
-                       find_by: [:collection_id, :user_defined_id],
-                       items_hash: items,
-                       counts: counts,
-                       errors: errors) do |item_props, rewrite_errors|
-        RewriteItemMetadata.call(item_hash: item_props, errors: rewrite_errors, configuration: configuration(collection))
+      parents_then_children(items: items).each do |items_hash|
+        CreateItems.call(collection: collection,
+                         find_by: [:collection_id, :user_defined_id],
+                         items_hash: items_hash,
+                         counts: counts,
+                         errors: errors) do |item_props, rewrite_errors|
+          RewriteItemMetadata.call(item_hash: item_props, errors: rewrite_errors, configuration: configuration(collection))
+        end
       end
     end
     {
@@ -45,6 +46,19 @@ class GoogleCreateItems
   end
 
   private
+
+  def parents_then_children(items:)
+    parents = []
+    children = []
+    items.each.with_index do |item, index|
+      if item["Parent Identifier"].present?
+        parents << { original_index: index, item_hash: item }
+      else
+        children << { original_index: index, item_hash: item }
+      end
+    end
+    [parents, children]
+  end
 
   def configuration(collection)
     @configuration ||= CollectionConfigurationQuery.new(collection).find

--- a/app/services/google_session.rb
+++ b/app/services/google_session.rb
@@ -45,7 +45,8 @@ class GoogleSession
   end
 
   # Returns an array of hashes where the hash keys are the column names
-  # Worksheet must have a header row to use as keys in the hash
+  # Worksheet must have a header row to use as keys in the hash. Blank cells will
+  # be ignored except in the case of the Identifier or Parent Identifier columns
   def worksheet_to_hash(worksheet:)
     results = []
     rows = worksheet.rows
@@ -54,8 +55,9 @@ class GoogleSession
       results = rows[1..rows.size].map do |row|
         hash = Hash.new
         row.each_with_index do |cell, cell_index|
-          if cell.present?
-            hash[header_row[cell_index]] = cell
+          header = header_row[cell_index]
+          if header == "Identifier" || header == "Parent Identifier" || cell.present?
+            hash[header] = cell.presence
           end
         end
         hash

--- a/app/services/rewrite_item_metadata.rb
+++ b/app/services/rewrite_item_metadata.rb
@@ -16,7 +16,21 @@ class RewriteItemMetadata
     result = Hash.new
     metadata = Hash.new
     item_hash.each do |k, v|
-      if k == "Identifier"
+      case k
+      when "Parent Identifier"
+        if v.present?
+          parent = Item.where(user_defined_id: v).take
+          if parent.present?
+            result[:parent_id] = parent.id
+          else
+            errors << "Unable to find parent item '#{v}'"
+          end
+        else
+          # Since this label was explicitly defined with a nil value, we have to
+          # insert a parent_id of nil to clear any existing association
+          result[:parent_id] = nil
+        end
+      when "Identifier"
         result[:user_defined_id] = v
       else
         new_pair = rewrite_pair(key: k, value: v)

--- a/spec/services/create_items_spec.rb
+++ b/spec/services/create_items_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe CreateItems, helpers: :item_meta_helpers do
       end
     end
 
-    it "adds these errors to the items", :focus => true do
+    it "adds these errors to the items" do
       expected_errors = {
         10 => { errors: [["Rewrite error 1 on name1", "Rewrite error 2 on name1"], "Item validation error"], item: item },
         11 => { errors: [["Rewrite error 1 on name2", "Rewrite error 2 on name2"], "Item validation error"], item: item },

--- a/spec/services/create_items_spec.rb
+++ b/spec/services/create_items_spec.rb
@@ -8,9 +8,9 @@ end
 RSpec.describe CreateItems, helpers: :item_meta_helpers do
   let(:items) do
     [
-      item_meta_hash_remapped(item_id: 1),
-      item_meta_hash_remapped(item_id: 2),
-      item_meta_hash_remapped(item_id: 3)
+      { original_index: 10, item_hash: item_meta_hash_remapped(item_id: 1) },
+      { original_index: 11, item_hash: item_meta_hash_remapped(item_id: 2) },
+      { original_index: 12, item_hash: item_meta_hash_remapped(item_id: 3) }
     ]
   end
   let(:item_errors) { instance_double(ActiveModel::Errors, full_messages: ["Item validation error"]) }
@@ -42,10 +42,10 @@ RSpec.describe CreateItems, helpers: :item_meta_helpers do
   end
 
   it "allows injecting a block to edit the properties before creating the item" do
-    rewritten = items.each { |item_hash| { item_name: item_hash[:name] } }
-    expect(FindOrCreateItem).to receive(:new).with(props: { collection_id: 1, item_name: rewritten[0][:name] }).and_return(creator).ordered
-    expect(FindOrCreateItem).to receive(:new).with(props: { collection_id: 1, item_name: rewritten[1][:name] }).and_return(creator).ordered
-    expect(FindOrCreateItem).to receive(:new).with(props: { collection_id: 1, item_name: rewritten[2][:name] }).and_return(creator).ordered
+    rewritten = items.each { |item| { item_name: item[:item_hash][:name] } }
+    expect(FindOrCreateItem).to receive(:new).with(props: { collection_id: 1, item_name: rewritten[0][:item_hash][:name] }).and_return(creator).ordered
+    expect(FindOrCreateItem).to receive(:new).with(props: { collection_id: 1, item_name: rewritten[1][:item_hash][:name] }).and_return(creator).ordered
+    expect(FindOrCreateItem).to receive(:new).with(props: { collection_id: 1, item_name: rewritten[2][:item_hash][:name] }).and_return(creator).ordered
     described_class.call(collection: collection, find_by: [], items_hash: items, counts: counts, errors: errors) do |item_props, _rewrite_errors|
       { item_name: item_props[:name] }
     end
@@ -84,9 +84,9 @@ RSpec.describe CreateItems, helpers: :item_meta_helpers do
   context "called with items" do
     it "uses FindOrCreateItem to create the item with the given properties" do
       allow(CreateUniqueId).to receive(:call).and_return(true)
-      expect(FindOrCreateItem).to receive(:new).with(props: hash_including(items[0])).ordered
-      expect(FindOrCreateItem).to receive(:new).with(props: hash_including(items[1])).ordered
-      expect(FindOrCreateItem).to receive(:new).with(props: hash_including(items[2])).ordered
+      expect(FindOrCreateItem).to receive(:new).with(props: hash_including(items[0][:item_hash])).ordered
+      expect(FindOrCreateItem).to receive(:new).with(props: hash_including(items[1][:item_hash])).ordered
+      expect(FindOrCreateItem).to receive(:new).with(props: hash_including(items[2][:item_hash])).ordered
       subject
     end
 

--- a/spec/services/create_items_spec.rb
+++ b/spec/services/create_items_spec.rb
@@ -8,13 +8,13 @@ end
 RSpec.describe CreateItems, helpers: :item_meta_helpers do
   let(:items) do
     [
-      { original_index: 10, item_hash: item_meta_hash_remapped(item_id: 1) },
-      { original_index: 11, item_hash: item_meta_hash_remapped(item_id: 2) },
-      { original_index: 12, item_hash: item_meta_hash_remapped(item_id: 3) }
+      { index: 10, item_hash: item_meta_hash_remapped(item_id: 1) },
+      { index: 11, item_hash: item_meta_hash_remapped(item_id: 2) },
+      { index: 12, item_hash: item_meta_hash_remapped(item_id: 3) }
     ]
   end
   let(:item_errors) { instance_double(ActiveModel::Errors, full_messages: ["Item validation error"]) }
-  let(:errors) { [] }
+  let(:errors) { {} }
   let(:counts) do
     {
       total_count: 0,
@@ -59,12 +59,12 @@ RSpec.describe CreateItems, helpers: :item_meta_helpers do
       end
     end
 
-    it "adds these errors to the items" do
-      expected_errors = [
-        { errors: [["Rewrite error 1 on name1", "Rewrite error 2 on name1"], "Item validation error"], item: item },
-        { errors: [["Rewrite error 1 on name2", "Rewrite error 2 on name2"], "Item validation error"], item: item },
-        { errors: [["Rewrite error 1 on name3", "Rewrite error 2 on name3"], "Item validation error"], item: item }
-      ]
+    it "adds these errors to the items", :focus => true do
+      expected_errors = {
+        10 => { errors: [["Rewrite error 1 on name1", "Rewrite error 2 on name1"], "Item validation error"], item: item },
+        11 => { errors: [["Rewrite error 1 on name2", "Rewrite error 2 on name2"], "Item validation error"], item: item },
+        12 => { errors: [["Rewrite error 1 on name3", "Rewrite error 2 on name3"], "Item validation error"], item: item }
+      }
       subject
       expect(errors).to eq(expected_errors)
     end
@@ -124,7 +124,7 @@ RSpec.describe CreateItems, helpers: :item_meta_helpers do
 
       it "returns no errors" do
         subject
-        expect(errors).to eq([])
+        expect(errors).to eq({})
       end
     end
 
@@ -144,7 +144,7 @@ RSpec.describe CreateItems, helpers: :item_meta_helpers do
 
       it "returns no errors" do
         subject
-        expect(errors).to eq([])
+        expect(errors).to eq({})
       end
     end
 
@@ -164,7 +164,7 @@ RSpec.describe CreateItems, helpers: :item_meta_helpers do
 
       it "returns no errors" do
         subject
-        expect(errors).to eq([])
+        expect(errors).to eq({})
       end
     end
 
@@ -181,11 +181,11 @@ RSpec.describe CreateItems, helpers: :item_meta_helpers do
       end
 
       it "returns a hash with errors" do
-        expected = [
-          { errors: ["Item validation error"], item: item },
-          { errors: ["Item validation error"], item: item },
-          { errors: ["Item validation error"], item: item }
-        ]
+        expected = {
+          10 => { errors: ["Item validation error"], item: item },
+          11 => { errors: ["Item validation error"], item: item },
+          12 => { errors: ["Item validation error"], item: item }
+        }
         subject
         expect(errors).to eq(expected)
       end
@@ -203,7 +203,7 @@ RSpec.describe CreateItems, helpers: :item_meta_helpers do
 
     it "returns a hash with errors" do
       subject
-      expect(errors).to eq([])
+      expect(errors).to eq({})
     end
   end
 end

--- a/spec/services/csv_create_items_spec.rb
+++ b/spec/services/csv_create_items_spec.rb
@@ -53,9 +53,10 @@ RSpec.describe CsvCreateItems, helpers: :item_meta_helpers do
     expect(subject).to include(:errors)
   end
 
-  it "calls CreateItems with the hash read from the csv" do
-    allow(CSV).to receive(:parse).and_return([{ item: "item" }])
-    expect(CreateItems).to receive(:call).with(hash_including(items_hash: [{ item: "item" }]))
+  it "calls CreateItems with the hash read from the csv, parent items first" do
+    allow(CSV).to receive(:parse).and_return([{ item: "child item" }, { "Parent Identifier" => 1, item: "parent item" }])
+    expect(CreateItems).to receive(:call).with(hash_including(items_hash: [{ index: 1, item_hash: { "Parent Identifier" => 1, item: "parent item" } }])).ordered
+    expect(CreateItems).to receive(:call).with(hash_including(items_hash: [{ index: 0, item_hash: { item: "child item" } }])).ordered
     subject
   end
 

--- a/spec/services/google_create_items_spec.rb
+++ b/spec/services/google_create_items_spec.rb
@@ -63,10 +63,11 @@ RSpec.describe GoogleCreateItems, helpers: :item_meta_helpers do
     subject
   end
 
-  it "calls CreateItems with the hash read from the worksheet" do
-    allow_any_instance_of(GoogleSession).to receive(:worksheet_to_hash).and_return([{ item: "item" }])
+  it "calls CreateItems with the hash read from the worksheet, parent items first" do
+    allow_any_instance_of(GoogleSession).to receive(:worksheet_to_hash).and_return([{ item: "child item" }, { "Parent Identifier" => 1, item: "parent item" }])
     creator = GoogleCreateItems.new(auth_code: param_hash[:auth_code], callback_uri: param_hash[:callback_uri])
-    expect(CreateItems).to receive(:call).with(hash_including(items_hash: [{ item: "item" }]))
+    expect(CreateItems).to receive(:call).with(hash_including(items_hash: [{ index: 1, item_hash: { "Parent Identifier" => 1, item: "parent item" } }])).ordered
+    expect(CreateItems).to receive(:call).with(hash_including(items_hash: [{ index: 0, item_hash: { item: "child item" } }])).ordered
     creator.create_from_worksheet!(collection: collection, file: param_hash[:file], sheet: param_hash[:sheet])
   end
 

--- a/spec/services/google_session_spec.rb
+++ b/spec/services/google_session_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe GoogleSession do
   describe "worksheet_to_hash", helpers: :item_meta_helpers do
     let(:rows) do
       [
-        ["Identifier", "Name", "Alternate Name", "Description", "Date Created", "Creator", "Subject", "Original Language"],
+        ["Identifier", "Name", "Alternate Name", "Description", "Date Created", "Creator", "Subject", "Original Language", "Parent Identifier"],
         item_meta_array(item_id: 1),
         item_meta_array(item_id: 2),
         item_meta_array(item_id: 3)
@@ -116,6 +116,26 @@ RSpec.describe GoogleSession do
       items[0].delete("Description")
       result = subject.worksheet_to_hash(worksheet: worksheet)
       expect(result).to eq(items)
+    end
+
+    it "returns Parent Identifier even if the column has no value" do
+      rows[1][8] = nil
+      rows[2][8] = nil
+      rows[3][8] = nil
+      results = subject.worksheet_to_hash(worksheet: worksheet)
+      results.each do |result|
+        expect(result).to include("Parent Identifier" => nil)
+      end
+    end
+
+    it "returns Identifier even if the column has no value" do
+      rows[1][0] = nil
+      rows[2][0] = nil
+      rows[3][0] = nil
+      results = subject.worksheet_to_hash(worksheet: worksheet)
+      results.each do |result|
+        expect(result).to include("Identifier" => nil)
+      end
     end
   end
 

--- a/spec/services/rewrite_item_metadata_fields_spec.rb
+++ b/spec/services/rewrite_item_metadata_fields_spec.rb
@@ -6,13 +6,13 @@ RSpec.configure do |c|
 end
 
 RSpec.describe RewriteItemMetadata, helpers: :item_meta_helpers do
-  let(:item) { {} }
+  let(:item_hash) { {} }
   let(:errors) { [] }
   let(:configuration) { instance_double(Metadata::Configuration, field_names: ["name", "alternate_name", "date_created"], field?: true, label?: true) }
   let(:field) { double(name: "name", multiple: false, type: :string) }
   let(:date_field) { double(name: "date_created", multiple: false, type: :date) }
   let(:multiple_field) { double(name: "alternate_name", multiple: true, type: :string) }
-  let(:subject) { described_class.call(item_hash: item, errors: errors, configuration: configuration) }
+  let(:subject) { described_class.call(item_hash: item_hash, errors: errors, configuration: configuration) }
 
   before(:each) do
     allow(configuration).to receive(:field?).and_return(false)
@@ -20,7 +20,7 @@ RSpec.describe RewriteItemMetadata, helpers: :item_meta_helpers do
   end
 
   it "rewrites the hash to match item property structure" do
-    item["Identifier"] = "identifier"
+    item_hash["Identifier"] = "identifier"
     expect(subject).to include(:user_defined_id, :metadata)
   end
 
@@ -29,7 +29,7 @@ RSpec.describe RewriteItemMetadata, helpers: :item_meta_helpers do
     allow(configuration).to receive(:field?).with("name").and_return(true)
     allow(configuration).to receive(:label?).with("Name").and_return(true)
 
-    item["Name"] = "the name"
+    item_hash["Name"] = "the name"
     expect(subject[:metadata]).to eq("name" => "the name", "alternate_name" => nil, "date_created" => nil)
   end
 
@@ -38,7 +38,7 @@ RSpec.describe RewriteItemMetadata, helpers: :item_meta_helpers do
     allow(configuration).to receive(:field?).with("alternate_name").and_return(true)
     allow(configuration).to receive(:label?).with("Alternate Name").and_return(true)
 
-    item["Alternate Name"] = "name1||name2"
+    item_hash["Alternate Name"] = "name1||name2"
     expect(subject[:metadata]).to eq("name" => nil, "alternate_name" => ["name1", "name2"], "date_created" => nil)
   end
 
@@ -48,7 +48,7 @@ RSpec.describe RewriteItemMetadata, helpers: :item_meta_helpers do
       allow(configuration).to receive(:field?).with("date_created").and_return(true)
       allow(configuration).to receive(:label?).with("Date Created").and_return(true)
 
-      item["Date Created"] = "-2001/01/01"
+      item_hash["Date Created"] = "-2001/01/01"
       expect(subject[:metadata]).to eq(
         "name" => nil,
         "alternate_name" => nil,
@@ -61,7 +61,7 @@ RSpec.describe RewriteItemMetadata, helpers: :item_meta_helpers do
       allow(configuration).to receive(:field?).with("date_created").and_return(true)
       allow(configuration).to receive(:label?).with("Date Created").and_return(true)
 
-      item["Date Created"] = "'-2001/01/01"
+      item_hash["Date Created"] = "'-2001/01/01"
       expect(subject[:metadata]).to eq(
         "name" => nil,
         "alternate_name" => nil,
@@ -73,7 +73,58 @@ RSpec.describe RewriteItemMetadata, helpers: :item_meta_helpers do
   it "adds to the given errors array when a label is not found" do
     allow(Item).to receive(:method_defined?).and_return false
     subject
-    expected = item.keys.map { |attribute| "Unknown attribute #{attribute}" }
+    expected = item_hash.keys.map { |attribute| "Unknown attribute #{attribute}" }
     expect(errors).to eq(expected)
+  end
+
+  context "when it has a parent identifier column with a value" do
+    let(:parent_item) { instance_double(Item, id: 1) }
+    let(:parent_item_relation) { instance_double(ActiveRecord::Relation, take: parent_item) }
+
+    before(:each) do
+      item_hash["Parent Identifier"] = "parent id"
+    end
+
+    it "finds the parent by user defined id" do
+      expect(Item).to receive(:where).with(user_defined_id: "parent id").and_return(parent_item_relation)
+      subject
+    end
+
+    it "adds a parent_id field to the hash using the id of the found parent" do
+      allow(Item).to receive(:where).with(user_defined_id: "parent id").and_return(parent_item_relation)
+      expect(subject[:parent_id]).to eq(1)
+    end
+
+    it "adds an error if the parent item does not exist" do
+      subject
+      expected = item_hash.keys.map { |attribute| "Unable to find parent item 'parent id'" }
+      expect(errors).to eq(expected)
+    end
+  end
+
+  context "when it has a parent identifier column with no value" do
+    before(:each) do
+      item_hash["Parent Identifier"] = nil
+    end
+
+    it "does not query for the parent" do
+      expect(Item).not_to receive(:where).with(user_defined_id: "parent id")
+      subject
+    end
+
+    it "adds a parent_id to the hash with a value of nil to disassociate a child item from its current parent if the value is nil" do
+      item_hash["Parent Identifier"] = nil
+      expect(subject[:parent_id]).to eq(nil)
+    end
+  end
+
+  context "when it does not have a parent identifier column" do
+    before(:each) do
+      item_hash.delete("Parent Identifier")
+    end
+
+    it "does not add a parent_id field to the hash, so that it's associations do not change" do
+      expect(subject.has_key?(:parent_id)).to eq(false)
+    end
   end
 end

--- a/spec/services/rewrite_item_metadata_fields_spec.rb
+++ b/spec/services/rewrite_item_metadata_fields_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe RewriteItemMetadata, helpers: :item_meta_helpers do
 
     it "adds an error if the parent item does not exist" do
       subject
-      expected = item_hash.keys.map { |attribute| "Unable to find parent item 'parent id'" }
+      expected = item_hash.keys.map { "Unable to find parent item 'parent id'" }
       expect(errors).to eq(expected)
     end
   end
@@ -124,7 +124,7 @@ RSpec.describe RewriteItemMetadata, helpers: :item_meta_helpers do
     end
 
     it "does not add a parent_id field to the hash, so that it's associations do not change" do
-      expect(subject.has_key?(:parent_id)).to eq(false)
+      expect(subject.key?(:parent_id)).to eq(false)
     end
   end
 end


### PR DESCRIPTION
This changes the google and csv import routines so that they can handle parent/child associations identified by a "Parent Identifier" column.

Summary of changes:
- Changed the metadata rewrite to lookup the parent by the user defined id anytime a parent is given. If the parent exists, it adds the associated parent id to the child to create the association.
- Changed any methods that call CreateItems to give parents first, then children, to make sure that new parents are created before the lookup for the child is executed.
- Since the order that the cells are read is no longer preserved when passing the data on to the lower level CreateItems service, and this service is what adds any errors encountered (including the row where it encountered it), I had to start passing the original index down. So, changed CreateItems to expect an array of objects that have the original index along with the item properties.
- If the user puts a Parent Identifier column with a null value, the expected behavior is that it will clear any existing association for that item. But, the GoogleSession#worksheet_to_hash was only extracting columns that had values. Had to change this to make an explicit exception for Parent Identifier so that if it exists in the spreadsheet, it will always pass that along to the underlying classes in order to clear the association.