### PR TITLE
Dec 1254 child search

### DIFF
--- a/app/controllers/v1/search_controller.rb
+++ b/app/controllers/v1/search_controller.rb
@@ -32,9 +32,7 @@ module V1
     private
 
     def collection
-      if params[:collection_id]
-        CollectionQuery.new.any_find(params[:collection_id])
-      end
+      @collection ||= params[:collection_id] ? CollectionQuery.new.any_find(params[:collection_id]) : nil
     end
   end
 end

--- a/app/controllers/v1/search_controller.rb
+++ b/app/controllers/v1/search_controller.rb
@@ -13,6 +13,22 @@ module V1
       @search = Waggle.search(**search_arguments)
     end
 
+    def children
+      group_by = params[:no_group] ? nil : "part_parent_s"
+
+      search_arguments = {
+        q: "-part_parent_s:_is_parent_ " + (params[:q] ? "AND " + params[:q] : ""),
+        facets: params[:facets],
+        sort: params[:sort],
+        rows: params[:rows],
+        start: params[:start],
+        filters: { collection_id: collection.unique_id },
+        group_by: group_by,
+        collection: collection,
+      }
+      @search = Waggle.search(**search_arguments)
+    end
+
     private
 
     def collection

--- a/app/models/waggle/adapters/solr/search/result.rb
+++ b/app/models/waggle/adapters/solr/search/result.rb
@@ -67,7 +67,7 @@ module Waggle
             @result
           end
 
-          def is_grouped
+          def grouped?
             query.group_by ? true : false
           end
 
@@ -205,7 +205,7 @@ module Waggle
           end
 
           def solr_response
-            if is_grouped
+            if grouped?
               result.fetch("grouped", {}).fetch(query.group_by, {})
             else
               result.fetch("response", {})

--- a/app/models/waggle/search/query.rb
+++ b/app/models/waggle/search/query.rb
@@ -3,15 +3,16 @@ module Waggle
     class Query
       DEFAULT_ROWS = 12
 
-      attr_reader :q, :facets, :sort, :rows, :start, :filters
+      attr_reader :q, :facets, :sort, :rows, :start, :filters, :group_by
 
-      def initialize(q:, facets: nil, sort: nil, rows: nil, start: nil, filters: {})
+      def initialize(q:, facets: nil, sort: nil, rows: nil, start: nil, filters: {}, group_by: nil)
         @q = q
         @facets = facets || {}
         @sort = sort
         @rows = (rows || DEFAULT_ROWS).to_i
         @start = (start || 0).to_i
         @filters = filters
+        @group_by = group_by
       end
 
       def configuration

--- a/app/models/waggle/search/result.rb
+++ b/app/models/waggle/search/result.rb
@@ -42,8 +42,8 @@ module Waggle
         end
       end
 
-      def is_grouped
-        adapter_result.is_grouped
+      def grouped?
+        adapter_result.grouped?
       end
 
       private

--- a/app/models/waggle/search/result.rb
+++ b/app/models/waggle/search/result.rb
@@ -11,6 +11,10 @@ module Waggle
         @hits ||= adapter_result.hits.map { |adapter_hit| Waggle::Search::Hit.new(adapter_hit) }
       end
 
+      def groups
+        @groups ||= convert_groups
+      end
+
       def start
         query.start
       end
@@ -38,7 +42,22 @@ module Waggle
         end
       end
 
+      def is_grouped
+        adapter_result.is_grouped
+      end
+
       private
+
+      def convert_groups
+        groups = []
+        adapter_result.groups.each do |group|
+          groups << {
+            id: group.fetch(:id, ""),
+            hits: group.fetch(:hits, []).map { |adapter_hit| Waggle::Search::Hit.new(adapter_hit) },
+          }
+        end
+        groups
+      end
 
       # The relevancy sort is purely for display purposes, since the default search sort is score.
       def relevancy_sort

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -4,7 +4,7 @@
 <%= render partial: 'action_bar', locals: { collection: @collection } %>
 
 <%= react_component 'SearchPage', {
-    searchUrl: v1_collection_search_index_path(@collection.unique_id),
+    searchUrl: v1_collection_search_path(@collection.unique_id),
     defaultSortField: "last_updated",
     defaultSortDirection: "desc"
   },

--- a/app/views/showcases/edit.html.erb
+++ b/app/views/showcases/edit.html.erb
@@ -4,7 +4,7 @@
 <%= render partial: 'edit_action_bar' %>
 
 <%= react_component 'ShowcaseEditor', {
-      itemSearchUrl: v1_collection_search_index_path(@showcase.collection.unique_id),
+      itemSearchUrl: v1_collection_search_path(@showcase.collection.unique_id),
       sectionsCreatePath: showcase_sections_path(@showcase, :json),
       showcaseJSONPath: showcase_path(@showcase.unique_id, :json),
     },

