### PR TITLE
DEC-1340 undo

### DIFF
--- a/app/models/waggle/adapters/solr/index/item.rb
+++ b/app/models/waggle/adapters/solr/index/item.rb
@@ -25,23 +25,11 @@ module Waggle
               hash.merge!(string_fields)
               hash.merge!(datetime_fields)
             end
-            if waggle_item.children && !waggle_item.children.empty?
-              @as_solr[:_childDocuments_] = children_field
-            end
             @as_solr[:last_updated_sort] = datetime_as_solr(waggle_item.send(:last_updated))
             @as_solr
           end
 
           private
-
-          def children_field
-            children = []
-            waggle_item.children.each do |child|
-              waggle_child = Waggle::Adapters::Solr::Index::Item.new(waggle_item: Waggle::Item.from_item(child))
-              children << waggle_child.as_solr
-            end
-            children
-          end
 
           def string_fields
             {}.tap do |hash|

--- a/app/models/waggle/adapters/solr/session.rb
+++ b/app/models/waggle/adapters/solr/session.rb
@@ -13,7 +13,7 @@ module Waggle
         end
 
         def index(*objects)
-          connection.add(parent_objects_as_solr(*objects))
+          connection.add(objects_as_solr(*objects))
         end
 
         def index!(*objects)
@@ -35,14 +35,6 @@ module Waggle
         end
 
         private
-
-        def parent_objects_as_solr(*objects)
-          # we only want to index parent objects, so if we're changing children make sure we get their parents
-          # and only index them one time
-          objects_as_solr(*objects.
-            map { |waggle_item| waggle_item.parent ? Waggle::Item.from_item(waggle_item.parent) : waggle_item }.
-            uniq(&:unique_id))
-        end
 
         def objects_as_solr(*objects)
           solr_objects(*objects).map(&:as_solr)

--- a/spec/models/waggle/adapters/solr/session_spec.rb
+++ b/spec/models/waggle/adapters/solr/session_spec.rb
@@ -43,8 +43,6 @@ RSpec.describe Waggle::Adapters::Solr::Session do
       it "maps objects to solr objects and indexes their as_solr values" do
         items.each do |waggle_item|
           expect(Waggle::Adapters::Solr::Index::Item).to receive(:new).with(waggle_item: waggle_item).and_call_original
-          expect(waggle_item).to receive(:parent).and_return(nil)
-          expect(waggle_item).to receive(:unique_id).and_return(waggle_item.id)
         end
         allow_any_instance_of(Waggle::Adapters::Solr::Index::Item).to receive(:as_solr).and_return(test: "test")
         expect(connection).to receive(:add).with([{ test: "test" }, { test: "test" }])


### PR DESCRIPTION
Indexing child relationships causes issues with the solr index in cases where the parent items exist before the relation is created.

I've removed this functionality as we will never be able to use the relation data (in the solr way) anyway.