### PR TITLE
Fix public images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,7 +3,7 @@
 /log/*.log
 /log/*.log.*
 /tmp
-/public/system/*
+/public/system
 /vendor/bundle
 /ssi/*
 /coverage

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -17,6 +17,8 @@ services:
       OKTA_REDIRECT_URL: https://localhost/users/auth/oktaoauth/callback
       # Do not use this value in actual production env
       SECRET_KEY_BASE: e08359113980fceb3b62152286866deac83789900db39acd16712910259d904089a53ebebf614db39844ddd467f004ae426424095083b447d9173c0ee6041de2
+    volumes:
+      - ./public/system:/mnt/system
   nginx:
     build:
       context: .

--- a/docker/Dockerfile.rails
+++ b/docker/Dockerfile.rails
@@ -4,31 +4,47 @@ ARG RAILS_ENV
 # apt-key adv --keyserver keyserver.ubuntu.com --recv-keys AA8E81B4331F7F50 && nodejs-legacy libmysql++-dev
 RUN apt-get update -qq && apt-get install --no-install-recommends -y build-essential libpq-dev wget nodejs npm unzip libssl-dev git file imagemagick && rm -rf /var/lib/apt/lists/*
 
-# Put the installed gems outside of project_root so that the sync volume won't interfere
-RUN mkdir /bundle
-COPY Gemfile /bundle
-COPY Gemfile.lock /bundle
-WORKDIR /bundle
-RUN bundle install  --without headless --path /bundle
+# In a mutable host scenario, Capistrano would handle symlinking ./public/system to a persistent
+# directory on the host. We'll have to recreate this pattern by providing a mount target (/mnt/system) 
+# that we'll mount a persistent volume to later and symlink ./public/system to that mount point. 
+# Note: We can create the mount point as part of the build, but we'll have to symlink it in 
+# rails_entry.sh since Docker does not allow symlinking outside of the context
+RUN mkdir /mnt/system
 
-RUN mkdir /project_root
+RUN groupadd -r rails && useradd --no-log-init -r -g rails rails
+RUN mkdir /home/rails && chown rails:rails /home/rails
+RUN mkdir /bundle && chown rails:rails /bundle
+RUN mkdir /project_root && chown rails:rails /project_root
+
+USER rails:rails
+
+# Put the installed gems outside of project_root so that the sync volume won't interfere
+COPY --chown=rails:rails Gemfile /bundle
+COPY --chown=rails:rails Gemfile.lock /bundle
+WORKDIR /bundle
+RUN bundle install --without headless --path /bundle
+
 WORKDIR /project_root
-COPY . /project_root
+COPY --chown=rails:rails . /project_root
 
 # Gemfile.lock may have changed after bundling, copy it back into the project_root
-RUN cp /bundle/Gemfile.lock /project_root/
+RUN ls -la /bundle
+RUN cp -v /bundle/Gemfile.lock /project_root/
 
 # Install necessary Node modules
 RUN npm install
 
-COPY docker/database.yml /project_root/config/database.yml
-COPY docker/solr.yml /project_root/config/solr.yml
-COPY config/secrets.example.yml /project_root/config/secrets.yml
-COPY docker/rails_entry.sh /project_root/rails_entry.sh
-COPY docker/rails_migrate.sh /project_root/rails_migrate.sh
+# Overwrite project configs with docker compatible configs
+COPY --chown=rails:rails docker/database.yml /project_root/config/database.yml
+COPY --chown=rails:rails docker/solr.yml /project_root/config/solr.yml
+COPY --chown=rails:rails config/secrets.example.yml /project_root/config/secrets.yml
+
+# Add entry point scripts
+COPY --chown=rails:rails docker/rails_entry.sh /project_root/rails_entry.sh
+COPY --chown=rails:rails docker/rails_migrate.sh /project_root/rails_migrate.sh
 
 RUN if [ "$RAILS_ENV" = "production" ]; then ASSET_PRECOMPILE=true bundle exec rake assets:precompile; fi
 VOLUME /project_root/public
-RUN mkdir /mnt/honeycomb
 RUN mkdir -p /project_root/tmp/pids/
+
 ENTRYPOINT ["bash", "rails_entry.sh"]

--- a/docker/rails_entry.sh
+++ b/docker/rails_entry.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
-
 # All the things that will execute when starting the rails service
-ln -s /mnt/honeycomb /project_root/public/system/images
+set -e
+
+# In a mutable host scenario, Capistrano would handle symlinking ./public/system to a persistent
+# directory on the host. We'll have to recreate this pattern by providing a mount target (/mnt/system) 
+# that we'll mount a persistent volume to later and symlink ./public/system to that mount point. 
+# Note: We can create the mount point as part of the build, but we'll have to symlink it in 
+# rails_entry.sh since Docker does not allow symlinking outside of the context
+ln -s /mnt/system /project_root/public/
 
 ### Wait for dependencies
 if ! docker/wait-for-it.sh -t 120 ${DB_HOSTNAME}:5432; then exit 1; fi


### PR DESCRIPTION
This fixes an issue with uploading images when deployed to ECS. Rails
expects public/system to exist, but is not kept in git, so image uploads
were failing to get moved by paperclip to the correct dir. Changed the
link of /project_root/public/system/images/honeycomb -> /mnt/honeycomb
to instead be a link of /project_root/public/system -> /mnt/system. The
issue was likely obfuscated locally because I had files in public/system
from a local execution of rails, so the docker build was copying these
in. Changed the dockerignore to ignore this directory so that the
behavior more closely match what the docker context will look like in a
fresh checkout.

Additionally moved away from running rails as root and added a rails user
(uid 999) that will run the processes in the container.