--- a/app/views/v1/search/_group.json.jbuilder
+++ b/app/views/v1/search/_group.json.jbuilder
@@ -1,0 +1,4 @@
+json.groupId group.fetch(:id, "")
+json.hits group.fetch(:hits, []) do |hit|
+  json.partial! "v1/search/hit", hit: hit
+end

--- a/app/views/v1/search/_group.json.jbuilder
+++ b/app/views/v1/search/_group.json.jbuilder
@@ -1,4 +1,5 @@
-json.groupId group.fetch(:id, "")
+json.set! "@type", "SearchHitParent"
+json.set! "@id", group.fetch(:id, "")
 json.hits group.fetch(:hits, []) do |hit|
   json.partial! "v1/search/hit", hit: hit
 end

--- a/app/views/v1/search/children.json.jbuilder
+++ b/app/views/v1/search/children.json.jbuilder
@@ -2,7 +2,7 @@ json.set! "@type", "SearchResult"
 json.hits do
   json.found @search.total
   json.start @search.start
-  if @search.is_grouped
+  if @search.grouped?
     json.group @search.groups do |group|
       json.partial! "v1/search/group", group: group
     end

--- a/app/views/v1/search/children.json.jbuilder
+++ b/app/views/v1/search/children.json.jbuilder
@@ -1,0 +1,20 @@
+json.set! "@type", "SearchResult"
+json.hits do
+  json.found @search.total
+  json.start @search.start
+  if @search.is_grouped
+    json.group @search.groups do |group|
+      json.partial! "v1/search/group", group: group
+    end
+  else
+    json.hit @search.hits do |hit|
+      json.partial! "v1/search/hit", hit: hit
+    end
+  end
+end
+json.facets @search.facets do |facet|
+  json.partial! "v1/search/facet", facet: facet
+end
+json.sorts @search.sorts do |sort_field|
+  json.partial! "v1/search/sort_field", sort_field: sort_field
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -80,7 +80,8 @@ Rails.application.routes.draw do
       get :site_path, defaults: { format: :json }
       put :site_path, to: "collections#site_path_update", defaults: { format: :json }
       post :import_csv, to: "import#csv"
-      resources :search, only: [:index], defaults: { format: :json }
+      get :search, to: "search#index", defaults: { format: :json }
+      get :children, path: "search/children", to: "search#children", defaults: { format: :json }
       resources :items, only: [:index, :create], defaults: { format: :json }
       resources :showcases, only: [:index], defaults: { format: :json }
       resources :pages, only: [:index], defaults: { format: :json }

--- a/config/style_guides/.ruby-style.yml
+++ b/config/style_guides/.ruby-style.yml
@@ -545,7 +545,7 @@ Style/NumericLiterals:
                  Add underscores to large numeric literals to improve their
                  readability.
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#underscores-in-numerics'
-  Enabled: true
+  Enabled: false
 
 Style/NumericLiteralPrefix:
   Description: 'Use smallcase prefixes for numeric literals.'

--- a/spec/controllers/v1/search_controller_spec.rb
+++ b/spec/controllers/v1/search_controller_spec.rb
@@ -10,27 +10,28 @@ RSpec.describe V1::SearchController, type: :controller do
   end
 
   describe "#index" do
-    let(:expected) do {
-      collection: collection,
-      filters: { collection_id: collection.unique_id },
-      q: "query",
-      facets: "none",
-      sort: "score desc",
-      rows: 30,
-      start: 0,
-    }
+    let(:expected) do
+      {
+        collection: collection,
+        filters: { collection_id: collection.unique_id },
+        q: "query",
+        facets: "none",
+        sort: "score desc",
+        rows: 30,
+        start: 0,
+      }
     end
 
-    subject {
+    subject do
       get :index,
-      collection_id: collection.id,
-      q: "query",
-      facets: "none",
-      sort: "score desc",
-      rows: 30,
-      start: 0,
-      format: :json
-    }
+          collection_id: collection.id,
+          q: "query",
+          facets: "none",
+          sort: "score desc",
+          rows: 30,
+          start: 0,
+          format: :json
+    end
 
     it "calls CollectionQuery" do
       expect_any_instance_of(CollectionQuery).to receive(:any_find).with(collection.id).and_return(collection)
