### PR TITLE
Addressing `NoMethodError: undefined method `admin?' for nil:NilClass`

### DIFF
--- a/app/policy/user_is_admin.rb
+++ b/app/policy/user_is_admin.rb
@@ -8,6 +8,7 @@ class UserIsAdmin
   end
 
   def is_admin?
+    return false unless @user
     @user.admin?
   end
 end

--- a/spec/policy/user_is_admin_spec.rb
+++ b/spec/policy/user_is_admin_spec.rb
@@ -11,4 +11,8 @@ describe UserIsAdmin do
     expect(user).to receive(:admin?).and_return(false)
     expect(subject).to be(false)
   end
+
+  it "returns false when there is no User" do
+    expect(described_class.call(nil)).to be(false)
+  end
 end


### PR DESCRIPTION
This exception shows up in our Errbit logs. By adding a guard clause,
we will stop throwing exceptions.