### PR TITLE
Add "prep" environment.

### DIFF
--- a/config/deploy/prep.rb
+++ b/config/deploy/prep.rb
@@ -1,0 +1,20 @@
+set :rack_env, :prep
+
+# Simple Role Syntax
+# ==================
+# Supports bulk-adding hosts to roles, the primary server in each group
+# is considered to be the first unless any hosts have the primary
+# property set.  Don't declare `role :all`, it's a meta role.
+
+# role :web, %w{deploy@example.com}
+# role :app, %w{deploy@example.com}
+# role :db,  %w{deploy@example.com}
+
+# Extended Server Syntax
+# ======================
+# This can be used to drop a more detailed server definition into the
+# server list. The second argument is a, or duck-types, Hash and is
+# used to set extended properties on the server.
+
+# server 'example.com', user: 'deploy', roles: %w{web app}, my_property: :my_value
+server "honeycomb-prep.lc.nd.edu", user: "app", roles: %w{web app db}

--- a/config/environments/prep.rb
+++ b/config/environments/prep.rb
@@ -1,0 +1,85 @@
+Rails.application.configure do
+  # Settings specified here will take precedence over those in config/application.rb.
+
+  # Code is not reloaded between requests.
+  config.cache_classes = true
+
+  # Eager load code on boot. This eager loads most of Rails and
+  # your application in memory, allowing both threaded web servers
+  # and those relying on copy on write to perform better.
+  # Rake tasks automatically ignore this option for performance.
+  config.eager_load = true
+
+  # Full error reports are disabled and caching is turned on.
+  config.consider_all_requests_local       = true
+  config.action_controller.perform_caching = true
+
+  # Enable Rack::Cache to put a simple HTTP cache in front of your application
+  # Add `rack-cache` to your Gemfile before enabling this.
+  # For large-scale production use, consider using a caching reverse proxy like nginx, varnish or squid.
+  # config.action_dispatch.rack_cache = true
+
+  # Disable Rails's static asset server (Apache or nginx will already do this).
+  config.serve_static_files = false
+
+  # Compress JavaScripts and CSS.
+  config.assets.js_compressor = :uglifier
+  # config.assets.css_compressor = :sass
+
+  # Do not fallback to assets pipeline if a precompiled asset is missed.
+  config.assets.compile = false
+
+  # Generate digests for assets URLs.
+  config.assets.digest = true
+
+  # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
+
+  # Specifies the header that your server uses for sending files.
+  # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for apache
+  # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for nginx
+
+  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
+  # config.force_ssl = true
+
+  # Set to :debug to see everything in the log.
+  config.log_level = :info
+
+  # Prepend all log lines with the following tags.
+  # config.log_tags = [ :subdomain, :uuid ]
+
+  # Use a different logger for distributed setups.
+  # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
+
+  # Use a different cache store in production.
+  # config.cache_store = :mem_cache_store
+
+  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
+  # config.action_controller.asset_host = "http://assets.example.com"
+
+  # Ignore bad email addresses and do not raise email delivery errors.
+  # Set this to true and configure the email server for immediate delivery to raise delivery errors.
+  # config.action_mailer.raise_delivery_errors = false
+
+  default_url_options = {
+    host: "honeycomb-prep.library.nd.edu",
+    protocol: "https"
+  }
+  config.action_mailer.default_url_options = default_url_options
+  Rails.application.routes.default_url_options = default_url_options
+
+  # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
+  # the I18n.default_locale when a translation cannot be found).
+  config.i18n.fallbacks = true
+
+  # Send deprecation notices to registered listeners.
+  config.active_support.deprecation = :notify
+
+  # Disable automatic flushing of the log to improve performance.
+  # config.autoflush_log = false
+
+  # Use default logging formatter so that PID and timestamp are not suppressed.
+  config.log_formatter = ::Logger::Formatter.new
+
+  # Do not dump schema after migrations.
+  config.active_record.dump_schema_after_migration = false
+end

--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -208,3 +208,9 @@ pre_production:
   monitor_mode: true
   license_key: '348cd858122b9ebabab148e3a220cc8346629faa'
   app_name: Honeycomb (pprd)
+
+prep:
+  <<: *default_settings
+  monitor_mode: true
+  license_key: '348cd858122b9ebabab148e3a220cc8346629faa'
+  app_name: Honeycomb (pprd)

--- a/config/secrets.example.yml
+++ b/config/secrets.example.yml
@@ -63,7 +63,7 @@ test:
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.
-pre_production:
+prep:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
   sneakers:
     amqp: <%= ENV["SNEAKERS_AMQP"] %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -36,6 +36,17 @@ pre_production:
     bucket: testlibnd-wse-honeycomb-pprd
     profile: honeycomb
 
+prep:
+  <<: *vm
+  # cas_base: https://login.nd.edu/cas
+  image_server_url: https://honeypotpprd.library.nd.edu
+  beehive_url: https://collections-pprd.library.nd.edu
+  media_server_url: https://buzz-pprd.library.nd.edu
+  aws:
+    region: us-east-1
+    bucket: testlibnd-wse-honeycomb-pprd
+    profile: honeycomb
+
 production:
   <<: *vm
 #  cas_base: https://login.nd.edu/cas

--- a/config/solr.yml
+++ b/config/solr.yml
@@ -13,6 +13,10 @@ pre_production:
   <<: *default
   port: 8080
   path: /solr/honeycomb
+prep:
+  <<: *default
+  port: 8080
+  path: /solr/honeycomb
 production:
   <<: *default
   port: 8080

--- a/config/sunspot.yml
+++ b/config/sunspot.yml
@@ -21,6 +21,15 @@ pre_production:
     # read_timeout: 2
     # open_timeout: 0.5
 
+prep:
+  solr:
+    hostname: localhost
+    port: 8080
+    log_level: WARNING
+    path: /solr/honeycomb
+    # read_timeout: 2
+    # open_timeout: 0.5
+
 production:
   solr:
     hostname: localhost


### PR DESCRIPTION
We need a new environment to point to a different domain without taking down honeycombpprd-vm for the time being. My hope is that once we are done testing, the new "prep" server can act as the testing environment going forward and we can decomission pre_production.