### PR TITLE
DEC-1447 Add reindex button to metadata settings page.

### DIFF
--- a/app/assets/javascripts/components/forms/MetaDataConfigurationForm/MetaDataConfigurationForm.jsx
+++ b/app/assets/javascripts/components/forms/MetaDataConfigurationForm/MetaDataConfigurationForm.jsx
@@ -17,6 +17,9 @@ var TabStyle = { borderRight: "1px white solid" };
 var TabsStyle = {
   backgroundColor: "#7F8C8D",
 };
+var ComponentStyle = {
+  marginBottom: "40px",
+};
 
 var MetaDataConfigurationForm = React.createClass({
   propTypes: {
@@ -26,7 +29,7 @@ var MetaDataConfigurationForm = React.createClass({
 
   render: function(){
     return (
-      <Tabs tabItemContainerStyle={ TabsStyle }>
+      <Tabs style={ComponentStyle} tabItemContainerStyle={ TabsStyle }>
         <Tab label="Edit" style={TabStyle}>
           <MetaDataConfigurationList baseUpdateUrl={this.props.baseUpdateUrl} />
         </Tab>

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -114,6 +114,18 @@ class CollectionsController < ApplicationController
     end
   end
 
+  def reindex
+    collection = CollectionQuery.new.find(params[:id])
+    check_user_edits!(collection)
+
+    if QueueJob.call(ReindexCollectionJob, collection_id: params[:id])
+      flash[:notice] = t(".success")
+      redirect_to settings_form_collection_path(collection, form: "metadata")
+    else
+      render :settings
+    end
+  end
+
   protected
 
   def save_params

--- a/app/decorators/reindex_panel.rb
+++ b/app/decorators/reindex_panel.rb
@@ -1,0 +1,23 @@
+require "draper"
+
+class ReindexPanel < Draper::Decorator
+  attr_accessor :path
+
+  def display()
+    yield(self) if block_given?
+
+    h.render partial: "shared/reindex_panel", locals: { default_name: default_name, path: path, i18n_key_base: i18n_key_base }
+  end
+
+  def default_name
+    object.class.to_s
+  end
+
+  def path
+    @path || h.url_for(object) + '/reindex'
+  end
+
+  def i18n_key_base
+    "#{object.class.to_s.downcase.pluralize}.reindex_panel"
+  end
+end

--- a/app/jobs/reindex_collection_job.rb
+++ b/app/jobs/reindex_collection_job.rb
@@ -1,0 +1,9 @@
+class ReindexCollectionJob < ActiveJob::Base
+  queue_as :honeycomb_index
+
+  def perform(collection_id:)
+    collection = Collection.find(collection_id)
+
+    Index::Collection.index!(collection: collection)
+  end
+end

--- a/app/views/collections/_metadata_settings_form.html.erb
+++ b/app/views/collections/_metadata_settings_form.html.erb
@@ -4,3 +4,4 @@
   facetUpdateUrl: v1_collection_configurations_facets_path(@collection.unique_id),
   sortUpdateUrl: v1_collection_configurations_sorts_path(@collection.unique_id),
 ) %>
+<%= ReindexPanel.new(@collection).display %>

--- a/app/views/shared/_reindex_panel.html.erb
+++ b/app/views/shared/_reindex_panel.html.erb
@@ -1,0 +1,16 @@
+<div class="panel panel-danger">
+  <div class="panel-heading">
+    <h3 class="panel-title"><%= t('.title', default: 'Proceed with caution') %></h3>
+  </div>
+  <div class="panel-body">
+    <h4 class=""><%= t("#{i18n_key_base}.heading", default: "Reindex this #{default_name}") %></h4>
+    <p class=""><%= t("#{i18n_key_base}.message", default: "This will reindex all items in the #{default_name}. This may take several minutes to complete depending on collection size. Items may not be discoverable on the live site while reindexing is in progress.") %></p>
+    <%= link_to content_tag('span', t("#{i18n_key_base}.heading", default: "Reindex this #{default_name}") , class: ''),
+                path,
+                class: "btn btn-small btn-default btn-danger",
+                method: :post,
+                data: { confirm: "#{t("#{i18n_key_base}.message",
+                        default: "This will reindex all items in the #{default_name}. This may take several minutes to complete depending on collection size. Items may not be discoverable on the live site while reindexing is in progress.")} Are you sure you wish to continue?" }
+    %>
+  </div>
+</div>

--- a/app/workers/honeycomb_index_worker.rb
+++ b/app/workers/honeycomb_index_worker.rb
@@ -1,0 +1,7 @@
+class HoneycombIndexWorker < RetryWorker
+  from_queue "honeycomb_index",
+             threads: 1,
+             timeout_job_after: 3600,
+             prefetch: 1,
+             retry_max_times: 1
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -99,9 +99,14 @@ en:
       success: 'Collection updated'
     destroy:
       success: "Collection deleted"
+    reindex:
+      success: "Reindex queued. Please allow a few minutes for indexing to process."
     delete_panel:
       heading: Delete this Collection
       message: "Proceed with caution. This will also remove all items and showcases."
+    reindex_panel:
+      heading: Reindex this Collection
+      message: "Reindex all items in this collection. This may take several minutes to complete depending on collection size. Items may not be discoverable on the live site while reindexing is in progress."
   import:
     import_google_sheet_callback:
       title: "Import Results"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,7 @@ Rails.application.routes.draw do
   resources :errors
 
   resources :collections,
-            only: [:index, :show, :new, :create, :edit, :update, :destroy] do
+            only: [:index, :show, :new, :create, :edit, :update, :destroy, :reindex] do
     collection do
       get :import_google_sheet_callback, controller: "import"
       get :export_google_sheet_callback, controller: "export"
@@ -36,6 +36,7 @@ Rails.application.routes.draw do
       put :unpublish
       post :get_google_import_authorization_uri, controller: "import"
       post :get_google_export_authorization_uri, controller: "export"
+      post :reindex
     end
 
     resources :items, only: [:index, :new, :create]

--- a/lib/tasks/sneakers.rake
+++ b/lib/tasks/sneakers.rake
@@ -108,6 +108,7 @@ namespace :sneakers do
       workers = []
       worker_classes = [
         HoneypotImageWorker,
+        HoneycombIndexWorker,
       ]
       worker_classes.each do |worker_class|
         SneakersRakeHelper::test_worker(worker_class)

--- a/spec/decorators/reindex_panel_spec.rb
+++ b/spec/decorators/reindex_panel_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe ReindexPanel do
+  subject { described_class.new(object) }
+  let(:object) { double(Collection, id: 1) }
+
+  before(:each) do
+    allow(subject.h).to receive(:url_for).and_return('/collections/1')
+  end
+
+  it "renders the reindex section template" do
+    required_locals = { path: '/collections/1/reindex' }
+    expect(subject.h).to receive(:render).with(partial: "shared/reindex_panel", locals: hash_including(required_locals))
+    subject.display
+  end
+
+  it "allows the path to be set" do
+    subject.display do |ds|
+      ds.path = "/path"
+    end
+
+    expect(subject.path).to eq("/path")
+  end
+end

--- a/spec/jobs/reindex_collection_job_spec.rb
+++ b/spec/jobs/reindex_collection_job_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe ReindexCollectionJob, type: :job do
+  let(:collection_id) { 1 }
+  let(:collection) { instance_double(Collection, id: 1, name_line_1: "name_line_1") }
+
+  subject { described_class }
+
+  describe "#perform" do
+    before do
+      allow(Collection).to receive(:find).and_return(collection)
+    end
+
+    it "calls Index::Collection.index! with params" do
+      expect(Index::Collection).to receive(:index!).with(collection: collection)
+      subject.perform_now(collection_id: collection_id)
+    end
+  end
+end

--- a/spec/workers/honeycomb_index_worker_spec.rb
+++ b/spec/workers/honeycomb_index_worker_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe HoneycombIndexWorker, type: :worker do
+  subject { described_class.new }
+
+  let (:queue) { subject.queue }
+
+  let (:queue_options) { queue.opts.to_hash }
+
+  describe "self" do
+    subject { described_class }
+
+    describe "#number_of_workers" do
+      it "is 1" do
+        expect(subject.number_of_workers).to eq(1)
+      end
+    end
+  end
+
+  describe "queue" do
+    it "uses the correct queue name" do
+      expect(queue.name).to eq("honeycomb_index")
+    end
+
+    it "sets the correct queue options" do
+      expect(queue_options[:arguments]).to eq(:"x-dead-letter-exchange" => "honeycomb_index-retry")
+      expect(queue_options[:handler]).to eq(Sneakers::Handlers::Maxretry)
+      expect(queue_options[:routing_key]).to eq(["honeycomb_index"])
+      expect(queue_options[:threads]).to eq(1)
+      expect(queue_options[:timeout_job_after]).to eq(3600)
+      expect(queue_options[:prefetch]).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
This will allow curators to reindex their collections on demand, as is needed when adding facets.