@@ -49,29 +50,30 @@ RSpec.describe V1::SearchController, type: :controller do
     let(:group_field) { "part_parent_s" }
 
     describe "all arguments defined" do
-      let(:expected) do {
-        collection: collection,
-        filters: { collection_id: collection.unique_id },
-        q: "-" + group_field + ":_is_parent_ AND query",
-        facets: "none",
-        sort: "score desc",
-        rows: 30,
-        start: 0,
-        group_by: nil
-      }
+      let(:expected) do
+        {
+          collection: collection,
+          filters: { collection_id: collection.unique_id },
+          q: "-" + group_field + ":_is_parent_ AND query",
+          facets: "none",
+          sort: "score desc",
+          rows: 30,
+          start: 0,
+          group_by: nil
+        }
       end
 
-      subject {
+      subject do
         get :children,
-        collection_id: collection.id,
-        q: "query",
-        facets: "none",
-        sort: "score desc",
-        rows: 30,
-        start: 0,
-        no_group: true,
-        format: :json
-      }
+            collection_id: collection.id,
+            q: "query",
+            facets: "none",
+            sort: "score desc",
+            rows: 30,
+            start: 0,
+            no_group: true,
+            format: :json
+      end
 
       it "calls CollectionQuery" do
         expect_any_instance_of(CollectionQuery).to receive(:any_find).with(collection.id).and_return(collection)
@@ -87,27 +89,28 @@ RSpec.describe V1::SearchController, type: :controller do
     end
 
     describe "groups with no query" do
-      let(:expected) do {
-        collection: collection,
-        filters: { collection_id: collection.unique_id },
-        q: "-" + group_field + ":_is_parent_ ",
-        facets: "none",
-        sort: "score desc",
-        rows: 30,
-        start: 0,
-        group_by: group_field
-      }
+      let(:expected) do
+        {
+          collection: collection,
+          filters: { collection_id: collection.unique_id },
+          q: "-" + group_field + ":_is_parent_ ",
+          facets: "none",
+          sort: "score desc",
+          rows: 30,
+          start: 0,
+          group_by: group_field
+        }
       end
 
-      subject {
+      subject do
         get :children,
-        collection_id: collection.id,
-        facets: "none",
-        sort: "score desc",
-        rows: 30,
-        start: 0,
-        format: :json
-      }
+            collection_id: collection.id,
+            facets: "none",
+            sort: "score desc",
+            rows: 30,
+            start: 0,
+            format: :json
+      end
 
       it "passes arguments correctly" do
         expect(Waggle).to receive(:search).with(expected)

--- a/spec/controllers/v1/search_controller_spec.rb
+++ b/spec/controllers/v1/search_controller_spec.rb
@@ -1,0 +1,120 @@
+require "rails_helper"
+require "cache_spec_helper"
+
+RSpec.describe V1::SearchController, type: :controller do
+  let(:collection_configuration) { double(CollectionConfiguration) }
+  let(:collection) { instance_double(Collection, id: "1", unique_id: "3", updated_at: nil, items: nil, collection_configuration: collection_configuration) }
+
+  before(:each) do
+    allow_any_instance_of(CollectionQuery).to receive(:any_find).and_return(collection)
+  end
+
+  describe "#index" do
+    let(:expected) do {
+      collection: collection,
+      filters: { collection_id: collection.unique_id },
+      q: "query",
+      facets: "none",
+      sort: "score desc",
+      rows: 30,
+      start: 0,
+    }
+    end
+
+    subject {
+      get :index,
+      collection_id: collection.id,
+      q: "query",
+      facets: "none",
+      sort: "score desc",
+      rows: 30,
+      start: 0,
+      format: :json
+    }
+
+    it "calls CollectionQuery" do
+      expect_any_instance_of(CollectionQuery).to receive(:any_find).with(collection.id).and_return(collection)
+
+      subject
+    end
+
+    it "passes arguments correctly" do
+      expect(Waggle).to receive(:search).with(expected)
+
+      subject
+    end
+  end
+
+  context "#children" do
+    let(:group_field) { "part_parent_s" }
+
+    describe "all arguments defined" do
+      let(:expected) do {
+        collection: collection,
+        filters: { collection_id: collection.unique_id },
+        q: "-" + group_field + ":_is_parent_ AND query",
+        facets: "none",
+        sort: "score desc",
+        rows: 30,
+        start: 0,
+        group_by: nil
+      }
+      end
+
+      subject {
+        get :children,
+        collection_id: collection.id,
+        q: "query",
+        facets: "none",
+        sort: "score desc",
+        rows: 30,
+        start: 0,
+        no_group: true,
+        format: :json
+      }
+
+      it "calls CollectionQuery" do
+        expect_any_instance_of(CollectionQuery).to receive(:any_find).with(collection.id).and_return(collection)
+
+        subject
+      end
+
+      it "passes arguments correctly" do
+        expect(Waggle).to receive(:search).with(expected)
+
+        subject
+      end
+    end
+
+    describe "groups with no query" do
+      let(:expected) do {
+        collection: collection,
+        filters: { collection_id: collection.unique_id },
+        q: "-" + group_field + ":_is_parent_ ",
+        facets: "none",
+        sort: "score desc",
+        rows: 30,
+        start: 0,
+        group_by: group_field
+      }
+      end
+
+      subject {
+        get :children,
+        collection_id: collection.id,
+        facets: "none",
+        sort: "score desc",
+        rows: 30,
+        start: 0,
+        format: :json
+      }
+
+      it "passes arguments correctly" do
+        expect(Waggle).to receive(:search).with(expected)
+
+        subject
+      end
+    end
+
+  end
+end

