### PR TITLE
Add rate limiting

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -24,6 +24,8 @@ services:
     command: bash project_root/nginx_entry.sh
     environment: 
       RAILS_HOST: rails
+      RAILS_RATE_LIMIT: 200
+      RAILS_BURST_LIMIT: 20
     ports:
       - "80:80"
     volumes_from:

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,18 +1,25 @@
 # conf.d/nginx.conf
 
+# For now, binary_remote_addr will appear as the load balancer IP. If we want to
+# rate limit by actual client, we may need to use real ip. This would make it
+# more susceptible to crashing if multiple clients overwhelm the site (such as
+# with lots of crawlers), so leaving it this way for now. If we determine we need
+# to change this, see http://nginx.org/en/docs/http/ngx_http_realip_module.html
+limit_req_zone $binary_remote_addr zone=upstream:10m rate=${RAILS_RATE_LIMIT}r/m;
+
 upstream app_service {
   server ${RAILS_HOST}:3000;
 }
-
 
 server {
   listen 80;
   server_name localhost;
   root /project_root/public;
 
-  try_files $uri/index.html $uri @app_service;
+  try_files $uri @app_service;
 
   location @app_service {
+      limit_req zone=upstream burst=${RAILS_BURST_LIMIT} nodelay;
       proxy_pass http://app_service;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header Host $http_host;

--- a/docker/nginx_entry.sh
+++ b/docker/nginx_entry.sh
@@ -1,6 +1,8 @@
 # Have to do this here to allow using localhost when deployed with ECS awsvpc
 # Could not see a way to have nginx config read env
 sed -i "s;\${RAILS_HOST};$RAILS_HOST;g" /etc/nginx/conf.d/default.conf
+sed -i "s;\${RAILS_RATE_LIMIT};$RAILS_RATE_LIMIT;g" /etc/nginx/conf.d/default.conf
+sed -i "s;\${RAILS_BURST_LIMIT};$RAILS_BURST_LIMIT;g" /etc/nginx/conf.d/default.conf
 
 bash /project_root/wait-for-it.sh -t 120 --strict ${RAILS_HOST}:3000
 exec nginx -g 'daemon off;'


### PR DESCRIPTION
This adds the ability to control how many requests per minute will be
forwarded to the upstream rails service. This is to prevent requests
from overwhelming the rails service and/or the underlying data services
such as solr/db.