### PR TITLE
Fix editors in Docker env

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,7 +18,7 @@ GIT
 
 GIT
   remote: https://github.com/ndlib/hesburgh_api.git
-  revision: ecff95532186162e27affc092ac64cdbb6cce97f
+  revision: 712ee7882db922d8c40a5c3f10e4145d8f6c82ac
   specs:
     hesburgh_api (0.0.3)
       excon

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,8 @@ services:
       GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
       GOOGLE_DEVELOPER_KEY: ${GOOGLE_DEVELOPER_KEY}
       GOOGLE_APP_ID: "${GOOGLE_APP_ID}"
+      HAPI_TOKEN: "${HAPI_TOKEN}"
+      HAPI_URL: "${HAPI_URL}"
       # Need to pass the user running docker into the container so that
       # config/admin_usernames.yml pulls in the user as an admin. This is
       # to replicate existing behavior on OSX and may not work correctly on

--- a/docker/Dockerfile.rails
+++ b/docker/Dockerfile.rails
@@ -35,6 +35,7 @@ RUN cp -v /bundle/Gemfile.lock /project_root/
 RUN npm install
 
 # Overwrite project configs with docker compatible configs
+COPY --chown=rails:rails docker/hesburgh_api.yml /project_root/config/hesburgh_api.yml
 COPY --chown=rails:rails docker/database.yml /project_root/config/database.yml
 COPY --chown=rails:rails docker/solr.yml /project_root/config/solr.yml
 COPY --chown=rails:rails config/secrets.example.yml /project_root/config/secrets.yml

--- a/docker/hesburgh_api.yml
+++ b/docker/hesburgh_api.yml
@@ -1,0 +1,8 @@
+settings_from_env: &settings_from_env
+  token: <%= ENV['HAPI_TOKEN'] %>
+  url: <%= ENV['HAPI_URL'] %>
+pre_production:
+  <<: *settings_from_env
+production:
+  <<: *settings_from_env
+  


### PR DESCRIPTION
The previous deploy strategy expected a config/hesburgh_api.yml to exist
on the host. This file configures how to connect to the Hesburgh API for
searching for users. This PR is to add this file to the Docker build
and instructs rails to read the url and token values from env. This should
fix an issue with searching for users when adding admins to the site, or
when adding editors to a collection.