--- a/spec/fixtures/waggle/solr_grouped_response.json
+++ b/spec/fixtures/waggle/solr_grouped_response.json
@@ -1,0 +1,104 @@
+{
+  "responseHeader": {
+    "status": 0,
+    "QTime": 1,
+    "params": {
+      "q": "-part_parent_s:_is_parent_ AND test",
+      "defType": "edismax",
+      "facet.field": "{!ex=creator_facet}creator_facet, {!ex=language_facet}language_facet",
+      "indent": "on",
+      "fl": "score *",
+      "fq": "collection_id_s:b18c4efca0",
+      "sort": "score desc",
+      "facet": "on",
+      "wt": "json",
+      "group.field": "part_parent_s",
+      "group": "true"
+    }
+  },
+  "grouped": {
+    "part_parent_s": {
+      "matches": 2,
+      "groups": [
+        {
+          "groupValue": "http://localhost:3017/v1/items/43d48988c4",
+          "doclist": {
+            "numFound": 1,
+            "start": 0,
+            "maxScore": 9.3233795,
+            "docs": [
+              {
+                "name_t": [
+                  "metaonly"
+                ],
+                "description_t": [
+                  "coffee"
+                ],
+                "b5d95b26-c8b2-4f34-bea0-b47af22dd921_t": [
+                  "test"
+                ],
+                "id": "b18c4efca0 a4acc9ccf7",
+                "title_t": [
+                  "metaonly"
+                ],
+                "at_id_s": "http://localhost:3017/v1/items/a4acc9ccf7",
+                "unique_id_s": "a4acc9ccf7",
+                "collection_id_s": "b18c4efca0",
+                "type_s": "Metadata Only",
+                "part_parent_s": "http://localhost:3017/v1/items/43d48988c4",
+                "last_updated_dt": "2017-01-06T18:06:02Z",
+                "last_updated_sort": "2017-01-06T18:06:02Z",
+                "_version_": 1556237965715308500,
+                "score": 9.3233795
+              }
+            ]
+          }
+        },
+        {
+          "groupValue": "http://localhost:3017/v1/items/37d40eefdf",
+          "doclist": {
+            "numFound": 1,
+            "start": 0,
+            "maxScore": 8.415446,
+            "docs": [
+              {
+                "name_t": [
+                  "Paint on a Drum Slow Mo"
+                ],
+                "b5d95b26-c8b2-4f34-bea0-b47af22dd921_t": [
+                  "test"
+                ],
+                "c0d8ceb4-1c19-4e81-b6cc-8ecdb1bb3c8b_t": [
+                  "The Slow Mo Guys"
+                ],
+                "id": "b18c4efca0 e43f31ab38",
+                "title_t": [
+                  "Paint on a Drum Slow Mo"
+                ],
+                "at_id_s": "http://localhost:3017/v1/items/e43f31ab38",
+                "unique_id_s": "e43f31ab38",
+                "collection_id_s": "b18c4efca0",
+                "type_s": "VideoObject",
+                "thumbnail_url_s": "http://localhost:3019/images/honeycomb/000/029/031/473/medium/RackMultipart20161118-39665-i1oua4.jpg",
+                "part_parent_s": "http://localhost:3017/v1/items/37d40eefdf",
+                "last_updated_dt": "2017-01-06T20:37:14Z",
+                "last_updated_sort": "2017-01-06T20:37:14Z",
+                "_version_": 1556237965714260000,
+                "score": 8.415446
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "facet_counts": {
+    "facet_queries": {},
+    "facet_fields": {
+      "creator_facet": [], "language_facet": []
+    },
+    "facet_ranges": {},
+    "facet_intervals": {},
+    "facet_heatmaps": {}
+  }
+}

--- a/spec/models/waggle/adapters/solr/search/result_spec.rb
+++ b/spec/models/waggle/adapters/solr/search/result_spec.rb
@@ -79,7 +79,8 @@ RSpec.describe Waggle::Adapters::Solr::Search::Result do
         q: "-part_parent_s:_is_parent_ AND a query",
         group: true,
         :"group.field" => "part_parent_s",
-        :"group.limit" => 99999)
+        :"group.limit" => 99999
+      )
 
       expect(subject.send(:connection)).to receive(:paginate).with(
         2,
@@ -114,7 +115,7 @@ RSpec.describe Waggle::Adapters::Solr::Search::Result do
     it "returns the expected params" do
       allow(instance).to receive(:solr_phrase_fields).and_return("phrase_fields")
       allow(instance).to receive(:solr_query_fields).and_return("query_fields")
-      allow(instance).to receive(:group).and_return({group: "group_info"})
+      allow(instance).to receive(:group).and_return(group: "group_info")
       expect(subject).to eq(
         q: "query",
         fl: "score *",

--- a/spec/models/waggle/adapters/solr/search/result_spec.rb
+++ b/spec/models/waggle/adapters/solr/search/result_spec.rb
@@ -75,7 +75,8 @@ RSpec.describe Waggle::Adapters::Solr::Search::Result do
     it "sends the expected arguments to solr for children" do
       expect(subject).to receive(:page).exactly(2).times.and_return(2)
       expect(subject).to receive(:per_page).and_return(15)
-      expect(subject).to receive(:solr_params).exactly(2).times.and_return(q: "-part_parent_s:_is_parent_ AND a query",
+      expect(subject).to receive(:solr_params).exactly(2).times.and_return(
+        q: "-part_parent_s:_is_parent_ AND a query",
         group: true,
         :"group.field" => "part_parent_s",
         :"group.limit" => 99999)

--- a/spec/models/waggle/adapters/solr/search/result_spec.rb
+++ b/spec/models/waggle/adapters/solr/search/result_spec.rb
@@ -92,6 +92,12 @@ RSpec.describe Waggle::Adapters::Solr::Search::Result do
         expect(subject.groups).to be_kind_of(Array)
         expect(subject.groups.first).to be_kind_of(Hash)
       end
+
+      it "has the correct grouped keys" do
+        expect(subject.groups.first).to have_key(:id)
+        expect(subject.groups.first).to have_key(:hits)
+        expect(subject.groups.first.fetch(:hits)).to be_kind_of(Array)
+      end
     end
   end
 

--- a/spec/models/waggle/search/query_spec.rb
+++ b/spec/models/waggle/search/query_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe Waggle::Search::Query do
       sort: "sort",
       rows: 20,
       start: 40,
-      filters: { collection_id: "collection_id" }
+      filters: { collection_id: "collection_id" },
+      group_by: "group_field",
     }
   end
   let(:configuration) { double(Metadata::Configuration, fields: [], facets: [facet], sort: sort) }

--- a/spec/models/waggle/search/result_spec.rb
+++ b/spec/models/waggle/search/result_spec.rb
@@ -24,6 +24,18 @@ RSpec.describe Waggle::Search::Result do
     end
   end
 
+  describe "groups" do
+    it "returns grouped state" do
+      expect(adapter_result).to receive(:is_grouped).and_return(true)
+      expect(subject.is_grouped).to eq(true)
+    end
+
+    it "is the results groups" do
+      expect(adapter_result).to receive(:groups).and_return([{ id: 0, hits: [] }])
+      expect(subject.groups).to eq([{ id: 0, hits: [] }])
+    end
+  end
+
   describe "rows" do
     it "is the query rows" do
       expect(query).to receive(:rows).and_return(15)

--- a/spec/models/waggle/search/result_spec.rb
+++ b/spec/models/waggle/search/result_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe Waggle::Search::Result do
 
   describe "groups" do
     it "returns grouped state" do
-      expect(adapter_result).to receive(:is_grouped).and_return(true)
-      expect(subject.is_grouped).to eq(true)
+      expect(adapter_result).to receive(:grouped?).and_return(true)
+      expect(subject.grouped?).to eq(true)
     end
 
     it "is the results groups" do


### PR DESCRIPTION
Add the `../search/children` route to search only the children items of a collection.

By default, the resulting hits are returned grouped by the parent id. This can be turned off to return flat hits by adding the parameter `no_group=true` to the url.