### PR TITLE
Disregard facet amount limit when fetching facet values for search.

### DIFF
--- a/app/models/waggle/adapters/solr/search/result.rb
+++ b/app/models/waggle/adapters/solr/search/result.rb
@@ -138,7 +138,7 @@ module Waggle
           def facet_limits
             result = {}
             configuration.facets.each do |facet|
-              result[:"f.#{facet.name}_facet.facet.limit"] = facet.limit if facet.limit.present?
+              result[:"f.#{facet.name}_facet.facet.limit"] = 9999
             end
             result
           end


### PR DESCRIPTION
Limit will be applied by UI only.