### PR TITLE
Add basic smoke tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,10 +19,11 @@ services:
     environment:
       SSL: "true"
       RAILS_ENV: development
-      DB_HOST: postgres
+      DB_HOSTNAME: postgres
       DB_USERNAME: ${DB_USERNAME}
       DB_PASSWORD: ${DB_PASSWORD}
       DB_NAME: ${DB_NAME}
+      DB_PORT: 5432
       SOLR_HOST: solr
       SOLR_PORT: 8983
       OKTA_CLIENT_ID: ${OKTA_CLIENT_ID}

--- a/docker/database.yml
+++ b/docker/database.yml
@@ -10,8 +10,8 @@ postgres_settings: &postgres_settings
   username: <%= ENV['DB_USERNAME'] %>
   password: <%= ENV['DB_PASSWORD'] %>
   database: <%= ENV['DB_NAME'] %>
-  host: <%= ENV['DB_HOST'] %>
-  port: 5432
+  host: <%= ENV['DB_HOSTNAME'] %>
+  port: <%= ENV['DB_PORT'] %>
 
 development:
   <<: *postgres_settings

--- a/docker/rails_entry.sh
+++ b/docker/rails_entry.sh
@@ -2,7 +2,7 @@
 ln -s /mnt/honeycomb /project_root/public/system/images
 
 ### Wait for dependencies
-if ! docker/wait-for-it.sh -t 120 ${DB_HOST}:5432; then exit 1; fi
+if ! docker/wait-for-it.sh -t 120 ${DB_HOSTNAME}:5432; then exit 1; fi
 if ! docker/wait-for-it.sh -t 120 ${SOLR_HOST}:8983; then exit 1; fi
 
 echo Running container in "$PWD" with the following command: "$@"

--- a/spec/newman/smoke.json
+++ b/spec/newman/smoke.json
@@ -1,0 +1,101 @@
+{
+	"info": {
+		"_postman_id": "cee4ba0d-4df6-489d-b63f-64e1ac802c20",
+		"name": "Honeycomb Smoke Tests",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Get Collections",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "bce9b692-ad78-4130-9105-f3ee0f88ac7f",
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {",
+							"    pm.response.to.have.status(200);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{app-host}}/v1/collections",
+					"host": [
+						"{{app-host}}"
+					],
+					"path": [
+						"v1",
+						"collections"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Homepage (unauthenticated)",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "23968005-a1ed-4719-a9b5-df5cbba26a08",
+						"exec": [
+							"pm.test(\"Redirects to oktaoauth\", function () {",
+							"    pm.response.to.have.status(302);",
+							"    pm.response.to.have.header(\"Location\");",
+							"    pm.response.to.be.header(\"Location\", `${pm.variables.get('app-host')}/users/auth/oktaoauth`);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{app-host}}",
+					"host": [
+						"{{app-host}}"
+					]
+				}
+			},
+			"response": []
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"id": "69946a3c-afc8-43dd-87b8-f5b91b02457a",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"id": "714baca9-ede5-4d6d-baa5-59fcfe59b113",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"variable": [
+		{
+			"id": "33a33375-cf34-4d05-a367-2b1037aee791",
+			"key": "app-host",
+			"value": "https://jg-honeycomb-test.libraries.nd.edu"
+		}
+	],
+	"protocolProfileBehavior": {}
+}


### PR DESCRIPTION
This primarily adds tests that are a bit more basic than the others for
running smoke tests. Additionally includes some refactoring of env keys
to be more consistent with other services in the stack.