### PR TITLE
DEC-1447 Implement UI for selecting facets

### DIFF
--- a/app/assets/javascripts/components/forms/MetaDataConfigurationForm/MetaDataConfigurationEventTypes.jsx
+++ b/app/assets/javascripts/components/forms/MetaDataConfigurationForm/MetaDataConfigurationEventTypes.jsx
@@ -1,6 +1,8 @@
 var Types = {
   MetaDataConfigurationDnD: "MetaDataConfigurationDnD",
   CardDroppedOnTarget: "SiteObjectCardDroppedOnTarget",
+  FacetDnD: "FacetDnD",
+  FacetDroppedOnTarget: "FacetDroppedOnTarget",
 };
 
 module.exports = Types;

--- a/app/assets/javascripts/components/forms/MetaDataConfigurationForm/MetaDataConfigurationFacetItem.jsx
+++ b/app/assets/javascripts/components/forms/MetaDataConfigurationForm/MetaDataConfigurationFacetItem.jsx
@@ -1,0 +1,77 @@
+const React = require("react")
+const mui = require("material-ui")
+const Colors = require("material-ui/lib/styles/colors")
+const DragSource = require('react-dnd').DragSource
+const EventEmitter = require('../../../EventEmitter')
+const MetadataConfigurationEventTypes = require("./MetaDataConfigurationEventTypes")
+
+const ListItem = mui.ListItem
+const FontIcon = mui.FontIcon
+const IconButton = mui.IconButton
+
+const metadataCollectionSource = {
+  beginDrag: function (props, monitor, component) {
+    return props
+  },
+
+  endDrag: function (props, monitor, component) {
+    if (monitor.didDrop()) {
+      const item = monitor.getItem()
+      const dropResult = monitor.getDropResult()
+      EventEmitter.emit(MetadataConfigurationEventTypes.FacetDroppedOnTarget, dropResult, item)
+    }
+  }
+}
+
+function source_collect(connect, monitor) {
+  return {
+    connectDragSource: connect.dragSource(),
+    connectDragPreview: connect.dragPreview(),
+    isDragging: monitor.isDragging(),
+  }
+}
+
+const MetaDataConfigurationFacetItem = React.createClass({
+  propTypes: {
+    facet: React.PropTypes.shape({
+      name: React.PropTypes.string,
+      label: React.PropTypes.string,
+      limit: React.PropTypes.number,
+      field: React.PropTypes.shape({
+        name: React.PropTypes.string,
+        label: React.PropTypes.string,
+        type: React.PropTypes.string.isRequired,
+      }).isRequired,
+    }).isRequired,
+    handleEditClick: React.PropTypes.func.isRequired,
+    handleRemoveClick: React.PropTypes.func.isRequired,
+    index: React.PropTypes.number.isRequired,
+  },
+
+  render() {
+    const name = this.props.facet.name || this.props.facet.field.name
+    const label = this.props.facet.label || this.props.facet.field.label
+    const { connectDragSource, connectDragPreview, isDragging } = this.props
+
+    const reorderHandle = connectDragSource(
+      <div><FontIcon className='material-icons' style={{ cursor: 'move', marginRight: '24px' }}>reorder</FontIcon></div>
+    )
+    return (
+      <mui.Paper>
+        {connectDragPreview(
+          <div onClick={(event) => this.props.handleEditClick(this.props.facet, event)} className='facet-list-item'>
+            <div className='left-side'>
+              {reorderHandle}
+              {label}
+            </div>
+            <IconButton onTouchTap={() => this.props.handleRemoveClick(name)}>
+              <FontIcon className='material-icons' color={Colors.grey500} hoverColor={Colors.red500}>delete</FontIcon>
+            </IconButton>
+          </div>
+        )}
+      </mui.Paper>
+    )
+  }
+})
+
+module.exports = DragSource(MetadataConfigurationEventTypes.FacetDnD, metadataCollectionSource, source_collect)(MetaDataConfigurationFacetItem)

--- a/app/assets/javascripts/components/forms/MetaDataConfigurationForm/MetaDataConfigurationFacets.jsx
+++ b/app/assets/javascripts/components/forms/MetaDataConfigurationForm/MetaDataConfigurationFacets.jsx
@@ -1,0 +1,164 @@
+const React = require("react")
+const mui = require("material-ui")
+
+const ReactLink = require('react/lib/ReactLink')
+const ReactStateSetters = require('react/lib/ReactStateSetters')
+const update = require('react/lib/update')
+
+const MetaDataConfigurationFacetItem = require("./MetaDataConfigurationFacetItem")
+const MetadataConfigurationEventTypes = require("./MetaDataConfigurationEventTypes")
+const MetaDataConfigurationActions = require("../../../actions/MetaDataConfigurationActions")
+const MetaDataFacetDialog = require("../MetaDataFacetDialog")
+const AvailableDropTarget = StylableDropTarget(MetadataConfigurationEventTypes.FacetDnD)
+
+const Colors = require("material-ui/lib/styles/colors")
+const MoreVertIcons = require("material-ui/lib/svg-icons/navigation/more-vert")
+const FloatingActionButton = require("material-ui/lib/floating-action-button")
+const ContentAdd = require("material-ui/lib/svg-icons/content/add")
+
+const Paper = mui.Paper
+const List = mui.List
+const Toggle = mui.Toggle
+const Toolbar = mui.Toolbar
+const ToolbarGroup = mui.ToolbarGroup
+const ToolbarTitle = mui.ToolbarTitle
+const FontIcon = mui.FontIcon
+
+const listStyle = {
+  paddingBottom: "0px",
+}
+
+const addButtonStyle = {
+  position: "absolute",
+  top: "-16px",
+  left: "8px",
+  zIndex: "1"
+}
+
+const MetaDataConfigurationFacets = React.createClass({
+  propTypes: {
+    baseUpdateUrl: React.PropTypes.string.isRequired,
+  },
+
+  getInitialState() {
+    return {
+      facets: this.filteredFacets(false),
+      selectedFacet: undefined,
+    }
+  },
+
+  componentDidMount() {
+    EventEmitter.on(MetadataConfigurationEventTypes.FacetDroppedOnTarget, this.handleDrop)
+    MetaDataConfigurationStore.on("MetaDataConfigurationStoreChanged", this.setFormFacetsFromConfiguration)
+    MetaDataConfigurationStore.getAll()
+  },
+
+  setFormFacetsFromConfiguration() {
+    this.setState({
+      facets: this.filteredFacets(this.state.showInactive),
+      selectedFacet: undefined,
+    })
+  },
+
+  filteredFacets(showInactive) {
+    const facets = _.filter(MetaDataConfigurationStore.facets, (facet) => showInactive || facet.active)
+    return _.sortBy(facets, 'order')
+  },
+
+  handleNewClick() {
+    this.setState({ selectedFacet: '' })
+  },
+
+
+  handleEditClick(facet, event) {
+    // Ignore the click if it was on the drag icon
+    if (!event.target.classList.contains('material-icons')) {
+      this.setState({ selectedFacet: facet.name || facet.field.name })
+    }
+  },
+
+  handleRemove(facetName) {
+    MetaDataConfigurationActions.removeFacet(facetName, this.props.baseUpdateUrl)
+  },
+
+  handleClose() {
+    this.setState({ selectedFacet: undefined })
+  },
+
+  handleDrop(target, source) {
+    const fromIndex = source.index
+    const toIndex = target.index
+
+    if (fromIndex === toIndex) {
+      return
+    }
+    let removeIndex = fromIndex;
+    if (toIndex < fromIndex) {
+      removeIndex++;
+    }
+
+    this.setState(update(this.state, {
+      facets: {
+        $splice: [
+          [toIndex, 0, source.facet],
+          [removeIndex, 1],
+        ]
+      }
+    }), this.pushChanges)
+  },
+
+  pushChanges() {
+    const reorder = this.state.facets.map((facet, index) => {
+      return { name: facet.name, order: index+1 }
+    })
+    MetaDataConfigurationActions.reorderFacets(reorder, this.props.baseUpdateUrl)
+  },
+
+  render() {
+    return (
+      <div>
+        <FloatingActionButton onMouseDown={this.handleNewClick} onTouchStart={this.handleNewClick} mini={true} style={addButtonStyle}>
+          <ContentAdd />
+        </FloatingActionButton>
+        <MetaDataFacetDialog
+          facetName={this.state.selectedFacet}
+          open={this.state.selectedFacet != undefined}
+          baseUpdateUrl={this.props.baseUpdateUrl}
+          handleClose={this.handleClose}
+        />
+        <p style={{ textAlign: 'center', paddingTop: '15px', marginBottom: '0px' }}>
+          Drag and drop facets using
+          <FontIcon className='material-icons' style={{ verticalAlign: 'bottom' }}>reorder</FontIcon>
+          to reorder.
+          Click item to edit.
+        </p>
+        <List style={listStyle}>
+          <AvailableDropTarget
+            className="metadata-configuration-target"
+            dragClassName="metadata-configuration-target-ondrag"
+            hoverClassName="metadata-configuration-target-onhover"
+            data={{ index: 0 }}
+          />
+          {this.state.facets.map((facet, index) => (
+            <div key={facet.name}>
+              <MetaDataConfigurationFacetItem
+                facet={facet}
+                handleEditClick={this.handleEditClick}
+                handleRemoveClick={this.handleRemove}
+                index={index}
+              />
+              <AvailableDropTarget
+                className="metadata-configuration-target"
+                dragClassName="metadata-configuration-target-ondrag"
+                hoverClassName="metadata-configuration-target-onhover"
+                data={{ index: index+1 }}
+              />
+            </div>
+          ))}
+        </List>
+      </div>
+    )
+  },
+})
+
+module.exports = MetaDataConfigurationFacets

--- a/app/assets/javascripts/components/forms/MetaDataConfigurationForm/MetaDataConfigurationForm.jsx
+++ b/app/assets/javascripts/components/forms/MetaDataConfigurationForm/MetaDataConfigurationForm.jsx
@@ -6,6 +6,7 @@ var DragDropContext = require('react-dnd').DragDropContext;
 
 var MetaDataConfigurationList = require("./MetaDataConfigurationList");
 var MetaDataConfigurationReorder = require("./MetaDataConfigurationReorder");
+var MetaDataConfigurationFacets = require("./MetaDataConfigurationFacets");
 var MetaDataConfigurationUndelete = require("./MetaDataConfigurationUndelete");
 
 var Tabs = mui.Tabs;
