### PR TITLE
DEC-1261 Relation Depth Validation

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -12,6 +12,7 @@ class Item < ActiveRecord::Base
 
   validates :collection, :unique_id, :user_defined_id, presence: true
   validate :manuscript_url_is_valid_uri
+  validate :relation_depth_of_1
 
   def name
     item_metadata.name
@@ -30,6 +31,12 @@ class Item < ActiveRecord::Base
   end
 
   private
+
+  def relation_depth_of_1
+    if parent.present? && parent.parent.present?
+      errors.add(:parent, "Must be depth of 1, parent can't have a parent")
+    end
+  end
 
   def manuscript_url_is_valid_uri
     if manuscript_url.present? && !URIParser.valid?(manuscript_url)

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -34,7 +34,7 @@ class Item < ActiveRecord::Base
 
   def relation_depth_of_1
     if parent.present? && parent.parent.present?
-      errors.add(:parent, "Must be depth of 1, parent can't have a parent")
+      errors.add(:parent, "This item is a child of a child, which is not supported. Please ensure that item relationships are only one level deep.")
     end
   end
 

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -71,6 +71,13 @@ RSpec.describe Item do
     expect(subject.parent).to be_nil
   end
 
+  it "doesn't allow a relation depth greater than 1" do
+    FactoryGirl.create(:collection)
+    FactoryGirl.create(:item, user_defined_id: "one", unique_id: 1, id: 1)
+    FactoryGirl.create(:item, id: 2, unique_id: 2, user_defined_id: 'two', parent_id: 1)
+    expect { FactoryGirl.create(:item, id: 3, unique_id: 3, user_defined_id: 'three', parent_id: 2) }.to raise_error
+  end
+
   it "has children" do
     expect(subject).to respond_to(:children)
     expect(subject.children).to eq([])


### PR DESCRIPTION
We needed to validate that the depth of our relation tree is only 1.

In my timings this added ~20 seconds to the import of the Catholic Social Teachings collection of ~7000 items.