### PR TITLE
Clear collection

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -10,4 +10,24 @@ namespace :db do
     Rake::Task["db:test:prepare"].invoke
     Rake::Task["db:seed"].invoke
   end
+
+  desc "Empties a collection's items, showcases, and pages. Similar to Destroy::Collection, but leaves the configuration and editors in tact."
+  task :empty_collection, [:collection_id] => :environment do |_t, args|
+    destroy_showcase = Destroy::Showcase.new
+    destroy_item = Destroy::Item.new
+    destroy_page = Destroy::Page.new
+    collection = Collection.find(args[:collection_id])
+
+    ActiveRecord::Base.transaction do
+      collection.showcases.each do |child|
+        destroy_showcase.force_cascade!(showcase: child)
+      end
+      collection.items.each do |child|
+        destroy_item.cascade!(item: child)
+      end
+      collection.pages.each do |child|
+        destroy_page.force_cascade!(page: child)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Created a rake task to clear out a collection. Eventually it might make sense to have this as an actual service that can be reached from some admin function on a collection, but I didn't want to touch app code for this since we're limited on time.