@@ -19,6 +20,7 @@ var TabsStyle = {
 var MetaDataConfigurationForm = React.createClass({
   propTypes: {
     baseUpdateUrl: React.PropTypes.string.isRequired,
+    facetUpdateUrl: React.PropTypes.string.isRequired,
   },
 
   render: function(){
@@ -29,6 +31,9 @@ var MetaDataConfigurationForm = React.createClass({
         </Tab>
         <Tab label="Reorder" style={TabStyle}>
           <MetaDataConfigurationReorder baseUpdateUrl={this.props.baseUpdateUrl} />
+        </Tab>
+        <Tab label="Facets" style={TabStyle}>
+          <MetaDataConfigurationFacets baseUpdateUrl={this.props.facetUpdateUrl} />
         </Tab>
         <Tab label="Undelete" style={TabStyle}>
           <MetaDataConfigurationUndelete baseUpdateUrl={this.props.baseUpdateUrl} />

--- a/app/assets/javascripts/components/forms/MetaDataConfigurationForm/MetaDataConfigurationList.jsx
+++ b/app/assets/javascripts/components/forms/MetaDataConfigurationForm/MetaDataConfigurationList.jsx
@@ -77,13 +77,11 @@ var MetaDataConfigurationList = React.createClass({
   },
 
   getFieldItems: function() {
-    return this.state.fields.map(function(field, index) {
+    return this.state.fields.map(function(field) {
       return [
       <MetaDataConfigurationListItem
         key={ field.name }
-        id={ field.id }
         field={ field }
-        index={ index }
         handleEditClick={ this.handleEditClick }
         handleRightClick={ this.handleRemove } />,
       ];

--- a/app/assets/javascripts/components/forms/MetaDataConfigurationForm/MetaDataConfigurationListItem.jsx
+++ b/app/assets/javascripts/components/forms/MetaDataConfigurationForm/MetaDataConfigurationListItem.jsx
@@ -9,9 +9,7 @@ var IconButton = mui.IconButton;
 
 var MetaDataConfigurationListItem = React.createClass({
   propTypes: {
-    id: React.PropTypes.number.isRequired,
     field: React.PropTypes.object.isRequired,
-    index: React.PropTypes.number,
     handleEditClick: React.PropTypes.func.isRequired,
     handleRightClick: React.PropTypes.func.isRequired,
   },

--- a/app/assets/javascripts/components/forms/MetaDataConfigurationForm/MetaDataConfigurationUndelete.jsx
+++ b/app/assets/javascripts/components/forms/MetaDataConfigurationForm/MetaDataConfigurationUndelete.jsx
@@ -71,13 +71,11 @@ var MetaDataConfigurationUndelete = React.createClass({
     if (this.state.fields.length == 0) {
       return <p>There are no fields to undelete.</p>
     } else {
-      return this.state.fields.map(function(field, index) {
+      return this.state.fields.map(function(field) {
         return [
         <MetaDataConfigurationListItem
           key={ field.name }
-          id={ field.id }
           field={ field }
-          index={ index }
           handleEditClick={ this.handleEditClick }
           handleRightClick={ this.handleRestore } />,
         ];

--- a/app/assets/javascripts/components/forms/MetaDataFacetDialog.jsx
+++ b/app/assets/javascripts/components/forms/MetaDataFacetDialog.jsx
@@ -1,0 +1,261 @@
+const React = require('react')
+const mui = require('material-ui')
+const Dialog = mui.Dialog
+const RaisedButton = mui.RaisedButton
+const FlatButton = mui.FlatButton
+const update = require('react-addons-update')
+const ReactLink = require('react/lib/ReactLink')
+const ReactStateSetters = require('react/lib/ReactStateSetters')
+const MetaDataConfigurationActions = require('../../actions/MetaDataConfigurationActions')
+const MetaDataConfigurationActionTypes = require('../../constants/MetaDataConfigurationActionTypes')
+const AppEventEmitter = require("../../EventEmitter")
+
+const MetaDataFacetDialog = React.createClass({
+  mixins: [MuiThemeMixin],
+
+  propTypes: {
+    open: React.PropTypes.bool.isRequired,
+    createForm: React.PropTypes.bool,
+    baseUpdateUrl: React.PropTypes.string.isRequired,
+    facetName: React.PropTypes.string,
+  },
+
+  getInitialState() {
+    return {
+      open: this.props.open,
+      facetName: this.props.facetName,
+      saving: false,
+      createForm: false,
+      errors: {
+        field: '',
+        limit: '',
+      },
+    }
+  },
+
+  componentWillMount() {
+    MetaDataConfigurationActions.on('ChangeFacetFinished', this.handleSaved)
+    MetaDataConfigurationActions.on('CreateFacetFinished', this.handleSaved)
+  },
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.open) {
+      // Clone store field values, otherwise the linked states will directly change the store
+      let facetValues
+      let createFrom
+      const match = MetaDataConfigurationStore.facets.find(facet => facet.name === nextProps.facetName)
+      if (match) {
+        facetValues = match
+        createFrom = false
+        // Set the unlimited box to checked when opening dialog if limit is zero
+        if (facetValues.limit === 0 && nextProps.open && !this.props.open) {
+          facetValues.unlimited = true
+        }
+      } else {
+        facetValues = _. mapObject(_.find(MetaDataConfigurationStore.facets), function() { return null })
+        createFrom = true
+      }
+      this.setState({
+        open: nextProps.open,
+        facetName: nextProps.facetName,
+        facetValues: facetValues,
+        createForm: createFrom,
+      })
+    }
+  },
+
+  componentDidUpdate(prevProps, prevState) {
+    if (this.state.open) {
+      this.refs.EditMetaDialog.show()
+    } else {
+      this.refs.EditMetaDialog.dismiss()
+    }
+  },
+
+  // Creating custom react link so that we can store the field values
+  // in state.facetValues instead of flat within state, in order
+  // to easily serialize this to json when updating the store.
+  linkFacetState(key) {
+    return new ReactLink(
+      this.state['facetValues'][key],
+      function(value) { this.updateFieldValue(key, value) }.bind(this)
+    )
+  },
+
+  // Updates a specific value within state.facetValues
+  updateFieldValue(key, value) {
+    const kvp = {}
+    kvp[key] = value
+    if (key === 'field_name') {
+      kvp['name'] = value // Facet name should match field name
+      this.validateField(value)
+    }
+    if (key === 'limit') {
+      this.validateLimit(value)
+    }
+    if (key === 'unlimited') {
+      kvp['limit'] = value ? '0' : '5'
+      this.validateLimit(kvp['limit'])
+    }
+
+    const facetValues = update(this.state.facetValues, {$merge: kvp})
+    this.setState({ facetValues: facetValues })
+  },
+
+  validateField(newValue) {
+    const result = (!newValue) ? 'Field is required.' : ''
+    this.setState({
+      errors: {
+        ...this.state.errors,
+        field: result,
+      },
+    })
+    return result
+  },
+
+  validateLimit(newValue) {
+    const result = (newValue !== undefined && isNaN(newValue))
+      ? 'Value must be a number.'
+      : ''
+    this.setState({
+      errors: {
+        ...this.state.errors,
+        limit: result,
+      },
+    })
+    return result
+  },
+
+  handleSave() {
+    // We won't get state updates until the next cycle, so we need to validate all form elements here
+    // and check for the result instead of just checking for errors in the state.
+    const errors = Object.assign({}, this.state.errors)
+    errors.field = this.validateField(this.state.facetValues.field_name)
+    errors.limit = this.validateLimit(this.state.facetValues.limit)
+    // Now set the state with all validation errors at once
+    this.setState({
+      errors: errors,
+    })
+    // If there were any errors, cancel saving
+    if (Object.values(errors).some(value => value)) {
+      AppEventEmitter.emit('MessageCenterDisplay', 'error', 'Unable to save due to invalid data.')
+      return
+    }
+
+    let newLimit = parseInt(this.state.facetValues.limit, 10)
+    // Anything falsy besides zero gets converted to the default value of 5
+    if (!newLimit && newLimit !== 0) {
+      newLimit = 5
+    }
+    const values = {
+      ...this.state.facetValues,
+      limit: newLimit,
+      order: this.state.facetValues.order || MetaDataConfigurationStore.facets.length+1,
+    }
+    if (this.state.createForm) {
+      MetaDataConfigurationActions.createFacet(this.state.facetName, values, this.props.baseUpdateUrl)
+    } else {
+      MetaDataConfigurationActions.changeFacet(this.state.facetName || values.name, values, this.props.baseUpdateUrl)
+    }
+    this.setState({ saving: true })
+  },
+
+  handleSaved(success, data) {
+    if (success) {
+      this.setState({ open: false, facetName: null })
+    } else {
+      console.log('Add error handling stuff here when !success', data)
+    }
+    this.setState({ saving: false })
+    this.handleClose()
+  },
+
+  handleClose() {
+    this.setState({ open: false })
+    this.props.handleClose()
+  },
+
+  render() {
+    const actions = [
+      <FlatButton
+        label='Save'
+        primary={true}
+        disabled={this.state.saving}
+        keyboardFocused={true}
+        onTouchTap={this.handleSave}
+      />,
+      <FlatButton
+        label='Close'
+        primary={false}
+        disabled={this.state.saving}
+        keyboardFocused={false}
+        onTouchTap={this.handleClose}
+      />,
+    ]
+    const fieldOptions = Object.values(MetaDataConfigurationStore.fields || {})
+       // only allow active string fields as facets
+      .filter(field => field.active && field.type === 'string' && (
+        // exclude fields that already have facets, unless this is the edit form in which case it needs to be there
+        !this.state.createForm || !MetaDataConfigurationStore.facets.find(facet => facet.field_name === field.name)
+      ))
+      .sort((a, b) => (a.order || 0) - (b.order || 0))
+      .map(field => ({
+        payload: field.name,
+        text: field.label,
+      }))
+    return (
+      <div>
+        <Dialog
+          ref='EditMetaDialog'
+          title={this.state.createForm ? 'New Facet' : 'Edit Facet'}
+          actions={actions}
+          modal={true}
+          bodyStyle={{ overflow: 'visible', margin: '0 auto' }}
+          contentStyle={{ width: '35%' }}
+          style={{ zIndex: 100 }}
+          openImmediately={this.props.open}
+        >
+          { this.state.open && (
+            <div>
+              <mui.SelectField
+                style={{ width: '100%' }}
+                className='select-field'
+                disabled={!this.state.createForm}
+                floatingLabelText='Field'
+                menuItems={fieldOptions}
+                valueLink={this.linkFacetState('field_name')}
+                errorText={this.state.errors.field}
+                errorStyle={{ top: '-15px', bottom: '0px' }}
+              />
+              <mui.TextField
+                style={{ width: '100%' }}
+                floatingLabelText='Label'
+                valueLink={this.linkFacetState('label')}
+              />
+              <div>
+                <label style={{ marginTop: '32px' }}>
+                  Default Options Visible
+                  <mui.TextField
+                    style={{ width: '100%' }}
+                    disabled={this.state.facetValues.unlimited}
+                    hintText='5'
+                    defaultValue='5'
+                    valueLink={this.linkFacetState('limit')}
+                    errorText={this.state.errors.limit}
+                  />
+                </label>
+                <mui.Checkbox
+                  style={{ width: '100%' }}
+                  label='Unlimited'
+                  checkedLink={ this.linkFacetState('unlimited') }
+                />
+              </div>
+            </div>
+          )}
+        </Dialog>
+      </div>
+    )
+  }
+})
+
+module.exports = MetaDataFacetDialog

--- a/app/assets/javascripts/constants/MetaDataConfigurationActionTypes.js
+++ b/app/assets/javascripts/constants/MetaDataConfigurationActionTypes.js
@@ -2,5 +2,8 @@ var keyMirror = require('keymirror');
 
 module.exports = keyMirror({
   MDC_CHANGE_FIELD: null, // Change a field's properties within the metadata configuration
-  MDC_REORDER_FIELDS: null, // Change a field's properties within the metadata configuration
+  MDC_CHANGE_FACET: null, // Change a facet's properties within the metadata configuration
+  MDC_REORDER_FIELDS: null, // Change the order of fields within the metadata configuration
+  MDC_REORDER_FACETS: null, // Change the order of facets within the metadata configuration
+  MDC_REMOVE_FACET: null, // Remove a facet from the metadata configuration
 });

--- a/app/assets/javascripts/stores/MetaDataConfigurationStore.js
+++ b/app/assets/javascripts/stores/MetaDataConfigurationStore.js
@@ -21,10 +21,18 @@ class MetaDataConfigurationStore extends EventEmitter {
       case MetaDataConfigurationActionTypes.MDC_CHANGE_FIELD:
         this.changeField(action.name, action.values);
         break;
+      case MetaDataConfigurationActionTypes.MDC_CHANGE_FACET:
+        this.changeFacet(action.name, action.values);
+        break;
       case MetaDataConfigurationActionTypes.MDC_REORDER_FIELDS:
         this.reorderFields(action.newFieldOrder);
         break;
-
+      case MetaDataConfigurationActionTypes.MDC_REORDER_FACETS:
+        this.reorderFacets(action.newFacetOrder);
+        break;
+      case MetaDataConfigurationActionTypes.MDC_REMOVE_FACET:
+        this.removeFacet(action.name);
+        break;
     }
   }
 
@@ -36,6 +44,17 @@ class MetaDataConfigurationStore extends EventEmitter {
     this.emit("MetaDataConfigurationStoreChanged");
   }
 
+  reorderFacets(newFacetOrder) {
+    newFacetOrder.map(data => {
+      const match = this._data.facets.find(facet => facet.name === data.name)
+      if (match) {
+        match.order = data.order
+      }
+    })
+
+    this.emit("MetaDataConfigurationStoreChanged")
+  }
+
   changeField(name, values) {
     // ensure the values
     if (!values.order) {
@@ -43,6 +62,38 @@ class MetaDataConfigurationStore extends EventEmitter {
     }
     this._data.fields[name] = values;
     this.emit("MetaDataConfigurationStoreChanged");
+  }
+
+  changeFacet(name, values) {
+    // Must have an order value
+    if (!values.order) {
+      values.order = this.facets.length + 1
+    }
+    // Get field from the store's fields
+    if (!values.field) {
+      values.field = this.fields[values.field_name]
+    }
+
+    const index = this._data.facets.findIndex(facet => facet.name === name)
+    if (index === -1) {
+      // create
+      this._data.facets.push({
+        ...values,
+        name: name,
+      })
+    } else {
+      // update
+      this._data.facets[index] = values
+    }
+    this.emit("MetaDataConfigurationStoreChanged")
+  }
+
+  removeFacet(name) {
+    const index = this._data.facets.findIndex(facet => facet.name === name)
+    if (index !== -1) {
+      this._data.facets.splice(index, 1)
+    }
+    this.emit("MetaDataConfigurationStoreChanged")
   }
 
   // Pass false for useCache if you want to force a new load from the api

--- a/app/assets/stylesheets/components/metaDataConfigurationFacetItem.css.scss
+++ b/app/assets/stylesheets/components/metaDataConfigurationFacetItem.css.scss
@@ -1,0 +1,31 @@
+.facet-list-item {
+  display: flex;
+  flex-flow: row nowrap;
+  justify-content: space-between;
+  overflow: hidden;
+  position: relative;
+}
+
+.facet-list-item:hover {
+  background-color: rgba(0, 0, 0, 0.1);
+  cursor: pointer;
+  transition: all 450ms cubic-bezier(0.23, 1, 0.32, 1) 0ms;
+}
+
+.facet-list-item:active {
+  background-color: rgba(0, 0, 0, 0.25);
+  transition: all 2s cubic-bezier(0.23, 1, 0.32, 1) 0ms;
+}
+
+.facet-list-item .left-side {
+  display: flex;
+  flex-flow: row nowrap;
+  align-items: center;
+  margin-left: 12px;
+  font-size: 15px;
+  font-family: Roboto, sans-serif;
+}
+
+.facet-list-item .left-side span {
+  vertical-align: middle;
+}

--- a/app/assets/stylesheets/components/metaDataFacetDialog.css.scss
+++ b/app/assets/stylesheets/components/metaDataFacetDialog.css.scss
@@ -1,0 +1,6 @@
+/* this is a really dumb way to find the dropdown, because
+this version of Material UI doesn't provide a way to style it. */
+.select-field div[tabindex="0"] {
+  max-height: 500px;
+  overflow-y: auto !important;
+}

--- a/app/controllers/v1/facets_controller.rb
+++ b/app/controllers/v1/facets_controller.rb
@@ -35,7 +35,7 @@ module V1
       if result
         render json: { success: true }.to_json
       else
-        render status: :unprocessable_entity, json: { success: false }.to_json
+        render status: :unprocessable_entity, json: { success: false, id: params[:id] }.to_json
       end
     end
 

--- a/app/controllers/v1/facets_controller.rb
+++ b/app/controllers/v1/facets_controller.rb
@@ -1,0 +1,64 @@
+module V1
+  class FacetsController < APIController
+    def update
+      @collection = CollectionQuery.new.any_find(params[:collection_id])
+
+      return if rendered_forbidden?(@collection)
+
+      result = Metadata::UpdateConfigurationFacet.call(@collection, params[:id], facet_params)
+      if result
+        render json: { facet: result }.to_json
+      else
+        render status: :unprocessable_entity, json: { facet: facet_params }.to_json
+      end
+    end
+
+    def create
+      @collection = CollectionQuery.new.any_find(params[:collection_id])
+
+      return if rendered_forbidden?(@collection)
+
+      result = Metadata::CreateConfigurationFacet.call(@collection, facet_params)
+      if result
+        render json: { facet: result }.to_json
+      else
+        render status: :unprocessable_entity, json: { facet: facet_params }.to_json
+      end
+    end
+
+    def destroy
+      @collection = CollectionQuery.new.any_find(params[:collection_id])
+
+      return if rendered_forbidden?(@collection)
+
+      result = Metadata::RemoveConfigurationFacet.call(@collection, params[:id])
+      if result
+        render json: { success: true }.to_json
+      else
+        render status: :unprocessable_entity, json: { success: false }.to_json
+      end
+    end
+
+    def reorder
+      @collection = CollectionQuery.new.any_find(params[:collection_id])
+
+      return if rendered_forbidden?(@collection)
+
+      if ReorderFacets.call(@collection, facet_params)
+        render json: { new_order: reorder_params }.to_json
+      else
+        render :errors, status: :unprocessable_entity
+      end
+    end
+
+    private
+
+    def facet_params
+      @facet_params ||= params[:facets] ? params[:facets] : params.except(:format, :controller, :action, :collection_id, :id)
+    end
+
+    def reorder_params
+      params.require(:facets)
+    end
+  end
+end

--- a/app/models/metadata/configuration.rb
+++ b/app/models/metadata/configuration.rb
@@ -28,6 +28,29 @@ module Metadata
       end
     end
 
+    def save_facet(name, values)
+      f = facet(name)
+
+      if !f
+        facets
+        f = new_facet(values)
+        @facets << f
+      elsif values != nil
+        f.update(values)
+      else
+        facets.delete_if { |facet| facet.name === name }
+      end
+
+      return false if !f.valid?
+
+      data.facets = facets.map { |facet| facet.to_hash.except(:field) } # exclude "field" when saving to db
+      if data.save
+        f
+      else
+        false
+      end
+    end
+
     def fields
       @fields ||= build_fields
     end
@@ -157,6 +180,10 @@ module Metadata
 
     def new_field(field_data)
       self.class::Field.new(**field_data)
+    end
+
+    def new_facet(facet_data)
+      self.class::Facet.new(**facet_data)
     end
   end
 end

--- a/app/models/metadata/configuration/facet.rb
+++ b/app/models/metadata/configuration/facet.rb
@@ -1,19 +1,75 @@
 module Metadata
   class Configuration
     class Facet
-      attr_reader :field, :field_name, :name, :active, :limit
+      include ActiveModel::Validations
 
-      def initialize(name:, field:, field_name:, label: nil, active: true, limit: nil)
+      attr_accessor :name, :field_name, :label, :active, :limit, :order
+      attr_reader :field
+
+      validates :name, :field_name, presence: true
+      validates :limit, :order, numericality: { only_integer: true, allow_nil: true }
+
+      def initialize(name:, field: nil, field_name:, label: nil, active: true, limit: 5, order: nil)
         @name = name
         @field = field
         @field_name = field_name
         @label = label
         @active = active
         @limit = limit
+        @order = order
+        validate
       end
 
       def label
-        @label || field.label
+        @label || (field ? field.label : nil)
+      end
+
+      def to_hash
+        {
+          name: name,
+          field: field,
+          field_name: field_name,
+          label: label,
+          active: active,
+          limit: limit,
+          order: order,
+        }
+      end
+
+      def update(new_attributes)
+        convert_json_to_ruby_keys!(new_attributes)
+
+        # remove attributes that are readonly or not persisted to database
+        if name.present?
+          new_attributes.delete(:name)
+        end
+        if field.present?
+          new_attributes.delete(:field)
+        end
+
+        new_attributes.each do |key, value|
+          send("#{key}=", value)
+        end
+        valid?
+      end
+
+      private
+
+      def convert_json_to_ruby_keys!(hash)
+        hash.to_hash.symbolize_keys!
+
+        convert_strings_to_booleans([:active], hash)
+      end
+
+      def convert_strings_to_booleans(keys, hash)
+        keys.each do |key|
+          case hash[key]
+          when "true"
+            hash[key] = true
+          when "false"
+            hash[key] = false
+          end
+        end
       end
     end
   end

--- a/app/services/metadata/configuration_input_cleaner.rb
+++ b/app/services/metadata/configuration_input_cleaner.rb
@@ -45,7 +45,7 @@ module Metadata
     end
 
     def ensure_int_values
-      [:order, :boost].each do |key|
+      [:order, :boost, :limit].each do |key|
         if data.has_key?(key)
           begin
             data[key] = Integer(data[key])

--- a/app/services/metadata/create_configuration_facet.rb
+++ b/app/services/metadata/create_configuration_facet.rb
@@ -1,0 +1,55 @@
+module Metadata
+  class CreateConfigurationFacet
+    attr_reader :collection
+
+    def self.call(collection, new_data)
+      new(collection).create_facet(new_data)
+    end
+
+    def initialize(collection)
+      @collection = collection
+    end
+
+    def create_facet(new_data)
+      populate_defaults(values: new_data)
+      new_data = ConfigurationInputCleaner.call(new_data)
+      # Name for facet should always match field name
+      new_data[:name] = new_data[:field_name]
+      if new_data[:unlimited].present?
+        new_data.delete(:unlimited)
+      end
+
+      if duplicate_name?(new_data)
+        return nil
+      else
+        configuration.save_facet(new_data[:name], new_data)
+      end
+    end
+
+    private
+
+    # Populates default values for when there are no values given,
+    # since we can't do it at the database layer
+    def populate_defaults(values:)
+      if values[:limit].nil? || values[:limit] == ""
+        values[:limit] = 5
+      end
+
+      if values[:active].nil? || values[:active] == ""
+        values[:active] = true
+      end
+    end
+
+    def duplicate_name?(new_data)
+      duplicates = @collection.collection_configuration.facets.select do |f|
+        h = f.with_indifferent_access
+        h[:name].casecmp(new_data[:name]) == 0
+      end
+      duplicates.count >= 1 ? true : false
+    end
+
+    def configuration
+      @configuration ||= CollectionConfigurationQuery.new(collection).find
+    end
+  end
+end

--- a/app/services/metadata/remove_configuration_facet.rb
+++ b/app/services/metadata/remove_configuration_facet.rb
@@ -1,0 +1,23 @@
+module Metadata
+  class RemoveConfigurationFacet
+    attr_reader :collection
+
+    def self.call(collection, facet)
+      new(collection).remove_facet(facet)
+    end
+
+    def initialize(collection)
+      @collection = collection
+    end
+
+    def remove_facet(facet)
+      configuration.save_facet(facet, nil)
+    end
+
+    private
+
+    def configuration
+      @configuration ||= CollectionConfigurationQuery.new(collection).find
+    end
+  end
+end

--- a/app/services/metadata/update_configuration_facet.rb
+++ b/app/services/metadata/update_configuration_facet.rb
@@ -1,0 +1,28 @@
+module Metadata
+  class UpdateConfigurationFacet
+    attr_reader :collection
+
+    def self.call(collection, facet, new_data)
+      new(collection).update_facet(facet, new_data)
+    end
+
+    def initialize(collection)
+      @collection = collection
+    end
+
+    def update_facet(facet, new_data)
+      new_data = ConfigurationInputCleaner.call(new_data)
+      new_data[:name] = new_data[:field_name]
+      if new_data[:unlimited].present?
+        new_data.delete(:unlimited)
+      end
+      configuration.save_facet(facet, new_data)
+    end
+
+    private
+
+    def configuration
+      @configuration ||= CollectionConfigurationQuery.new(collection).find
+    end
+  end
+end

--- a/app/services/reorder_facets.rb
+++ b/app/services/reorder_facets.rb
@@ -1,0 +1,20 @@
+class ReorderFacets
+  attr_reader :configuration
+
+  def self.call(collection, new_facet_order)
+    new(collection).reorder(new_facet_order)
+  end
+
+  def initialize(collection)
+    @collection = collection
+    @configuration = CollectionConfigurationQuery.new(@collection).find
+  end
+
+  def reorder(new_facet_order)
+    new_facet_order.each do |_index, facet|
+      if configuration.facet(facet['name'])
+        configuration.save_facet(facet['name'], 'order' => facet['order'].to_i)
+      end
+    end
+  end
+end

--- a/app/views/collections/_metadata_settings_form.html.erb
+++ b/app/views/collections/_metadata_settings_form.html.erb
@@ -1,1 +1,5 @@
-<%= react_component("MetaDataConfigurationForm", baseUpdateUrl: v1_collection_configurations_metadata_fields_path(@collection.unique_id)) %>
+<%= react_component(
+  "MetaDataConfigurationForm",
+  baseUpdateUrl: v1_collection_configurations_metadata_fields_path(@collection.unique_id),
+  facetUpdateUrl: v1_collection_configurations_facets_path(@collection.unique_id),
+) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -95,6 +95,11 @@ Rails.application.routes.draw do
             put :reorder
           end
         end
+        resources :facets, only: [:create, :update, :destroy], defaults: { format: :json } do
+          collection do
+            put :reorder
+          end
+        end
       end
     end
     resources :items,

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -14,7 +14,7 @@
       "integrity": "sha1-kWV9/m/4V0gwZhMrRhi2Lo9Ih70=",
       "requires": {
         "jsonparse": "0.0.5",
-        "through": "2.3.8"
+        "through": ">=2.2.7 <3"
       }
     },
     "acorn": {
@@ -37,9 +37,9 @@
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.0.tgz",
       "integrity": "sha1-9xoSQ/PnnUbXsH1/v0gk7nOvBUo=",
       "requires": {
-        "bn.js": "4.11.6",
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0"
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "assert": {
@@ -60,12 +60,12 @@
       "resolved": "https://registry.npmjs.org/astw/-/astw-2.0.0.tgz",
       "integrity": "sha1-CBIayCiNNWEcDO7GY/bNVFYEiX0=",
       "requires": {
-        "acorn": "1.2.2"
+        "acorn": "^1.0.3"
       }
     },
     "async": {
       "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+      "resolved": "http://registry.npmjs.org/async/-/async-0.2.10.tgz",
       "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
     },
     "axios": {
@@ -103,7 +103,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
       "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
       "requires": {
-        "balanced-match": "0.4.2",
+        "balanced-match": "^0.4.1",
         "concat-map": "0.0.1"
       }
     },
@@ -117,23 +117,23 @@
       "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-3.2.0.tgz",
       "integrity": "sha1-+qHLxBSHsazEdH43PhFIrf/Q4tk=",
       "requires": {
-        "JSONStream": "0.8.4",
-        "combine-source-map": "0.3.0",
-        "concat-stream": "1.4.10",
-        "defined": "0.0.0",
-        "through2": "0.5.1",
-        "umd": "2.1.0"
+        "JSONStream": "~0.8.4",
+        "combine-source-map": "~0.3.0",
+        "concat-stream": "~1.4.1",
+        "defined": "~0.0.0",
+        "through2": "~0.5.1",
+        "umd": "^2.1.0"
       },
       "dependencies": {
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "through2": {
@@ -141,8 +141,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
           "integrity": "sha1-390BLrnHAOIyP9M084rGIqs3Lac=",
           "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "3.0.0"
+            "readable-stream": "~1.0.17",
+            "xtend": "~3.0.0"
           }
         }
       }
@@ -164,58 +164,58 @@
     },
     "browserify": {
       "version": "6.3.4",
-      "resolved": "https://registry.npmjs.org/browserify/-/browserify-6.3.4.tgz",
+      "resolved": "http://registry.npmjs.org/browserify/-/browserify-6.3.4.tgz",
       "integrity": "sha1-V7XRlcxWgTnpcTAuXNnVjdr7VNg=",
       "requires": {
-        "JSONStream": "0.8.4",
-        "assert": "1.1.2",
-        "browser-pack": "3.2.0",
-        "browser-resolve": "1.11.2",
-        "browserify-zlib": "0.1.4",
-        "buffer": "2.8.2",
-        "builtins": "0.0.7",
+        "JSONStream": "~0.8.3",
+        "assert": "~1.1.0",
+        "browser-pack": "^3.2.0",
+        "browser-resolve": "^1.3.0",
+        "browserify-zlib": "~0.1.2",
+        "buffer": "^2.3.0",
+        "builtins": "~0.0.3",
         "commondir": "0.0.1",
-        "concat-stream": "1.4.10",
-        "console-browserify": "1.1.0",
-        "constants-browserify": "0.0.1",
-        "crypto-browserify": "3.11.0",
-        "deep-equal": "0.2.2",
-        "defined": "0.0.0",
-        "deps-sort": "1.3.9",
-        "domain-browser": "1.1.7",
-        "duplexer2": "0.0.2",
-        "events": "1.0.2",
-        "glob": "4.5.3",
-        "http-browserify": "1.7.0",
-        "https-browserify": "0.0.1",
-        "inherits": "2.0.3",
-        "insert-module-globals": "6.6.3",
+        "concat-stream": "~1.4.1",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "~0.0.1",
+        "crypto-browserify": "^3.0.0",
+        "deep-equal": "~0.2.1",
+        "defined": "~0.0.0",
+        "deps-sort": "^1.3.5",
+        "domain-browser": "~1.1.0",
+        "duplexer2": "~0.0.2",
+        "events": "~1.0.0",
+        "glob": "^4.0.5",
+        "http-browserify": "^1.4.0",
+        "https-browserify": "~0.0.0",
+        "inherits": "~2.0.1",
+        "insert-module-globals": "^6.1.0",
         "isarray": "0.0.1",
-        "labeled-stream-splicer": "1.0.2",
-        "module-deps": "3.9.1",
-        "os-browserify": "0.1.2",
-        "parents": "0.0.3",
-        "path-browserify": "0.0.0",
-        "process": "0.8.0",
-        "punycode": "1.2.4",
-        "querystring-es3": "0.2.1",
-        "readable-stream": "1.1.14",
-        "resolve": "0.7.4",
+        "labeled-stream-splicer": "^1.0.0",
+        "module-deps": "^3.5.0",
+        "os-browserify": "~0.1.1",
+        "parents": "~0.0.1",
+        "path-browserify": "~0.0.0",
+        "process": "^0.8.0",
+        "punycode": "~1.2.3",
+        "querystring-es3": "~0.2.0",
+        "readable-stream": "^1.0.33-1",
+        "resolve": "~0.7.1",
         "shallow-copy": "0.0.1",
-        "shasum": "1.0.2",
-        "shell-quote": "0.0.1",
-        "stream-browserify": "1.0.0",
-        "string_decoder": "0.10.31",
-        "subarg": "1.0.0",
-        "syntax-error": "1.1.6",
-        "through2": "1.1.1",
-        "timers-browserify": "1.4.2",
-        "tty-browserify": "0.0.0",
-        "umd": "2.1.0",
-        "url": "0.10.3",
-        "util": "0.10.3",
-        "vm-browserify": "0.0.4",
-        "xtend": "3.0.0"
+        "shasum": "^1.0.0",
+        "shell-quote": "~0.0.1",
+        "stream-browserify": "^1.0.0",
+        "string_decoder": "~0.10.0",
+        "subarg": "^1.0.0",
+        "syntax-error": "^1.1.1",
+        "through2": "^1.0.0",
+        "timers-browserify": "^1.0.1",
+        "tty-browserify": "~0.0.0",
+        "umd": "~2.1.0",
+        "url": "~0.10.1",
+        "util": "~0.10.1",
+        "vm-browserify": "~0.0.1",
+        "xtend": "^3.0.0"
       }
     },
     "browserify-aes": {
@@ -223,11 +223,11 @@
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
       "integrity": "sha1-Xncl297x/Vkw1OurSFZ85FHEigo=",
       "requires": {
-        "buffer-xor": "1.0.3",
-        "cipher-base": "1.0.3",
-        "create-hash": "1.1.2",
-        "evp_bytestokey": "1.0.0",
-        "inherits": "2.0.3"
+        "buffer-xor": "^1.0.2",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "browserify-cache-api": {
@@ -235,10 +235,10 @@
       "resolved": "https://registry.npmjs.org/browserify-cache-api/-/browserify-cache-api-1.5.1.tgz",
       "integrity": "sha1-JZ1KkPwWGmRwbbkQbZ1w3ZixUJo=",
       "requires": {
-        "async": "0.9.2",
-        "labeled-stream-splicer": "1.0.2",
-        "through2": "0.6.5",
-        "xtend": "4.0.1"
+        "async": "^0.9.0",
+        "labeled-stream-splicer": "^1.0.2",
+        "through2": "^0.6.2",
+        "xtend": "^4.0.0"
       },
       "dependencies": {
         "async": {
@@ -251,10 +251,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "through2": {
@@ -262,8 +262,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "4.0.1"
+            "readable-stream": ">=1.0.33-1 <1.1.0-0",
+            "xtend": ">=4.0.0 <4.1.0-0"
           }
         },
         "xtend": {
@@ -278,9 +278,9 @@
       "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
       "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
       "requires": {
-        "browserify-aes": "1.0.6",
-        "browserify-des": "1.0.0",
-        "evp_bytestokey": "1.0.0"
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
       }
     },
     "browserify-des": {
@@ -288,9 +288,9 @@
       "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
       "integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
       "requires": {
-        "cipher-base": "1.0.3",
-        "des.js": "1.0.0",
-        "inherits": "2.0.3"
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "browserify-incremental": {
@@ -298,11 +298,11 @@
       "resolved": "https://registry.npmjs.org/browserify-incremental/-/browserify-incremental-1.5.0.tgz",
       "integrity": "sha1-dlGJA7hMNrSx+G8wgwnsQkiVUAk=",
       "requires": {
-        "JSONStream": "0.10.0",
-        "browserify": "6.3.4",
-        "browserify-cache-api": "1.5.1",
-        "through2": "0.6.5",
-        "xtend": "4.0.1"
+        "JSONStream": "^0.10.0",
+        "browserify": "^6.3.4",
+        "browserify-cache-api": "^1.3.0",
+        "through2": "^0.6.2",
+        "xtend": "^4.0.0"
       },
       "dependencies": {
         "JSONStream": {
@@ -311,7 +311,7 @@
           "integrity": "sha1-dDSdDYlSK3HzDwoD/5vSDKbxKsA=",
           "requires": {
             "jsonparse": "0.0.5",
-            "through": "2.3.8"
+            "through": ">=2.2.7 <3"
           }
         },
         "readable-stream": {
@@ -319,10 +319,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "through2": {
@@ -330,8 +330,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "4.0.1"
+            "readable-stream": ">=1.0.33-1 <1.1.0-0",
+            "xtend": ">=4.0.0 <4.1.0-0"
           }
         },
         "xtend": {
@@ -343,11 +343,11 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "requires": {
-        "bn.js": "4.11.6",
-        "randombytes": "2.0.3"
+        "bn.js": "^4.1.0",
+        "randombytes": "^2.0.1"
       }
     },
     "browserify-sign": {
@@ -355,13 +355,13 @@
       "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.0.tgz",
       "integrity": "sha1-EHc5EMPCBtVCCkaq2GlPgguFlo8=",
       "requires": {
-        "bn.js": "4.11.6",
-        "browserify-rsa": "4.0.1",
-        "create-hash": "1.1.2",
-        "create-hmac": "1.1.4",
-        "elliptic": "6.3.2",
-        "inherits": "2.0.3",
-        "parse-asn1": "5.0.0"
+        "bn.js": "^4.1.1",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.2",
+        "elliptic": "^6.0.0",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^5.0.0"
       }
     },
     "browserify-zlib": {
@@ -369,7 +369,7 @@
       "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
       "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
       "requires": {
-        "pako": "0.2.9"
+        "pako": "~0.2.0"
       }
     },
     "browserslist": {
@@ -377,17 +377,17 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.4.0.tgz",
       "integrity": "sha1-nP3PU4TZFY9bcNoqoAsw6P8BkEk=",
       "requires": {
-        "caniuse-db": "1.0.30000578"
+        "caniuse-db": "^1.0.30000539"
       }
     },
     "buffer": {
       "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-2.8.2.tgz",
+      "resolved": "http://registry.npmjs.org/buffer/-/buffer-2.8.2.tgz",
       "integrity": "sha1-1zwhTAM0OE3CmwTuD/X1Unx5dOc=",
       "requires": {
         "base64-js": "0.0.7",
-        "ieee754": "1.1.8",
-        "is-array": "1.0.1"
+        "ieee754": "^1.1.4",
+        "is-array": "^1.0.1"
       }
     },
     "buffer-xor": {
@@ -415,11 +415,11 @@
       "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.5.2.tgz",
       "integrity": "sha1-jzk8aC9mHAqZe3e7pugmSD+zYA4=",
       "requires": {
-        "browserslist": "1.4.0",
-        "caniuse-db": "1.0.30000578",
-        "lodash.memoize": "4.1.2",
-        "lodash.uniq": "4.5.0",
-        "shelljs": "0.7.5"
+        "browserslist": "^1.0.1",
+        "caniuse-db": "^1.0.30000346",
+        "lodash.memoize": "^4.1.0",
+        "lodash.uniq": "^4.3.0",
+        "shelljs": "^0.7.0"
       },
       "dependencies": {
         "lodash.memoize": {
@@ -439,7 +439,7 @@
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.3.tgz",
       "integrity": "sha1-7qvxlEGc6QDaMBjCB9IS8qbfCgc=",
       "requires": {
-        "inherits": "2.0.3"
+        "inherits": "^2.0.1"
       }
     },
     "classnames": {
@@ -452,9 +452,9 @@
       "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
       "integrity": "sha1-2edPWT2c1DgHMSy12EbUUe+qnrc=",
       "requires": {
-        "convert-source-map": "0.3.5",
-        "inline-source-map": "0.3.1",
-        "source-map": "0.1.43"
+        "convert-source-map": "~0.3.0",
+        "inline-source-map": "~0.3.0",
+        "source-map": "~0.1.31"
       }
     },
     "commander": {
@@ -462,7 +462,7 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
       "requires": {
-        "graceful-readlink": "1.0.1"
+        "graceful-readlink": ">= 1.0.0"
       }
     },
     "commondir": {
@@ -475,15 +475,15 @@
       "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.4.tgz",
       "integrity": "sha1-mPMzPdOtOZWWuy04Sng7tyE9aPg=",
       "requires": {
-        "commander": "2.9.0",
-        "detective": "4.3.2",
-        "glob": "5.0.15",
-        "graceful-fs": "4.1.10",
-        "iconv-lite": "0.4.13",
-        "mkdirp": "0.5.1",
-        "private": "0.1.6",
-        "q": "1.4.1",
-        "recast": "0.10.43"
+        "commander": "^2.5.0",
+        "detective": "^4.3.1",
+        "glob": "^5.0.15",
+        "graceful-fs": "^4.1.2",
+        "iconv-lite": "^0.4.5",
+        "mkdirp": "^0.5.0",
+        "private": "^0.1.6",
+        "q": "^1.1.2",
+        "recast": "^0.10.0"
       },
       "dependencies": {
         "glob": {
@@ -491,11 +491,11 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "2.0.10",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         }
       }
@@ -510,9 +510,9 @@
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
       "integrity": "sha1-rMO79WAsuMyYDGrIQPp9hgPj7zY=",
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "1.1.14",
-        "typedarray": "0.0.6"
+        "inherits": "~2.0.1",
+        "readable-stream": "~1.1.9",
+        "typedarray": "~0.0.5"
       }
     },
     "console-browserify": {
@@ -520,7 +520,7 @@
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
       "requires": {
-        "date-now": "0.1.4"
+        "date-now": "^0.1.4"
       }
     },
     "constants-browserify": {
@@ -530,7 +530,7 @@
     },
     "convert-source-map": {
       "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
+      "resolved": "http://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
       "integrity": "sha1-8dgClQr33SYxof6+BZZVDIarMZA="
     },
     "core-js": {
@@ -548,8 +548,8 @@
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
       "integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
       "requires": {
-        "bn.js": "4.11.6",
-        "elliptic": "6.3.2"
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.0.0"
       }
     },
     "create-hash": {
@@ -557,10 +557,10 @@
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.2.tgz",
       "integrity": "sha1-USEAYte7dHn2xlu0GpIgix1hq60=",
       "requires": {
-        "cipher-base": "1.0.3",
-        "inherits": "2.0.3",
-        "ripemd160": "1.0.1",
-        "sha.js": "2.4.5"
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "ripemd160": "^1.0.0",
+        "sha.js": "^2.3.6"
       }
     },
     "create-hmac": {
@@ -568,8 +568,8 @@
       "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.4.tgz",
       "integrity": "sha1-0/tLolPriz9W456i+8uK90e9MXA=",
       "requires": {
-        "create-hash": "1.1.2",
-        "inherits": "2.0.3"
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1"
       }
     },
     "crypto-browserify": {
@@ -577,16 +577,16 @@
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.0.tgz",
       "integrity": "sha1-NlKgkGq5sqfgw85mpAjpV6JIVSI=",
       "requires": {
-        "browserify-cipher": "1.0.0",
-        "browserify-sign": "4.0.0",
-        "create-ecdh": "4.0.0",
-        "create-hash": "1.1.2",
-        "create-hmac": "1.1.4",
-        "diffie-hellman": "5.0.2",
-        "inherits": "2.0.3",
-        "pbkdf2": "3.0.9",
-        "public-encrypt": "4.0.0",
-        "randombytes": "2.0.3"
+        "browserify-cipher": "^1.0.0",
+        "browserify-sign": "^4.0.0",
+        "create-ecdh": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^5.0.0",
+        "inherits": "^2.0.1",
+        "pbkdf2": "^3.0.3",
+        "public-encrypt": "^4.0.0",
+        "randombytes": "^2.0.0"
       }
     },
     "date-now": {
@@ -614,10 +614,10 @@
       "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.9.tgz",
       "integrity": "sha1-Kd//U+F7Nq7K51MK27v2IsLtGnE=",
       "requires": {
-        "JSONStream": "1.2.1",
-        "shasum": "1.0.2",
-        "subarg": "1.0.0",
-        "through2": "1.1.1"
+        "JSONStream": "^1.0.3",
+        "shasum": "^1.0.0",
+        "subarg": "^1.0.0",
+        "through2": "^1.0.0"
       },
       "dependencies": {
         "JSONStream": {
@@ -625,8 +625,8 @@
           "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.2.1.tgz",
           "integrity": "sha1-MqpXkOeZSBCDtJtLf6lOI7rmm/k=",
           "requires": {
-            "jsonparse": "1.2.0",
-            "through": "2.3.8"
+            "jsonparse": "^1.2.0",
+            "through": ">=2.2.7 <3"
           }
         },
         "jsonparse": {
@@ -641,8 +641,8 @@
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
       "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
       "requires": {
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0"
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "detective": {
@@ -650,8 +650,8 @@
       "resolved": "https://registry.npmjs.org/detective/-/detective-4.3.2.tgz",
       "integrity": "sha1-d2l+LnlHrD/nyOJqbW8RUjWvqRw=",
       "requires": {
-        "acorn": "3.3.0",
-        "defined": "1.0.0"
+        "acorn": "^3.1.0",
+        "defined": "^1.0.0"
       },
       "dependencies": {
         "acorn": {
@@ -671,9 +671,9 @@
       "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
       "integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
       "requires": {
-        "bn.js": "4.11.6",
-        "miller-rabin": "4.0.0",
-        "randombytes": "2.0.3"
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
       }
     },
     "disposables": {
@@ -691,7 +691,7 @@
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
       "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
       "requires": {
-        "readable-stream": "1.1.14"
+        "readable-stream": "~1.1.9"
       }
     },
     "elliptic": {
@@ -699,10 +699,10 @@
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.2.tgz",
       "integrity": "sha1-5MgeCCnPCmWrcOmYuCMnI7XBvEg=",
       "requires": {
-        "bn.js": "4.11.6",
-        "brorand": "1.0.6",
-        "hash.js": "1.0.3",
-        "inherits": "2.0.3"
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "encoding": {
@@ -710,7 +710,7 @@
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "requires": {
-        "iconv-lite": "0.4.13"
+        "iconv-lite": "~0.4.13"
       }
     },
     "envify": {
@@ -718,8 +718,8 @@
       "resolved": "https://registry.npmjs.org/envify/-/envify-3.4.1.tgz",
       "integrity": "sha1-1xIjKejfFoi6dxsSUBkXyc5cvOg=",
       "requires": {
-        "jstransform": "11.0.3",
-        "through": "2.3.8"
+        "jstransform": "^11.0.3",
+        "through": "~2.3.4"
       }
     },
     "es6-promise": {
@@ -739,7 +739,7 @@
     },
     "events": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/events/-/events-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/events/-/events-1.0.2.tgz",
       "integrity": "sha1-dYSdz+k9EPsFfDAFWv29UdBqjiQ="
     },
     "evp_bytestokey": {
@@ -747,7 +747,7 @@
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz",
       "integrity": "sha1-SXtmrZ/vZc18CKYYCCS6FHa2blM=",
       "requires": {
-        "create-hash": "1.1.2"
+        "create-hash": "^1.1.1"
       }
     },
     "fbemitter": {
@@ -755,7 +755,7 @@
       "resolved": "https://registry.npmjs.org/fbemitter/-/fbemitter-2.1.1.tgz",
       "integrity": "sha1-Uj4U/a9SSIBbsC9i78M75wP1GGU=",
       "requires": {
-        "fbjs": "0.8.5"
+        "fbjs": "^0.8.4"
       },
       "dependencies": {
         "fbjs": {
@@ -763,13 +763,13 @@
           "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.5.tgz",
           "integrity": "sha1-9puoqHYJbLG5v/5NfB5xwZ050Ag=",
           "requires": {
-            "core-js": "1.2.7",
-            "immutable": "3.8.1",
-            "isomorphic-fetch": "2.2.1",
-            "loose-envify": "1.3.0",
-            "object-assign": "4.1.0",
-            "promise": "7.1.1",
-            "ua-parser-js": "0.7.11"
+            "core-js": "^1.0.0",
+            "immutable": "^3.7.6",
+            "isomorphic-fetch": "^2.1.1",
+            "loose-envify": "^1.0.0",
+            "object-assign": "^4.1.0",
+            "promise": "^7.1.1",
+            "ua-parser-js": "^0.7.9"
           }
         },
         "object-assign": {
@@ -784,9 +784,9 @@
       "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.1.0-alpha.7.tgz",
       "integrity": "sha1-rUMIuPIy+zxzYDNJ6nJdHpw5Mjw=",
       "requires": {
-        "core-js": "1.2.7",
-        "promise": "7.1.1",
-        "whatwg-fetch": "0.9.0"
+        "core-js": "^1.0.0",
+        "promise": "^7.0.3",
+        "whatwg-fetch": "^0.9.0"
       },
       "dependencies": {
         "whatwg-fetch": {
@@ -801,9 +801,9 @@
       "resolved": "https://registry.npmjs.org/flux/-/flux-2.1.1.tgz",
       "integrity": "sha1-LGrGUtQzdIiWhInGWG86/yajjqQ=",
       "requires": {
-        "fbemitter": "2.1.1",
+        "fbemitter": "^2.0.0",
         "fbjs": "0.1.0-alpha.7",
-        "immutable": "3.8.1"
+        "immutable": "^3.7.4"
       }
     },
     "fs.realpath": {
@@ -816,10 +816,10 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
       "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
       "requires": {
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "2.0.10",
-        "once": "1.4.0"
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^2.0.1",
+        "once": "^1.3.0"
       }
     },
     "graceful-fs": {
@@ -837,7 +837,7 @@
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz",
       "integrity": "sha1-EzL/ABVsCg/92CNgE9B7d6BFFXM=",
       "requires": {
-        "inherits": "2.0.3"
+        "inherits": "^2.0.1"
       }
     },
     "hoist-non-react-statics": {
@@ -850,8 +850,8 @@
       "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
       "integrity": "sha1-M3la3nLfiKz7/TZ3PO/tp2RzWyA=",
       "requires": {
-        "Base64": "0.2.1",
-        "inherits": "2.0.3"
+        "Base64": "~0.2.0",
+        "inherits": "~2.0.1"
       }
     },
     "https-browserify": {
@@ -884,8 +884,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -898,7 +898,7 @@
       "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
       "integrity": "sha1-pSi1FOaJ/OkNswiehw2S9Sestes=",
       "requires": {
-        "source-map": "0.3.0"
+        "source-map": "~0.3.0"
       },
       "dependencies": {
         "source-map": {
@@ -906,7 +906,7 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
           "integrity": "sha1-hYb7mloAXltQHiHNGLbyG0V60fk=",
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -916,8 +916,8 @@
       "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-0.5.4.tgz",
       "integrity": "sha1-Pw+C6aYo8y91hdql0VPNtbsJew8=",
       "requires": {
-        "bowser": "1.5.0",
-        "caniuse-api": "1.5.2"
+        "bowser": "^1.0.0",
+        "caniuse-api": "^1.3.2"
       }
     },
     "insert-module-globals": {
@@ -925,14 +925,14 @@
       "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.6.3.tgz",
       "integrity": "sha1-IGOOKaMPntHKLjqCX7wsulJG3fw=",
       "requires": {
-        "JSONStream": "1.2.1",
-        "combine-source-map": "0.6.1",
-        "concat-stream": "1.4.10",
-        "is-buffer": "1.1.4",
-        "lexical-scope": "1.2.0",
-        "process": "0.11.9",
-        "through2": "1.1.1",
-        "xtend": "4.0.1"
+        "JSONStream": "^1.0.3",
+        "combine-source-map": "~0.6.1",
+        "concat-stream": "~1.4.1",
+        "is-buffer": "^1.1.0",
+        "lexical-scope": "^1.2.0",
+        "process": "~0.11.0",
+        "through2": "^1.0.0",
+        "xtend": "^4.0.0"
       },
       "dependencies": {
         "JSONStream": {
@@ -940,8 +940,8 @@
           "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.2.1.tgz",
           "integrity": "sha1-MqpXkOeZSBCDtJtLf6lOI7rmm/k=",
           "requires": {
-            "jsonparse": "1.2.0",
-            "through": "2.3.8"
+            "jsonparse": "^1.2.0",
+            "through": ">=2.2.7 <3"
           }
         },
         "combine-source-map": {
@@ -949,15 +949,15 @@
           "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.6.1.tgz",
           "integrity": "sha1-m0oJwxYDPXaODxHgKfonMOB5rZY=",
           "requires": {
-            "convert-source-map": "1.1.3",
-            "inline-source-map": "0.5.0",
-            "lodash.memoize": "3.0.4",
-            "source-map": "0.4.4"
+            "convert-source-map": "~1.1.0",
+            "inline-source-map": "~0.5.0",
+            "lodash.memoize": "~3.0.3",
+            "source-map": "~0.4.2"
           }
         },
         "convert-source-map": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
           "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA="
         },
         "inline-source-map": {
@@ -965,7 +965,7 @@
           "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.5.0.tgz",
           "integrity": "sha1-Skxd2OT7Xps82mDIIt+tyu5m4K8=",
           "requires": {
-            "source-map": "0.4.4"
+            "source-map": "~0.4.0"
           }
         },
         "jsonparse": {
@@ -983,7 +983,7 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         },
         "xtend": {
@@ -1003,7 +1003,7 @@
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.1.tgz",
       "integrity": "sha1-sJcBBUdmjH4zcCjr6Bbr42yKjVQ=",
       "requires": {
-        "loose-envify": "1.3.0"
+        "loose-envify": "^1.0.0"
       }
     },
     "is-array": {
@@ -1031,8 +1031,8 @@
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
       "requires": {
-        "node-fetch": "1.6.3",
-        "whatwg-fetch": "1.0.0"
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
       }
     },
     "jquery": {
@@ -1050,7 +1050,7 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
       "integrity": "sha1-YRwj6BTbN1Un34URk9tZ3Sryf0U=",
       "requires": {
-        "jsonify": "0.0.0"
+        "jsonify": "~0.0.0"
       }
     },
     "jsonify": {
@@ -1068,11 +1068,11 @@
       "resolved": "https://registry.npmjs.org/jstransform/-/jstransform-11.0.3.tgz",
       "integrity": "sha1-CaeJk+CuTU70SH9hVakfYZDLQiM=",
       "requires": {
-        "base62": "1.1.1",
-        "commoner": "0.10.4",
-        "esprima-fb": "15001.1.0-dev-harmony-fb",
-        "object-assign": "2.1.1",
-        "source-map": "0.4.4"
+        "base62": "^1.1.0",
+        "commoner": "^0.10.1",
+        "esprima-fb": "^15001.1.0-dev-harmony-fb",
+        "object-assign": "^2.0.0",
+        "source-map": "^0.4.2"
       },
       "dependencies": {
         "object-assign": {
@@ -1085,7 +1085,7 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -1100,9 +1100,9 @@
       "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.2.tgz",
       "integrity": "sha1-RhUzFTd4SYHo/SZOHzpDTE4N3WU=",
       "requires": {
-        "inherits": "2.0.3",
-        "isarray": "0.0.1",
-        "stream-splicer": "1.3.2"
+        "inherits": "^2.0.1",
+        "isarray": "~0.0.1",
+        "stream-splicer": "^1.1.0"
       }
     },
     "lexical-scope": {
@@ -1110,7 +1110,7 @@
       "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.2.0.tgz",
       "integrity": "sha1-/Ope3HBKSzqHls3KQZw6CvryLfQ=",
       "requires": {
-        "astw": "2.0.0"
+        "astw": "^2.0.0"
       }
     },
     "lodash-es": {
@@ -1128,7 +1128,7 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-3.1.1.tgz",
       "integrity": "sha1-gSIRw3ipTMKdWqTjNGzwv846ffU=",
       "requires": {
-        "lodash._getnative": "3.9.1"
+        "lodash._getnative": "^3.0.0"
       }
     },
     "lodash.memoize": {
@@ -1141,7 +1141,7 @@
       "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-3.0.4.tgz",
       "integrity": "sha1-vE9HH7Mo5Nb9xt8rPTyvET8Pick=",
       "requires": {
-        "lodash.debounce": "3.1.1"
+        "lodash.debounce": "^3.0.0"
       }
     },
     "lodash.uniq": {
@@ -1154,7 +1154,7 @@
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
       "integrity": "sha1-ayYkjEL21PpLDYVC947fzeNWQqg=",
       "requires": {
-        "js-tokens": "2.0.0"
+        "js-tokens": "^2.0.0"
       }
     },
     "material-ui": {
@@ -1162,14 +1162,14 @@
       "resolved": "https://registry.npmjs.org/material-ui/-/material-ui-0.13.4.tgz",
       "integrity": "sha1-aS7PwkTFxIzSflsEa9s9PHw3WSU=",
       "requires": {
-        "inline-style-prefixer": "0.5.4",
-        "lodash.debounce": "3.1.1",
-        "lodash.throttle": "3.0.4",
-        "react-addons-create-fragment": "0.14.8",
-        "react-addons-pure-render-mixin": "0.14.8",
-        "react-addons-transition-group": "0.14.8",
-        "react-addons-update": "0.14.7",
-        "warning": "2.1.0"
+        "inline-style-prefixer": "^0.5.1",
+        "lodash.debounce": "~3.1.1",
+        "lodash.throttle": "~3.0.4",
+        "react-addons-create-fragment": "^0.14.0",
+        "react-addons-pure-render-mixin": "^0.14.0",
+        "react-addons-transition-group": "^0.14.0",
+        "react-addons-update": "^0.14.0",
+        "warning": "^2.1.0"
       }
     },
     "miller-rabin": {
@@ -1177,8 +1177,8 @@
       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz",
       "integrity": "sha1-SmL7HUKTPAVYOYL0xxb2+55sbT0=",
       "requires": {
-        "bn.js": "4.11.6",
-        "brorand": "1.0.6"
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
       }
     },
     "minimalistic-assert": {
@@ -1191,12 +1191,12 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
       "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
       "requires": {
-        "brace-expansion": "1.1.6"
+        "brace-expansion": "^1.0.0"
       }
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mkdirp": {
@@ -1219,20 +1219,20 @@
       "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.9.1.tgz",
       "integrity": "sha1-6nXK+RmQkNJbDVUStaysuW5/h/M=",
       "requires": {
-        "JSONStream": "1.2.1",
-        "browser-resolve": "1.11.2",
-        "concat-stream": "1.4.10",
-        "defined": "1.0.0",
-        "detective": "4.3.2",
+        "JSONStream": "^1.0.3",
+        "browser-resolve": "^1.7.0",
+        "concat-stream": "~1.4.5",
+        "defined": "^1.0.0",
+        "detective": "^4.0.0",
         "duplexer2": "0.0.2",
-        "inherits": "2.0.3",
-        "parents": "1.0.1",
-        "readable-stream": "1.1.14",
-        "resolve": "1.1.7",
-        "stream-combiner2": "1.0.2",
-        "subarg": "1.0.0",
-        "through2": "1.1.1",
-        "xtend": "4.0.1"
+        "inherits": "^2.0.1",
+        "parents": "^1.0.0",
+        "readable-stream": "^1.1.13",
+        "resolve": "^1.1.3",
+        "stream-combiner2": "~1.0.0",
+        "subarg": "^1.0.0",
+        "through2": "^1.0.0",
+        "xtend": "^4.0.0"
       },
       "dependencies": {
         "JSONStream": {
@@ -1240,8 +1240,8 @@
           "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.2.1.tgz",
           "integrity": "sha1-MqpXkOeZSBCDtJtLf6lOI7rmm/k=",
           "requires": {
-            "jsonparse": "1.2.0",
-            "through": "2.3.8"
+            "jsonparse": "^1.2.0",
+            "through": ">=2.2.7 <3"
           }
         },
         "defined": {
@@ -1259,7 +1259,7 @@
           "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
           "integrity": "sha1-/t1NK/GTp3dF/nHjcdc8MwfZx1E=",
           "requires": {
-            "path-platform": "0.11.15"
+            "path-platform": "~0.11.15"
           }
         },
         "resolve": {
@@ -1279,8 +1279,8 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz",
       "integrity": "sha1-3CNO3WSJmC1Y6PDbT2lQKavNjAQ=",
       "requires": {
-        "encoding": "0.1.12",
-        "is-stream": "1.1.0"
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
       }
     },
     "object-assign": {
@@ -1293,7 +1293,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "optimist": {
@@ -1301,7 +1301,7 @@
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
       "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
       "requires": {
-        "wordwrap": "0.0.3"
+        "wordwrap": "~0.0.2"
       }
     },
     "os-browserify": {
@@ -1319,7 +1319,7 @@
       "resolved": "https://registry.npmjs.org/parents/-/parents-0.0.3.tgz",
       "integrity": "sha1-+iEvAk2fpjGNu2tM5nbIvkk7nEM=",
       "requires": {
-        "path-platform": "0.0.1"
+        "path-platform": "^0.0.1"
       },
       "dependencies": {
         "path-platform": {
@@ -1334,11 +1334,11 @@
       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.0.0.tgz",
       "integrity": "sha1-NQYPbVAV03Yox3D04JGgtaJ4vCM=",
       "requires": {
-        "asn1.js": "4.9.0",
-        "browserify-aes": "1.0.6",
-        "create-hash": "1.1.2",
-        "evp_bytestokey": "1.0.0",
-        "pbkdf2": "3.0.9"
+        "asn1.js": "^4.0.0",
+        "browserify-aes": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3"
       }
     },
     "path-browserify": {
@@ -1361,7 +1361,7 @@
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.9.tgz",
       "integrity": "sha1-8sSyWmAAWLPDdzwIbDfbvuH/5pM=",
       "requires": {
-        "create-hmac": "1.1.4"
+        "create-hmac": "^1.1.2"
       }
     },
     "private": {
@@ -1379,7 +1379,7 @@
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
       "integrity": "sha1-SJZUxpJha4qlWwck+oCbt9tJxb8=",
       "requires": {
-        "asap": "2.0.5"
+        "asap": "~2.0.3"
       }
     },
     "prop-types": {
@@ -1387,9 +1387,9 @@
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
       "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
       "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1"
+        "fbjs": "^0.8.16",
+        "loose-envify": "^1.3.1",
+        "object-assign": "^4.1.1"
       },
       "dependencies": {
         "fbjs": {
@@ -1397,13 +1397,13 @@
           "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
           "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
           "requires": {
-            "core-js": "1.2.7",
-            "isomorphic-fetch": "2.2.1",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1",
-            "promise": "7.1.1",
-            "setimmediate": "1.0.5",
-            "ua-parser-js": "0.7.11"
+            "core-js": "^1.0.0",
+            "isomorphic-fetch": "^2.1.1",
+            "loose-envify": "^1.0.0",
+            "object-assign": "^4.1.0",
+            "promise": "^7.1.1",
+            "setimmediate": "^1.0.5",
+            "ua-parser-js": "^0.7.9"
           }
         },
         "js-tokens": {
@@ -1416,7 +1416,7 @@
           "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
           "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
           "requires": {
-            "js-tokens": "3.0.2"
+            "js-tokens": "^3.0.0"
           }
         },
         "object-assign": {
@@ -1431,11 +1431,11 @@
       "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
       "integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
       "requires": {
-        "bn.js": "4.11.6",
-        "browserify-rsa": "4.0.1",
-        "create-hash": "1.1.2",
-        "parse-asn1": "5.0.0",
-        "randombytes": "2.0.3"
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1"
       }
     },
     "punycode": {
@@ -1468,8 +1468,8 @@
       "resolved": "https://registry.npmjs.org/react/-/react-0.14.8.tgz",
       "integrity": "sha1-B436RU1HRbzFSpcmMRwr8nLCNoQ=",
       "requires": {
-        "envify": "3.4.1",
-        "fbjs": "0.6.1"
+        "envify": "^3.0.0",
+        "fbjs": "^0.6.1"
       },
       "dependencies": {
         "fbjs": {
@@ -1477,11 +1477,11 @@
           "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.6.1.tgz",
           "integrity": "sha1-lja3cF9bqWhNRLcveDISVK/IYPc=",
           "requires": {
-            "core-js": "1.2.7",
-            "loose-envify": "1.3.0",
-            "promise": "7.1.1",
-            "ua-parser-js": "0.7.11",
-            "whatwg-fetch": "0.9.0"
+            "core-js": "^1.0.0",
+            "loose-envify": "^1.0.0",
+            "promise": "^7.0.3",
+            "ua-parser-js": "^0.7.9",
+            "whatwg-fetch": "^0.9.0"
           }
         },
         "whatwg-fetch": {
@@ -1526,12 +1526,12 @@
       "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-2.5.4.tgz",
       "integrity": "sha512-y9YmnusURc+3KPgvhYKvZ9oCucj51MSZWODyaeV0KFU0cquzA7dCD1g/OIYUKtNoZ+MXtacDngkdud2TklMSjw==",
       "requires": {
-        "disposables": "1.0.1",
-        "dnd-core": "2.5.4",
-        "hoist-non-react-statics": "2.3.1",
-        "invariant": "2.2.1",
-        "lodash": "4.17.4",
-        "prop-types": "15.6.0"
+        "disposables": "^1.0.1",
+        "dnd-core": "^2.5.4",
+        "hoist-non-react-statics": "^2.1.0",
+        "invariant": "^2.1.0",
+        "lodash": "^4.2.0",
+        "prop-types": "^15.5.10"
       },
       "dependencies": {
         "asap": {
@@ -1544,10 +1544,10 @@
           "resolved": "https://registry.npmjs.org/dnd-core/-/dnd-core-2.5.4.tgz",
           "integrity": "sha512-BcI782MfTm3wCxeIS5c7tAutyTwEIANtuu3W6/xkoJRwiqhRXKX3BbGlycUxxyzMsKdvvoavxgrC3EMPFNYL9A==",
           "requires": {
-            "asap": "2.0.6",
-            "invariant": "2.2.1",
-            "lodash": "4.17.4",
-            "redux": "3.7.2"
+            "asap": "^2.0.6",
+            "invariant": "^2.0.0",
+            "lodash": "^4.2.0",
+            "redux": "^3.7.1"
           }
         },
         "lodash": {
@@ -1560,10 +1560,10 @@
           "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
           "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
           "requires": {
-            "lodash": "4.17.4",
-            "lodash-es": "4.16.6",
-            "loose-envify": "1.3.0",
-            "symbol-observable": "1.0.4"
+            "lodash": "^4.2.1",
+            "lodash-es": "^4.2.1",
+            "loose-envify": "^1.1.0",
+            "symbol-observable": "^1.0.3"
           }
         }
       }
@@ -1573,7 +1573,7 @@
       "resolved": "https://registry.npmjs.org/react-dnd-html5-backend/-/react-dnd-html5-backend-2.5.4.tgz",
       "integrity": "sha512-jDqAkm/hI8Tl4HcsbhkBgB6HgpJR1e+ML1SbfxaegXYiuMxEVQm0FOwEH5WxUoo6fmIG4N+H0rSm59POuZOCaA==",
       "requires": {
-        "lodash": "4.17.4"
+        "lodash": "^4.2.0"
       },
       "dependencies": {
         "lodash": {
@@ -1598,7 +1598,7 @@
       "resolved": "https://registry.npmjs.org/react-tap-event-plugin/-/react-tap-event-plugin-0.2.1.tgz",
       "integrity": "sha1-fWrf4jWLfQeJxzym/zW6dWZs6GA=",
       "requires": {
-        "fbjs": "0.2.1"
+        "fbjs": "^0.2.1"
       },
       "dependencies": {
         "fbjs": {
@@ -1606,9 +1606,9 @@
           "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.2.1.tgz",
           "integrity": "sha1-YiBhYwpD4R+EUBe5BEqqZI7T9zE=",
           "requires": {
-            "core-js": "1.2.7",
-            "promise": "7.1.1",
-            "whatwg-fetch": "0.9.0"
+            "core-js": "^1.0.0",
+            "promise": "^7.0.3",
+            "whatwg-fetch": "^0.9.0"
           }
         },
         "whatwg-fetch": {
@@ -1623,8 +1623,8 @@
       "resolved": "https://registry.npmjs.org/react-tools/-/react-tools-0.12.2.tgz",
       "integrity": "sha1-kuVaJPhBLfZYNVXdls64zbJK6G4=",
       "requires": {
-        "commoner": "0.10.4",
-        "jstransform": "8.2.0"
+        "commoner": "^0.10.0",
+        "jstransform": "^8.2.0"
       },
       "dependencies": {
         "base62": {
@@ -1652,7 +1652,7 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.31.tgz",
           "integrity": "sha1-n3BNDWnZ4TioG63267T94z0VHGE=",
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -1662,9 +1662,9 @@
       "resolved": "https://registry.npmjs.org/reactify/-/reactify-0.17.1.tgz",
       "integrity": "sha1-CkaDzKWaTHp2lXn+L+wKm9+B7tY=",
       "requires": {
-        "jstransform": "8.2.0",
-        "react-tools": "0.12.2",
-        "through": "2.3.8"
+        "jstransform": "^8.0.0",
+        "react-tools": "~0.12.1",
+        "through": "~2.3.4"
       },
       "dependencies": {
         "base62": {
@@ -1692,7 +1692,7 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.31.tgz",
           "integrity": "sha1-n3BNDWnZ4TioG63267T94z0VHGE=",
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -1702,10 +1702,10 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
       "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
         "isarray": "0.0.1",
-        "string_decoder": "0.10.31"
+        "string_decoder": "~0.10.x"
       }
     },
     "readable-wrap": {
@@ -1713,7 +1713,7 @@
       "resolved": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz",
       "integrity": "sha1-O1ohHGMeEjA6VJkcgGwX564ga/8=",
       "requires": {
-        "readable-stream": "1.1.14"
+        "readable-stream": "^1.1.13-1"
       }
     },
     "recast": {
@@ -1722,9 +1722,9 @@
       "integrity": "sha1-uV1Q9tYHYaX2JS4V2AZ4FoSRzn8=",
       "requires": {
         "ast-types": "0.8.15",
-        "esprima-fb": "15001.1001.0-dev-harmony-fb",
-        "private": "0.1.6",
-        "source-map": "0.5.6"
+        "esprima-fb": "~15001.1001.0-dev-harmony-fb",
+        "private": "~0.1.5",
+        "source-map": "~0.5.0"
       },
       "dependencies": {
         "esprima-fb": {
@@ -1744,7 +1744,7 @@
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "requires": {
-        "resolve": "1.1.7"
+        "resolve": "^1.1.6"
       },
       "dependencies": {
         "resolve": {
@@ -1764,8 +1764,8 @@
       "resolved": "https://registry.npmjs.org/rfile/-/rfile-1.0.0.tgz",
       "integrity": "sha1-WXCM+Qyh50xUw8/Fw2/bmBBDUmE=",
       "requires": {
-        "callsite": "1.0.0",
-        "resolve": "0.3.1"
+        "callsite": "~1.0.0",
+        "resolve": "~0.3.0"
       },
       "dependencies": {
         "resolve": {
@@ -1785,17 +1785,17 @@
       "resolved": "https://registry.npmjs.org/ruglify/-/ruglify-1.0.0.tgz",
       "integrity": "sha1-3Ikw4qlUSidDAcyZcldMDQmGtnU=",
       "requires": {
-        "rfile": "1.0.0",
-        "uglify-js": "2.2.5"
+        "rfile": "~1.0",
+        "uglify-js": "~2.2"
       },
       "dependencies": {
         "uglify-js": {
           "version": "2.2.5",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
+          "resolved": "http://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
           "integrity": "sha1-puAqcNg5eSuXgEiLe4sYTAlcmcc=",
           "requires": {
-            "optimist": "0.3.7",
-            "source-map": "0.1.43"
+            "optimist": "~0.3.5",
+            "source-map": "~0.1.7"
           }
         }
       }
@@ -1810,7 +1810,7 @@
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.5.tgz",
       "integrity": "sha1-J9Fx78yCoRi5ljn/WBZgJCtQbnw=",
       "requires": {
-        "inherits": "2.0.3"
+        "inherits": "^2.0.1"
       }
     },
     "shallow-copy": {
@@ -1820,11 +1820,11 @@
     },
     "shasum": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
       "integrity": "sha1-5wEjENj0F/TetXEhUOVni4euVl8=",
       "requires": {
-        "json-stable-stringify": "0.0.1",
-        "sha.js": "2.4.5"
+        "json-stable-stringify": "~0.0.0",
+        "sha.js": "~2.4.4"
       }
     },
     "shell-quote": {
@@ -1837,9 +1837,9 @@
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.5.tgz",
       "integrity": "sha1-Lu96UKIeHM832gDfdn7GnjCtBnU=",
       "requires": {
-        "glob": "7.1.1",
-        "interpret": "1.0.1",
-        "rechoir": "0.6.2"
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
       },
       "dependencies": {
         "glob": {
@@ -1847,12 +1847,12 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
           "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.3",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.2",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "minimatch": {
@@ -1860,7 +1860,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
           "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
           "requires": {
-            "brace-expansion": "1.1.6"
+            "brace-expansion": "^1.0.0"
           }
         }
       }
@@ -1870,7 +1870,7 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
       "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
       "requires": {
-        "amdefine": "1.0.1"
+        "amdefine": ">=0.0.4"
       }
     },
     "stream-browserify": {
@@ -1878,8 +1878,8 @@
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
       "integrity": "sha1-v5tKv7QrJ011FHnkTg/yZWtvEZM=",
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "1.1.14"
+        "inherits": "~2.0.1",
+        "readable-stream": "^1.0.27-1"
       }
     },
     "stream-combiner2": {
@@ -1887,19 +1887,19 @@
       "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
       "integrity": "sha1-unKmtQy/q/qVD8i8h2BL0B62BnE=",
       "requires": {
-        "duplexer2": "0.0.2",
-        "through2": "0.5.1"
+        "duplexer2": "~0.0.2",
+        "through2": "~0.5.1"
       },
       "dependencies": {
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "through2": {
@@ -1907,8 +1907,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
           "integrity": "sha1-390BLrnHAOIyP9M084rGIqs3Lac=",
           "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "3.0.0"
+            "readable-stream": "~1.0.17",
+            "xtend": "~3.0.0"
           }
         }
       }
@@ -1919,11 +1919,11 @@
       "integrity": "sha1-PARBvhW5v04iYnXm3IOWR0VUZmE=",
       "requires": {
         "indexof": "0.0.1",
-        "inherits": "2.0.3",
-        "isarray": "0.0.1",
-        "readable-stream": "1.1.14",
-        "readable-wrap": "1.0.0",
-        "through2": "1.1.1"
+        "inherits": "^2.0.1",
+        "isarray": "~0.0.1",
+        "readable-stream": "^1.1.13-1",
+        "readable-wrap": "^1.0.0",
+        "through2": "^1.0.0"
       }
     },
     "string_decoder": {
@@ -1936,7 +1936,7 @@
       "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
       "integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
       "requires": {
-        "minimist": "1.2.0"
+        "minimist": "^1.1.0"
       }
     },
     "symbol-observable": {
@@ -1949,7 +1949,7 @@
       "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.6.tgz",
       "integrity": "sha1-tFSXBtOGzBwdx8JCPxhXm2yt5xA=",
       "requires": {
-        "acorn": "2.7.0"
+        "acorn": "^2.7.0"
       },
       "dependencies": {
         "acorn": {
@@ -1969,8 +1969,8 @@
       "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
       "integrity": "sha1-CEfLxESfNAVXTb3M2buEG4OsNUU=",
       "requires": {
-        "readable-stream": "1.1.14",
-        "xtend": "4.0.1"
+        "readable-stream": ">=1.1.13-1 <1.2.0-0",
+        "xtend": ">=4.0.0 <4.1.0-0"
       },
       "dependencies": {
         "xtend": {
@@ -1985,7 +1985,7 @@
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
       "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
       "requires": {
-        "process": "0.11.9"
+        "process": "~0.11.0"
       },
       "dependencies": {
         "process": {
@@ -2012,13 +2012,13 @@
     },
     "uglify-js": {
       "version": "2.4.24",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
+      "resolved": "http://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
       "integrity": "sha1-+tV1XB4Vd2WLsG/5q25UjJW+vW4=",
       "requires": {
-        "async": "0.2.10",
+        "async": "~0.2.6",
         "source-map": "0.1.34",
-        "uglify-to-browserify": "1.0.2",
-        "yargs": "3.5.4"
+        "uglify-to-browserify": "~1.0.0",
+        "yargs": "~3.5.4"
       },
       "dependencies": {
         "source-map": {
@@ -2026,7 +2026,7 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
           "integrity": "sha1-p8/omux7FoLDsZjQrPtH19CQVms=",
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -2041,10 +2041,10 @@
       "resolved": "https://registry.npmjs.org/umd/-/umd-2.1.0.tgz",
       "integrity": "sha1-SmMHt2LxfwLSAbX6FU5nM5bCY88=",
       "requires": {
-        "rfile": "1.0.0",
-        "ruglify": "1.0.0",
-        "through": "2.3.8",
-        "uglify-js": "2.4.24"
+        "rfile": "~1.0.0",
+        "ruglify": "~1.0.0",
+        "through": "~2.3.4",
+        "uglify-js": "~2.4.0"
       }
     },
     "url": {
@@ -2091,7 +2091,7 @@
       "resolved": "https://registry.npmjs.org/warning/-/warning-2.1.0.tgz",
       "integrity": "sha1-ISINnGOvx3qMkhEeARr3Bc4MaQE=",
       "requires": {
-        "loose-envify": "1.3.0"
+        "loose-envify": "^1.0.0"
       }
     },
     "whatwg-fetch": {
@@ -2121,11 +2121,11 @@
     },
     "yargs": {
       "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
+      "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
       "integrity": "sha1-2K/49mXpTDS9JZvevRv68N3TU2E=",
       "requires": {
-        "camelcase": "1.2.1",
-        "decamelize": "1.2.0",
+        "camelcase": "^1.0.2",
+        "decamelize": "^1.0.0",
         "window-size": "0.1.0",
         "wordwrap": "0.0.2"
       },

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "react-tools": "0.12.2"
   },
   "engines": {
-    "node": ">=5.5.0"
+    "node": ">=10.0.0"
   },
   "scripts": {
     "test": "node ./node_modules/jest-cli/bin/jest.js"

--- a/spec/controllers/v1/facets_controller_spec.rb
+++ b/spec/controllers/v1/facets_controller_spec.rb
@@ -1,0 +1,167 @@
+require "rails_helper"
+require "cache_spec_helper"
+
+RSpec.describe V1::FacetsController, type: :controller do
+  let(:collection) { instance_double(Collection, id: 1) }
+  let(:configuration) { double(Metadata::Configuration) }
+
+  before(:each) do
+    allow_any_instance_of(CollectionQuery).to receive(:any_find).and_return(collection)
+    @user = sign_in_admin
+  end
+
+  describe "update" do
+    let(:params) { { label: "name" } }
+    subject { put :update, collection_id: 1, id: "id", facets: params, format: :json }
+
+    before(:each) do
+      allow(Metadata::UpdateConfigurationFacet).to receive(:call).and_return(true)
+    end
+
+    it "queries for the collection" do
+      expect_any_instance_of(CollectionQuery).to receive(:any_find).and_return(collection)
+      subject
+    end
+
+    it "calls Metadata::UpdateConfigurationFacet with an empty hash even if there are no params in order to perform validation" do
+      expect(Metadata::UpdateConfigurationFacet).to receive(:call).with(collection, "id", {}).and_return(true)
+      put :update, collection_id: 1, id: "id", format: :json
+    end
+
+    it "uses the Metadata::UpdateConfigurationFacet to update the data" do
+      expect(Metadata::UpdateConfigurationFacet).to receive(:call).with(collection, "id", params)
+      subject
+    end
+
+    it "checks the editor permissions" do
+      expect_any_instance_of(described_class).to receive(:user_can_edit?).with(collection)
+      subject
+    end
+  end
+
+  describe "create" do
+    let(:params) { { label: "name" } }
+    subject { post :create, collection_id: 1, facets: params, format: :json }
+
+    before(:each) do
+      allow(Metadata::CreateConfigurationFacet).to receive(:call).and_return(true)
+    end
+
+    it "queries for the collection" do
+      expect_any_instance_of(CollectionQuery).to receive(:any_find).and_return(collection)
+      subject
+    end
+
+    it "calls Metadata::CreateConfigurationFacet with an empty hash even if there are no params in order to perform validation" do
+      expect(Metadata::CreateConfigurationFacet).to receive(:call).with(collection, {}).and_return(true)
+      post :create, collection_id: 1, id: "id", format: :json
+    end
+
+    it "uses the Metadata::CreateConfigurationFacet to update the data" do
+      expect(Metadata::CreateConfigurationFacet).to receive(:call).with(collection, params)
+      subject
+    end
+
+    it "checks the editor permissions" do
+      expect_any_instance_of(described_class).to receive(:user_can_edit?).with(collection)
+      subject
+    end
+
+    it "renders success if the save succeeds" do
+      subject
+      expect(response.status).to eq(200)
+    end
+
+    it "renders the new facet in the json response if the save succeeds" do
+      subject
+      expect(JSON.parse(response.body)).to include("facet" => true)
+    end
+
+    it "returns unprocessable entity if the save fails" do
+      allow(Metadata::CreateConfigurationFacet).to receive(:call).with(collection, params).and_return(false)
+      subject
+      expect(response.status).to eq(422)
+    end
+
+    it "returns the facet params in the json response if the save fails" do
+      allow(Metadata::CreateConfigurationFacet).to receive(:call).with(collection, params).and_return(false)
+      subject
+      expect(JSON.parse(response.body)).to include("facet" => params.stringify_keys)
+    end
+  end
+
+  describe "destroy" do
+    let(:id) { "name" }
+    subject { delete :destroy, collection_id: 1, id: id, format: :json }
+
+    before(:each) do
+      allow(Metadata::RemoveConfigurationFacet).to receive(:call).and_return(true)
+    end
+
+    it "queries for the collection" do
+      expect_any_instance_of(CollectionQuery).to receive(:any_find).and_return(collection)
+      subject
+    end
+
+    it "uses the Metadata::RemoveConfigurationFacet to delete the facet" do
+      expect(Metadata::RemoveConfigurationFacet).to receive(:call).with(collection, id)
+      subject
+    end
+
+    it "checks the editor permissions" do
+      expect_any_instance_of(described_class).to receive(:user_can_edit?).with(collection)
+      subject
+    end
+
+    it "renders success if the save succeeds" do
+      subject
+      expect(response.status).to eq(200)
+    end
+
+    it "renders success in the json response if the remove succeeds" do
+      subject
+      expect(JSON.parse(response.body)).to include("success" => true)
+    end
+
+    it "returns unprocessable entity if the remove fails" do
+      allow(Metadata::RemoveConfigurationFacet).to receive(:call).with(collection, id).and_return(false)
+      subject
+      expect(response.status).to eq(422)
+    end
+
+    it "returns the facet params in the json response if the remove fails" do
+      allow(Metadata::RemoveConfigurationFacet).to receive(:call).with(collection, id).and_return(false)
+      subject
+      expect(JSON.parse(response.body)).to include("id" => id)
+    end
+  end
+
+  describe "reorder" do
+    let(:params) { { "0" => { facet: "name", order: 1 } } }
+    subject { put :reorder, collection_id: 1, facets: params, format: :json }
+
+    before(:each) do
+      allow(ReorderFacets).to receive(:call).and_return(true)
+    end
+
+    it "queries for the collection" do
+      expect_any_instance_of(CollectionQuery).to receive(:any_find).and_return(collection)
+      subject
+    end
+
+    it "calls Metadata::UpdateConfigurationFacet with an empty hash even if there are no params in order to perform validation" do
+      expect(ReorderFacets).to receive(:call).with(collection, params).and_return(true)
+      put :reorder, collection_id: 1, facets: params, format: :json
+    end
+
+    it "uses the Metadata::UpdateConfigurationFacet to update the data" do
+      expect(ReorderFacets).to receive(:call).with(collection, params)
+      subject
+    end
+
+    it "checks the editor permissions" do
+      expect_any_instance_of(described_class).to receive(:user_can_edit?).with(collection)
+      subject
+    end
+  end
+end

--- a/spec/models/metadata/configuration/facet_spec.rb
+++ b/spec/models/metadata/configuration/facet_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Metadata::Configuration::Facet do
   let(:field) { instance_double(Metadata::Configuration::Field, name: :my_field, label: "Default Label") }
-  let(:data) { { name: :my_facet, field_name: :my_field, field: field, label: "Custom Label", active: false, limit: 462 } }
+  let(:data) { { name: :my_facet, field_name: :my_facet, field: field, label: "Custom Label", active: false, limit: 462, order: 3 } }
   let(:instance) { described_class.new(data) }
   subject { instance }
 
@@ -51,9 +51,67 @@ RSpec.describe Metadata::Configuration::Facet do
       expect(subject.limit).to eq(data.fetch(:limit))
     end
 
-    it "is assumed nil if not given in params" do
+    it "is assumed 5 if not given in params" do
       data.delete(:limit)
-      expect(subject.limit).to eq(nil)
+      expect(subject.limit).to eq(5)
+    end
+  end
+
+  describe "order" do
+    it "is the expected value" do
+      expect(subject.order).to eq(data.fetch(:order))
+    end
+  end
+
+  describe "to_hash" do
+    it "converts the data to a hash." do
+      expect(subject.to_hash).to eq(
+        name: :my_facet,
+        field: field,
+        field_name: :my_facet,
+        label: "Custom Label",
+        active: false,
+        limit: 462,
+        order: 3
+      )
+    end
+  end
+
+  describe "update" do
+    it "changes the values of the fields passed in" do
+      subject.update(order: "new_order", label: "NAME!")
+      expect(subject.order).to eq("new_order")
+      expect(subject.label).to eq("NAME!")
+    end
+
+    it "errors if there are invalid keys in the field hash" do
+      expect { subject.update(not_a_key: "value") }.to raise_error
+    end
+
+    it "returns true if it is a valid update" do
+      expect(subject.update(label: "NAME!")).to be(true)
+    end
+
+    it "does not allow name to be changed" do
+      subject.update(name: "new_name")
+      expect(subject.name).to eq(:my_facet)
+    end
+
+    it "does not allow field to be changed" do
+      subject.update(field: instance_double(Metadata::Configuration::Field, name: :new_field, label: "New Field Label"))
+      expect(subject.field).to eq(field)
+    end
+
+    it "converts string booleans to bools" do
+      subject.update(active: "true")
+      expect(subject.active).to eq(true)
+      subject.update(active: "false")
+      expect(subject.active).to eq(false)
+    end
+
+    it "works with string keys" do
+      subject.update("label" => "NAME!")
+      expect(subject.label).to eq("NAME!")
     end
   end
 end

--- a/spec/queries/person_api_search_spec.rb
+++ b/spec/queries/person_api_search_spec.rb
@@ -29,15 +29,15 @@ RSpec.describe PersonAPISearch do
 
     describe "special characters" do
       let(:query) { "<test>" }
-      it "encodes the query string and adds a wildcard" do
-        expect(subject.send(:query_search_string)).to eq("%3Ctest%3E*")
+      it "encodes the query string" do
+        expect(subject.send(:query_search_string)).to eq("%3Ctest%3E")
       end
     end
   end
 
   describe "#results" do
     it "calls HesburghAPI::PersonSearch with a formatted term" do
-      expect(HesburghAPI::PersonSearch).to receive(:search).with("test*").and_return([])
+      expect(HesburghAPI::PersonSearch).to receive(:search).with("test").and_return([])
       expect(subject.results).to eq([])
     end
 

--- a/spec/services/metatdata/create_configuration_facet_spec.rb
+++ b/spec/services/metatdata/create_configuration_facet_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+RSpec.describe Metadata::CreateConfigurationFacet do
+  let(:configuration) { double(Metadata::Configuration) }
+  let(:collection) { double(Collection) }
+  let(:unique_key) { 'facetName' }
+  let(:data) { { name: nil, field_name: 'facetName', unlimited: true } }
+
+  before(:each) do
+    allow_any_instance_of(CollectionConfigurationQuery).to receive(:find).and_return(configuration)
+    allow(configuration).to receive(:save_facet)
+    allow(Metadata::ConfigurationInputCleaner).to receive(:call).and_return(data)
+    allow_any_instance_of(Metadata::CreateConfigurationFacet).to receive(:duplicate_name?).and_return(false)
+  end
+
+  context "when name is unique" do
+    it "calls save_facet on the configuration" do
+      expect(configuration).to receive(:save_facet).with(unique_key, data)
+      described_class.call(collection, data)
+    end
+
+    it "calls the cleaner on the input data" do
+      expect(Metadata::ConfigurationInputCleaner).to receive(:call).with(data)
+      described_class.call(collection, data)
+    end
+
+    it "gets a default limit when one is not present" do
+      data.delete(:limit)
+      described_class.call(collection, data)
+      expect(data[:limit]).to be >= 0
+    end
+
+    it "uses the limit given when one is present" do
+      data[:limit] = 10
+      described_class.call(collection, data)
+      expect(data[:limit]).to eq(10)
+    end
+
+    it "populates a default value for active when one is not present" do
+      data.delete(:active)
+      described_class.call(collection, data)
+      expect(data[:active]).to eq(true)
+    end
+
+    it "uses the value given for active when one is present" do
+      data[:active] = false
+      described_class.call(collection, data)
+      expect(data[:active]).to eq(false)
+    end
+  end
+
+  context "when name is not unique" do
+    before(:each) do
+      allow_any_instance_of(Metadata::CreateConfigurationFacet).to receive(:duplicate_name?).and_return(true)
+    end
+
+    it "returns duplicate_found" do
+      expect(described_class.call(collection, data)).to be_nil
+    end
+
+    it "does not save_facet on the configuration" do
+      expect(configuration).to_not receive(:save_facet).with(unique_key, data)
+      described_class.call(collection, data)
+    end
+  end
+end

--- a/spec/services/metatdata/remove_configuration_facet_spec.rb
+++ b/spec/services/metatdata/remove_configuration_facet_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.describe Metadata::RemoveConfigurationFacet do
+  let(:configuration) { double(Metadata::Configuration) }
+  let(:collection) { double(Collection) }
+
+  before(:each) do
+    allow_any_instance_of(CollectionConfigurationQuery).to receive(:find).and_return(configuration)
+    allow(configuration).to receive(:save_facet)
+  end
+
+  it "calls save_facet on the configuration with nil data" do
+    expect(configuration).to receive(:save_facet).with(:facet_name, nil)
+    described_class.call(collection, :facet_name)
+  end
+end

--- a/spec/services/metatdata/update_configuration_facet_spec.rb
+++ b/spec/services/metatdata/update_configuration_facet_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe Metadata::UpdateConfigurationFacet do
+  let(:configuration) { double(Metadata::Configuration) }
+  let(:collection) { double(Collection) }
+  let(:data) { { name: 'test', unlimited: true } }
+
+  before(:each) do
+    allow_any_instance_of(CollectionConfigurationQuery).to receive(:find).and_return(configuration)
+    allow(configuration).to receive(:save_facet)
+    allow(Metadata::ConfigurationInputCleaner).to receive(:call).and_return(data)
+  end
+
+  it "calls save_facet on the configuration" do
+    expect(configuration).to receive(:save_facet).with(:facet_name, data)
+    described_class.call(collection, :facet_name, data)
+  end
+
+  it "calls the cleaner on the input data" do
+    expect(Metadata::ConfigurationInputCleaner).to receive(:call).with(data)
+    described_class.call(collection, :facet_name, data)
+  end
+end

--- a/spec/services/reorder_facets_spec.rb
+++ b/spec/services/reorder_facets_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+describe ReorderFacets do
+  subject { described_class.call(collection, new_order) }
+
+  let(:collection) { double(Collection) }
+  let(:new_order) { { "0" => { "name" => "facetName", "order" => 1 } } }
+  let(:configuration) { double(Metadata::Configuration, facet: "facetName", save_facet: true) }
+
+  before(:each) do
+    allow_any_instance_of(CollectionConfigurationQuery).to receive(:find).and_return(configuration)
+  end
+
+  it "passes the data to configuration save_facet " do
+    expect(configuration).to receive(:save_facet).with("facetName", "order" => 1)
+    subject
+  end
+
+  it "does not call save_facet if the facet value is not found" do
+    allow(configuration).to receive(:facet).and_return(false)
+    subject
+  end
+
+  it "calls facet with the name passed in" do
+    expect(configuration).to receive(:facet).with(new_order["0"]["name"])
+    subject
+  end
+end


### PR DESCRIPTION
Allows collection curators to select from a new tab on the Metadata page to add, edit, remove, and reorder facets.

Should be backwards-compatible with all existing facets. No changes to the structure in database storage, other than the addition of the "order" property which is optional to support existing facets.