### PR TITLE
Add healthchecks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -95,6 +95,9 @@ group :application do
   gem "rack-cache"
   gem "dalli"
   gem 'cacheable_flash'
+
+  # For ECS health checks
+  gem 'health_bit'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -242,6 +242,8 @@ GEM
       guard
       spring
     hashie (3.5.7)
+    health_bit (0.1.8)
+      rack
     hike (1.2.3)
     hitimes (1.2.4)
     http-cookie (1.0.3)
@@ -558,6 +560,7 @@ DEPENDENCIES
   guard-rails
   guard-rspec
   guard-spring
+  health_bit
   hesburgh_api!
   hesburgh_infrastructure!
   jbuilder (~> 2.0)

--- a/config/initializers/health_bit.rb
+++ b/config/initializers/health_bit.rb
@@ -1,0 +1,19 @@
+HealthBit.configure do |c|
+  # DEFAULT SETTINGS ARE SHOWN BELOW
+  c.success_text = '%<count>d checks passed'
+  c.headers = {
+    'Content-Type' => 'text/plain;charset=utf-8',
+    'Cache-Control' => 'private,max-age=0,must-revalidate,no-store'
+  }
+  c.success_code = 200
+  c.fail_code = 500
+  c.show_backtrace = false
+
+  # We don't want health checks to pass if there are pending migrations.
+  # Rails should throw by default if there are pending migrations, but adding 
+  # explicitly just to be clear in case this gets copy/pasted to some other
+  # env that doesn't do this by default for some reason.
+  c.add('Needs Migrations') do
+    !ActiveRecord::Migrator.needs_migration?
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  mount HealthBit.rack => '/health'
   devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks' }
   devise_scope :user do
     delete 'sign_out', :to => 'devise/sessions#destroy', :as => :destroy_user_session


### PR DESCRIPTION
Adds a healthcheck route that explicitly checks for migrations. We will
use this for ECS healthchecks to prevent a new task from serving requests
until migrations are run. This will allow us to get a bit closer to the
way capistrano handles the deploy, ie deploy the new version, run migrate,
then make the new deployment live. This will help us reduce the amount
of time between running migrations and cutting over to the new release.